### PR TITLE
Add new balancetomaintain rpc command

### DIFF
--- a/internal/rpchelp/helpdescs_en_US.go
+++ b/internal/rpchelp/helpdescs_en_US.go
@@ -605,12 +605,21 @@ var helpDescsEnUS = map[string]string{
 	"sendtossgen-tickethash":  "Hash of the ticket used for vote",
 	"sendtossgen-fromaccount": "The account to use (default=\"default\")",
 
-	// SetTxFeeCmd help.
+	// SetTicketFeeCmd help.
 	"setticketfee--synopsis": "Modify the increment used each time more fee is required for an authored stake transaction.",
 	"setticketfee-fee":       "The new fee increment valued in decred",
 	"setticketfee--result0":  "The boolean 'true'",
 
-	// SetTxFeeCmd help.
+	// GetTicketFeeCmd help.
 	"getticketfee--synopsis": "Get the current fee increment used for an authored stake transaction.",
 	"getticketfee--result0":  "The current fee",
+
+	// SetBalanceToMaintainCmd help.
+	"setbalancetomaintain--synopsis": "Modify the balance for wallet to maintain for automatic ticket purchasing",
+	"setbalancetomaintain-balance":   "The new balance for wallet to maintain for automatic ticket purchasing",
+	"setbalancetomaintain--result0":  "Should return nothing",
+
+	// GetBalanceToMaintainCmd help.
+	"getbalancetomaintain--synopsis": "Get the current balance to maintain",
+	"getbalancetomaintain--result0":  "The current balancetomaintain",
 }

--- a/rpc/legacyrpc/errors.go
+++ b/rpc/legacyrpc/errors.go
@@ -56,6 +56,10 @@ var (
 		errors.New("amount must be positive"),
 	}
 
+	ErrNeedBelowMaxAmount = InvalidParameterError{
+		errors.New("amount must be below max amount"),
+	}
+
 	ErrNeedPositiveSpendLimit = InvalidParameterError{
 		errors.New("spend limit must be positive"),
 	}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -127,7 +127,7 @@ ticketPurchaseLoop:
 		// wtxmgr is instead returned. We can use this to compress the
 		// amount to the ticket price, thus avoiding more costly db
 		// lookups.
-		eligible, err := w.CreatePurchaseTicket(w.BalanceToMaintain, -1,
+		eligible, err := w.CreatePurchaseTicket(w.BalanceToMaintain(), -1,
 			0, nil, waddrmgr.DefaultAccountNum)
 		if err != nil {
 			switch {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -110,9 +110,9 @@ type Wallet struct {
 	VoteBits           uint16
 	StakeMiningEnabled bool
 	CurrentStakeDiff   *StakeDifficultyInfo
-	BalanceToMaintain  dcrutil.Amount
 	CurrentVotingInfo  *VotingInfo
 	TicketMaxPrice     dcrutil.Amount
+	balanceToMaintain  dcrutil.Amount
 
 	automaticRepair bool
 
@@ -230,7 +230,7 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		StakeMgr:                 smgr,
 		StakeMiningEnabled:       esm,
 		VoteBits:                 vb,
-		BalanceToMaintain:        btm,
+		balanceToMaintain:        btm,
 		CurrentStakeDiff:         &StakeDifficultyInfo{nil, -1, -1},
 		lockedOutpoints:          map[wire.OutPoint]struct{}{},
 		feeIncrement:             feeIncrement,
@@ -326,6 +326,22 @@ func (w *Wallet) SetTicketFeeIncrement(fee dcrutil.Amount) {
 	w.ticketFeeIncrementLock.Lock()
 	w.ticketFeeIncrement = fee
 	w.ticketFeeIncrementLock.Unlock()
+}
+
+// BalanceToMaintain is used to get the current balancetomaintain for the wallet.
+func (w *Wallet) BalanceToMaintain() dcrutil.Amount {
+	w.stakeSettingsLock.Lock()
+	balance := w.balanceToMaintain
+	w.stakeSettingsLock.Unlock()
+
+	return balance
+}
+
+// SetBalanceToMaintain is used to set the current w.balancetomaintain for the wallet.
+func (w *Wallet) SetBalanceToMaintain(balance dcrutil.Amount) {
+	w.stakeSettingsLock.Lock()
+	w.balanceToMaintain = balance
+	w.stakeSettingsLock.Unlock()
 }
 
 // SetGenerate is used to enable or disable stake mining in the
@@ -736,7 +752,7 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 
 	if w.StakeMiningEnabled {
 		log.Infof("Stake mining is enabled. Votebits: %v, minimum wallet "+
-			"balance %v", w.VoteBits, w.BalanceToMaintain.ToCoin())
+			"balance %v", w.VoteBits, w.BalanceToMaintain().ToCoin())
 		log.Infof("PLEASE ENSURE YOUR WALLET IS UNLOCKED SO IT MAY " +
 			"VOTE ON BLOCKS AND RECEIVE STAKE REWARDS")
 	}


### PR DESCRIPTION
This will now allow users to update balancetomaintain while wallet is running.

Also make balanceToMaintain into unexported and restrict access to normal get/setters.