### PR TITLE
Print version string at startup.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -64,6 +64,9 @@ func walletMain() error {
 	cfg = tcfg
 	defer backendLog.Flush()
 
+	// Show version at startup.
+	log.Infof("Version %s", version())
+
 	if cfg.Profile != "" {
 		go func() {
 			listenAddr := net.JoinHostPort("", cfg.Profile)


### PR DESCRIPTION
This makes btcwallet match btcd's behavior.

Initially pointed out in:
decred/dcrwallet#125

Closes #125