### PR TITLE
Fix bug in the address pool when restoring from seed

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -45,6 +45,18 @@ func (w *Wallet) handleChainNotifications() {
 		if err != nil && !w.ShuttingDown() {
 			log.Warnf("Unable to synchronize wallet to chain: %v", err)
 		}
+
+		// Spin up the address pools.
+		err = w.internalPool.initialize(waddrmgr.InternalBranch, w)
+		if err != nil {
+			log.Errorf("Failed to start the default internal branch address "+
+				"pool: %v", err)
+		}
+		err = w.externalPool.initialize(waddrmgr.ExternalBranch, w)
+		if err != nil {
+			log.Errorf("Failed to start the default external branch address "+
+				"pool: %v", err)
+		}
 	}
 
 	for n := range w.chainSvr.Notifications() {


### PR DESCRIPTION
The address pool would fail to restore to the correct index when
restoring from a wallet seed. This was fixed by adding better tracking
of the address index in the wallet. A large portion of the code in
address pool was refactored for both clarity and concision. Some
code handling storing of the next to use address in the address manager
was also refactored to expand its use case and to make its role in
syncing the address pool clearer.

Fixes #35.