### PR TITLE
Automatically remove old tickets and expired transactions

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -277,6 +277,16 @@ func (w *Wallet) connectBlock(b wtxmgr.BlockMeta) {
 
 		w.Stop()
 	}
+
+	// Prune all expired transactions and all stake tickets that no longer
+	// meet the minimum stake difficulty.
+	stakeDifficultyInfo := w.GetStakeDifficulty()
+	err = w.TxStore.PruneUnconfirmed(bs.Height,
+		stakeDifficultyInfo.StakeDifficulty)
+	if err != nil {
+		log.Errorf("Failed to prune unconfirmed transactions when "+
+			"connecting block height %v: %v", bs.Height, err.Error())
+	}
 }
 
 // disconnectBlock handles a chain server reorganize by rolling back all


### PR DESCRIPTION
The wallet had no way to remove expired transactions from the internal
memory pool. Tickets that were lower than the current stake difficulty
were also never removed. Automatic pruning of these transactions on a
per block basis has been added, allowing the wallet to recover and
respend these funds. The function removeConflict has also been 
renamed to removeUnconfirmed to better describe its activity.

Fixes #3.