### PR TITLE
Revert "Fixes to work with dcrd sync"

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -807,12 +807,12 @@ func (w *Wallet) handleWinningTickets(blockHash *chainhash.Hash,
 	// out of sync with the voting channel here. This should probably
 	// be fixed somehow, but this should be stable for networks that
 	// are voting at normal block speeds.
-	if blockHeight >= int64(w.chainParams.StakeValidationHeight-1) &&
+	if blockHeight >= w.chainParams.StakeValidationHeight-1 &&
 		topBlockStamp.Hash.IsEqual(blockHash) {
 		w.SetCurrentVotingInfo(blockHash, blockHeight, tickets)
 	}
 
-	if blockHeight >= int64(w.chainParams.StakeValidationHeight-1) &&
+	if blockHeight >= w.chainParams.StakeValidationHeight-1 &&
 		w.StakeMiningEnabled {
 		ntfns, err := w.StakeMgr.HandleWinningTicketsNtfn(blockHash,
 			blockHeight,
@@ -852,7 +852,7 @@ func (w *Wallet) handleMissedTickets(blockHash *chainhash.Hash,
 		return nil
 	}
 
-	if blockHeight >= int64(w.chainParams.StakeValidationHeight+1) &&
+	if blockHeight >= w.chainParams.StakeValidationHeight+1 &&
 		w.StakeMiningEnabled {
 		ntfns, err := w.StakeMgr.HandleMissedTicketsNtfn(blockHash,
 			blockHeight,

--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -717,7 +717,7 @@ func (s *StakeStore) generateVote(blockHash *chainhash.Hash, height int64,
 		stake.GetSStxStakeOutputInfo(sstx)
 
 	// Get the current reward.
-	stakeVoteSubsidy := blockchain.CalcStakeVoteSubsidy(int32(height),
+	stakeVoteSubsidy := blockchain.CalcStakeVoteSubsidy(height,
 		s.Params)
 
 	// Calculate the output values from this data.


### PR DESCRIPTION
This reverts commit 9fc2eeea1275bf310951abcb32aae888d74685ae.

We are revert sync to 0208a commits due to possible consensus issues.

We will now break down each btcd sync commit into piecemeal commit PRs to avoid this in the future