### PR TITLE
Fix bug in multisignature output spending in chainntfns.go

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -536,16 +536,17 @@ func (w *Wallet) addRelevantTx(rec *wtxmgr.TxRecord,
 				}
 			}
 
-			// If we're spending a multisig outpoint we
-			// know about, update the outpoint.
-			// Inefficient because you deserialize the
-			// entire multisig output info, consider
-			// a specific exists function in wtxmgr. cj
+			// If we're spending a multisig outpoint we know about,
+			// update the outpoint. Inefficient because you deserialize
+			// the entire multisig output info. Consider a specific
+			// exists function in wtxmgr. The error here is skipped
+			// because the absence of an multisignature output for
+			// some script can not always be considered an error. For
+			// example, the wallet might be rescanning as called from
+			// the above function and so does not have the output
+			// included yet.
 			mso, err := w.TxStore.GetMultisigOutput(&input.PreviousOutPoint)
-			if err != nil {
-				return err
-			}
-			if mso != nil {
+			if mso != nil && err == nil {
 				w.TxStore.SpendMultisigOut(&input.PreviousOutPoint,
 					rec.Hash,
 					uint32(i))


### PR DESCRIPTION
A bug in multisignature handling would occasionally cause the
inappropriate failing of transactions being added to the transaction
manager. If a multisignature script of any kind was found but a
reference to the script could not be found in the transaction
manager, the whole function would fail. The error returned from
the function is now ignored because failing to find a multisignature
output to spend for a random multisignature script should not be
considered an error.