### PR TITLE
Hotfix for rare panic caused by uninitialized mutex

### DIFF
--- a/wallet/addresspool.go
+++ b/wallet/addresspool.go
@@ -41,7 +41,7 @@ type addressPool struct {
 	branch    uint32
 	index     uint32
 	started   bool
-	mutex     *sync.Mutex
+	mutex     sync.Mutex
 	wallet    *Wallet
 }
 
@@ -95,7 +95,6 @@ func (a *addressPool) initialize(branch uint32, w *Wallet) error {
 	}
 
 	a.addresses = make([]string, 0)
-	a.mutex = new(sync.Mutex)
 	a.wallet = w
 	a.branch = branch
 
@@ -294,12 +293,6 @@ func (w *Wallet) CloseAddressPools() {
 		return
 	}
 	if !w.internalPool.started || !w.externalPool.started {
-		return
-	}
-	if w.internalPool.mutex == nil {
-		return
-	}
-	if w.externalPool.mutex == nil {
 		return
 	}
 


### PR DESCRIPTION
This was caught when further testing master on TestNet. Now the mutex for the address pool should be initialized when wallet starts and the struct is instantiated.