### PR TITLE
Fix wallet resyncing from seed and address index positioning

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1034,7 +1034,15 @@ func GetRawChangeAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error
 	if err != nil {
 		return nil, err
 	}
-	addr, err := w.NewChangeAddress(account)
+
+	// Use the address pool for the default or imported accounts.
+	var addr dcrutil.Address
+	if account == waddrmgr.DefaultAccountNum ||
+		account == waddrmgr.ImportedAddrAccount {
+		addr, err = w.GetNewAddressInternal()
+	} else {
+		addr, err = w.NewChangeAddress(account)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/addresspool.go
+++ b/wallet/addresspool.go
@@ -243,6 +243,9 @@ func (a *addressPool) GetNewAddress() (dcrutil.Address, error) {
 // BatchFinish must be run after every successful series of usages of
 // GetNewAddress to purge the addresses from the unused map.
 func (a *addressPool) BatchFinish() {
+	log.Debugf("Closing address batch for pool branch %v, next index %v",
+		a.branch, a.index+1)
+
 	// Write the next address to use to the database.
 	addr, err := a.wallet.Manager.GetAddress(a.index+1,
 		waddrmgr.DefaultAccountNum, a.branch)


### PR DESCRIPTION
Some changes that were acquired when syncing to btcwallet caused
resyncing from seed to fail to correctly place the initial address
index in address pool, resulting in gaps. This has been fixed and
a new debug function added to assist in debugging wallet address
gaps. Tolerances on address gaps for the initial rescan have been
loosened to help correctly scan old wallets that may have had gaps
introduced.

A bug that could also introduce gaps was found in the
getrawchangeaddress RPC call, which used the wrong function to
get change addresses for default or imported accounts. It now
uses the correct function.