### PR TITLE
Fix a bug that caused votes and revocations not being stored

### DIFF
--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -808,18 +808,18 @@ func (s *StakeStore) generateVote(blockHash *chainhash.Hash, height int64,
 		return nil, err
 	}
 
-	// Send the transaction.
-	ssgenSha, err := s.chainSvr.SendRawTransaction(msgTx, false)
+	// Store the information about the SSGen.
+	err = s.insertSSGen(blockHash,
+		height,
+		ssgenTx.Sha(),
+		voteBits,
+		sstx.Sha())
 	if err != nil {
 		return nil, err
 	}
 
-	// Store the information about the SSGen.
-	err = s.insertSSGen(blockHash,
-		height,
-		ssgenSha,
-		voteBits,
-		sstx.Sha())
+	// Send the transaction.
+	ssgenSha, err := s.chainSvr.SendRawTransaction(msgTx, false)
 	if err != nil {
 		return nil, err
 	}
@@ -998,17 +998,17 @@ func (s *StakeStore) generateRevocation(blockHash *chainhash.Hash, height int64,
 		return nil, err
 	}
 
-	// Send the transaction.
-	ssrtxSha, err := s.chainSvr.SendRawTransaction(msgTx, false)
+	// Store the information about the SSRtx.
+	err = s.insertSSRtx(blockHash,
+		height,
+		ssrtxTx.Sha(),
+		sstx.Sha())
 	if err != nil {
 		return nil, err
 	}
 
-	// Store the information about the SSRtx.
-	err = s.insertSSRtx(blockHash,
-		height,
-		ssrtxSha,
-		sstx.Sha())
+	// Send the transaction.
+	ssrtxSha, err := s.chainSvr.SendRawTransaction(msgTx, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In the case of redundant wallets, votes and revocations that were
rejected from the daemon as duplicates were not stored at all in
the stake database. This would cause corrupted values for votes
and revocations when calling getstakeinfo. This was corrected by
storing the votes and revocations first, before shipping to the
daemon.