### PR TITLE
Fix a rare panic importing discovered multisignature scripts

### DIFF
--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1395,8 +1395,10 @@ func (m *Manager) ImportScript(script []byte,
 	// The start block needs to be updated when the newly imported address
 	// is before the current one.
 	updateStartBlock := false
-	if bs.Height < m.syncState.startBlock.Height {
-		updateStartBlock = true
+	if bs != nil {
+		if bs.Height < m.syncState.startBlock.Height {
+			updateStartBlock = true
+		}
 	}
 
 	// Save the new imported address to the db and update start block (if


### PR DESCRIPTION
A rare panic could occur importing multisignature scripts found in the
blockchain that were unconfirmed. This avoids the nil dereference that
causes the panic.

Fixes #26 