### PR TITLE
Fix a bug relating to relevantTx handling and uncaught error

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1180,7 +1180,12 @@ func (w *Wallet) activeData() ([]dcrutil.Address, []*wire.OutPoint, error) {
 	if err != nil {
 		return nil, nil, err
 	}
+
 	unspent, err := w.TxStore.UnspentOutpoints()
+	if err != nil {
+		return nil, nil, err
+	}
+
 	return addrs, unspent, err
 }
 


### PR DESCRIPTION
A call to UnspentOutpoints did not have error handling, which was
added.

A restrictive switch statement would cause all outputs that were not
either pay-to-pubkey hash or pay-to-script-hash multisig to be stored.
This was reverted to the same behavior as btcwallet where all outputs
are stored if the address is found in the address manager. Code
handling multisignature redeemScript lookup in outputs was also
corrected.