### PR TITLE
Fix multisig bug and add listscripts RPC command

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -498,13 +498,13 @@ func (a *scriptAddress) Script() ([]byte, error) {
 		return nil, managerError(ErrWatchingOnly, errWatchingOnly, nil)
 	}
 
-	a.manager.mtx.Lock()
-	defer a.manager.mtx.Unlock()
-
 	// Account manager must be unlocked to decrypt the script.
 	if a.manager.locked {
 		return nil, managerError(ErrLocked, errLocked, nil)
 	}
+
+	a.manager.mtx.Lock()
+	defer a.manager.mtx.Unlock()
 
 	// Decrypt the script as needed.  Also, make sure it's a copy since the
 	// script stored in memory can be cleared at any time.  Otherwise,

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -542,10 +542,7 @@ func (w *Wallet) addRelevantTx(rec *wtxmgr.TxRecord,
 			// entire multisig output info, consider
 			// a specific exists function in wtxmgr. cj
 			mso, err := w.TxStore.GetMultisigOutput(&input.PreviousOutPoint)
-			if err != nil {
-				return err
-			}
-			if mso != nil {
+			if mso != nil && err == nil {
 				w.TxStore.SpendMultisigOut(&input.PreviousOutPoint,
 					rec.Hash,
 					uint32(i))


### PR DESCRIPTION
A bug in multisignature handling would occasionally cause the
inappropriate failing of transactions being added to the transaction
manager. The code no longer returns when catching the error.

The listscripts RPC command has been added, allowing a user to dump
the redeem scripts contained by their wallet.