### PR TITLE
Prevent addresses from being shown more than once.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -780,9 +780,6 @@ func (w *Wallet) quitChan() <-chan struct{} {
 func (w *Wallet) CloseDatabases() {
 	w.TxStore.Close()
 	w.StakeMgr.Close()
-
-	// Store the current address pool last addresses.
-	w.CloseAddressPools()
 }
 
 // Stop signals all wallet goroutines to shutdown.
@@ -790,6 +787,9 @@ func (w *Wallet) Stop() {
 	w.quitMu.Lock()
 	quit := w.quit
 	w.quitMu.Unlock()
+
+	// Store the current address pool last addresses.
+	w.CloseAddressPools()
 
 	select {
 	case <-quit:


### PR DESCRIPTION
Add call to pool.BatchComplete() at the end of GetNewAddress()
to prevent address counter from being reset when it shouldn't.

Fixes #68

Also correct a comment typo in GetAddress code.