### PR TITLE
Stop uses of database before closing db.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -132,7 +132,10 @@ func walletMain() error {
 	}()
 	loader.RunAfterLoad(func(w *wallet.Wallet, db walletdb.DB) {
 		startWalletRPCServices(w, rpcs, legacyRPCServer)
-		closeDB = db.Close
+		closeDB = func() error {
+			w.CloseDatabases()
+			return db.Close()
+		}
 	})
 
 	if !cfg.NoInitialLoad {


### PR DESCRIPTION
Since the stop RPC and ^C interrupt handling now shutdown the process
using the same code path, the closeDB callback needs to stop any
remaining uses of the database before closing the DB.

This should prevent any database corruption issues that may happen
during clean shutdown, but unclean shutdown can still corrupt the
database since not all operations that should be atomic actually are.