### PR TITLE
Add individual ticket setting for VoteBits via the RPC

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -391,7 +391,7 @@ func (w *Wallet) addRelevantTx(rec *wtxmgr.TxRecord,
 		}
 
 		if insert {
-			err := w.StakeMgr.InsertSStx(tx)
+			err := w.StakeMgr.InsertSStx(tx, w.VoteBits)
 			if err != nil {
 				log.Errorf("Failed to insert SStx %v"+
 					"into the stake store.", tx.Sha())

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1384,7 +1384,7 @@ func (w *Wallet) purchaseTicket(req purchaseTicketRequest) (interface{},
 	// automatically insert it.
 	if _, err := w.Manager.Address(ticketAddr); err == nil {
 		if w.ticketAddress == nil {
-			err = w.StakeMgr.InsertSStx(txTemp)
+			err = w.StakeMgr.InsertSStx(txTemp, w.VoteBits)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to insert SStx %v"+
 					"into the stake store", txTemp.Sha())


### PR DESCRIPTION
This update allows the per-ticket setting of the VoteBits field so
that different VoteBits settings can be user selected in stake pools.
It is backwards compatible with the former VoteBits selection method
on the command line. Tickets stored before this update will continue
to use the VoteBits selection from the command line. Tickets stored
after this update will be initialized with the VoteBits selection from
the command line and then be able to be updated by the RPC. After
updating, any votes cast with that ticket will be assigned the
per-ticket, user selected VoteBits instead of the default VoteBits.