### PR TITLE
Refactor address pool code and change database storage to account index

### DIFF
--- a/waddrmgr/error.go
+++ b/waddrmgr/error.go
@@ -144,32 +144,37 @@ const (
 	// ErrCreateAddress is used to indicate that an address could not be
 	// created from a public key.
 	ErrCreateAddress
+
+	// ErrMetaPoolIdxNoExist indicates that the address index for some
+	// account's address pool was unset or short.
+	ErrMetaPoolIdxNoExist
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
 var errorCodeStrings = map[ErrorCode]string{
-	ErrDatabase:          "ErrDatabase",
-	ErrUpgrade:           "ErrUpgrade",
-	ErrKeyChain:          "ErrKeyChain",
-	ErrCrypto:            "ErrCrypto",
-	ErrInvalidKeyType:    "ErrInvalidKeyType",
-	ErrNoExist:           "ErrNoExist",
-	ErrAlreadyExists:     "ErrAlreadyExists", // ErrDuplicateAddress??? cj
-	ErrCoinTypeTooHigh:   "ErrCoinTypeTooHigh",
-	ErrAccountNumTooHigh: "ErrAccountNumTooHigh",
-	ErrLocked:            "ErrLocked",
-	ErrWatchingOnly:      "ErrWatchingOnly",
-	ErrInvalidAccount:    "ErrInvalidAccount",
-	ErrAddressNotFound:   "ErrAddressNotFound",
-	ErrAccountNotFound:   "ErrAccountNotFound",
-	ErrDuplicateAddress:  "ErrDuplicateAddress",
-	ErrDuplicateAccount:  "ErrDuplicateAccount",
-	ErrTooManyAddresses:  "ErrTooManyAddresses",
-	ErrWrongPassphrase:   "ErrWrongPassphrase",
-	ErrWrongNet:          "ErrWrongNet",
-	ErrCallBackBreak:     "ErrCallBackBreak",
-	ErrEmptyPassphrase:   "ErrEmptyPassphrase",
-	ErrCreateAddress:     "ErrCreateAddress",
+	ErrDatabase:           "ErrDatabase",
+	ErrUpgrade:            "ErrUpgrade",
+	ErrKeyChain:           "ErrKeyChain",
+	ErrCrypto:             "ErrCrypto",
+	ErrInvalidKeyType:     "ErrInvalidKeyType",
+	ErrNoExist:            "ErrNoExist",
+	ErrAlreadyExists:      "ErrAlreadyExists", // ErrDuplicateAddress??? cj
+	ErrCoinTypeTooHigh:    "ErrCoinTypeTooHigh",
+	ErrAccountNumTooHigh:  "ErrAccountNumTooHigh",
+	ErrLocked:             "ErrLocked",
+	ErrWatchingOnly:       "ErrWatchingOnly",
+	ErrInvalidAccount:     "ErrInvalidAccount",
+	ErrAddressNotFound:    "ErrAddressNotFound",
+	ErrAccountNotFound:    "ErrAccountNotFound",
+	ErrDuplicateAddress:   "ErrDuplicateAddress",
+	ErrDuplicateAccount:   "ErrDuplicateAccount",
+	ErrTooManyAddresses:   "ErrTooManyAddresses",
+	ErrWrongPassphrase:    "ErrWrongPassphrase",
+	ErrWrongNet:           "ErrWrongNet",
+	ErrCallBackBreak:      "ErrCallBackBreak",
+	ErrEmptyPassphrase:    "ErrEmptyPassphrase",
+	ErrCreateAddress:      "ErrCreateAddress",
+	ErrMetaPoolIdxNoExist: "ErrMetaPoolIdxNoExist",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -1164,46 +1164,14 @@ func (m *Manager) ExistsAddress(addressID []byte) (bool, error) {
 	return m.existsAddress(addressID)
 }
 
-// storeNextToUseAddresses stores the last used default external and internal
-// addresses to the database. It will only update one of the values if the
-// other passed address is nil.
+// storeNextToUseAddress is used to store the next to use address index for a
+// given account's internal or external branch to the database.
 //
 // This function MUST be called with the manager lock held for reads.
-func (m *Manager) storeNextToUseAddresses(nextExt dcrutil.Address,
-	nextInt dcrutil.Address) error {
-	// If we're only updating one address, fetch the current contents
-	// and reuse the other address.
-	doFetch := false
-	if nextExt == nil || nextInt == nil {
-		doFetch = true
-	}
-	if doFetch {
-		nextExtFetch, nextIntFetch, err := m.nextToUseAddresses()
-		if err != nil {
-			return maybeConvertDbError(err)
-		}
-		if nextExt == nil {
-			nextExt = nextExtFetch
-		}
-		if nextInt == nil {
-			nextInt = nextIntFetch
-		}
-	}
-
-	// These might still be nil if the wallet is being created from
-	// a seed and the next addresses are uninitialized. Leave them
-	// in their uninitialized state in this case.
-	nextExtPKH := new([20]byte)
-	nextIntPKH := new([20]byte)
-	if nextExt != nil {
-		nextExtPKH = nextExt.Hash160()
-	}
-	if nextInt != nil {
-		nextIntPKH = nextInt.Hash160()
-	}
-
+func (m *Manager) storeNextToUseAddress(isInternal bool, account uint32,
+	index uint32) error {
 	err := m.namespace.Update(func(tx walletdb.Tx) error {
-		errLocal := putNextToUseAddrs(tx, *nextExtPKH, *nextIntPKH)
+		errLocal := putNextToUseAddrPoolIdx(tx, isInternal, account, index)
 		return errLocal
 	})
 	if err != nil {
@@ -1213,71 +1181,46 @@ func (m *Manager) storeNextToUseAddresses(nextExt dcrutil.Address,
 	return nil
 }
 
-// StoreNextToUseAddresses is the exported version of storeNextToUseAddresses. It
-// is used to store the last used default external and internal addresses to
-// the database upon closing the wallet. This is for addresses in the pool
-// only.
+// StoreNextToUseAddress is the exported version of storeNextToUseAddress. It
+// is used to store the next to use address index for a given account's internal
+// or external branch to the database.
 //
 // This function is safe for concurrent access.
-func (m *Manager) StoreNextToUseAddresses(lastExt dcrutil.Address,
-	lastInt dcrutil.Address) error {
+func (m *Manager) StoreNextToUseAddress(isInternal bool, account uint32,
+	index uint32) error {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	return m.storeNextToUseAddresses(lastExt, lastInt)
+	return m.storeNextToUseAddress(isInternal, account, index)
 }
 
-// nextToUseAddresses is used to retrieve the next addresses for the
-// default account that were stored upon wallet last closing. If the
-// stored addresses are empty (zeroed), it returns nil pointers for
-// the addresses.
-func (m *Manager) nextToUseAddresses() (dcrutil.Address, dcrutil.Address, error) {
-	var nextExtPKH [20]byte
-	var nextIntPKH [20]byte
-
+// nextToUseAddrPoolIndex returns the next to use address index for a given
+// account's internal or external branch.
+func (m *Manager) nextToUseAddrPoolIndex(isInternal bool,
+	account uint32) (uint32, error) {
+	var index uint32
 	err := m.namespace.View(func(tx walletdb.Tx) error {
 		var errLocal error
-		nextExtPKH, nextIntPKH, errLocal = fetchNextToUseAddrs(tx)
+		index, errLocal = fetchNextToUseAddrPoolIdx(tx, isInternal, account)
 		return errLocal
 	})
 	if err != nil {
-		return nil, nil, maybeConvertDbError(err)
+		return 0, maybeConvertDbError(err)
 	}
 
-	var addrExt dcrutil.Address
-	var addrInt dcrutil.Address
-	var emptyArray [20]byte
-	if nextExtPKH != emptyArray {
-		var localErr error
-		addrExt, localErr = dcrutil.NewAddressPubKeyHash(nextExtPKH[:],
-			m.chainParams, chainec.ECTypeSecp256k1)
-		if localErr != nil {
-			return nil, nil, maybeConvertDbError(localErr)
-		}
-	}
-	if nextIntPKH != emptyArray {
-		var localErr error
-		addrInt, localErr = dcrutil.NewAddressPubKeyHash(nextIntPKH[:],
-			m.chainParams, chainec.ECTypeSecp256k1)
-		if localErr != nil {
-			return nil, nil, maybeConvertDbError(localErr)
-		}
-	}
-
-	return addrExt, addrInt, nil
+	return index, nil
 }
 
-// NextToUseAddresses is the exported version of nextToUseAddresses. It
-// is used to get the next default external and internal addresses from
-// the database upon opening the wallet. This is for addresses in the pool
-// only.
+// NextToUseAddrPoolIndex is the exported version of nextToUseAddrPoolIndex. It
+// returns the next to use address index for a given account's internal or
+// external branch.
 //
 // This function is safe for concurrent access.
-func (m *Manager) NextToUseAddresses() (dcrutil.Address, dcrutil.Address, error) {
+func (m *Manager) NextToUseAddrPoolIndex(isInternal bool, account uint32) (uint32, error) {
 	m.mtx.Lock()
 	defer m.mtx.Unlock()
 
-	return m.nextToUseAddresses()
+	return m.nextToUseAddrPoolIndex(isInternal, account)
 }
 
 // ImportPrivateKey imports a WIF private key into the address manager.  The
@@ -2868,8 +2811,12 @@ func Create(namespace walletdb.Namespace, seed, pubPassphrase,
 			return err
 		}
 
-		// Set the last used addresses as empty.
-		err = putNextToUseAddrs(tx, [20]byte{}, [20]byte{})
+		// Set the next to use addresses as empty for the address pool.
+		err = putNextToUseAddrPoolIdx(tx, false, DefaultAccountNum, 0)
+		if err != nil {
+			return err
+		}
+		err = putNextToUseAddrPoolIdx(tx, true, DefaultAccountNum, 0)
 		if err != nil {
 			return err
 		}
@@ -3092,8 +3039,12 @@ func CreateWatchOnly(namespace walletdb.Namespace, hdPubKey string,
 			return err
 		}
 
-		// Set the last used addresses as empty.
-		err = putNextToUseAddrs(tx, [20]byte{}, [20]byte{})
+		// Set the next to use addresses as empty for the address pool.
+		err = putNextToUseAddrPoolIdx(tx, false, DefaultAccountNum, 0)
+		if err != nil {
+			return err
+		}
+		err = putNextToUseAddrPoolIdx(tx, true, DefaultAccountNum, 0)
 		if err != nil {
 			return err
 		}

--- a/wallet/addresspool.go
+++ b/wallet/addresspool.go
@@ -216,8 +216,16 @@ func (w *Wallet) CloseAddressPools() {
 		return
 	}
 
-	w.internalPool.Close()
-	w.externalPool.Close()
+	err := w.internalPool.Close()
+	if err != nil {
+		log.Errorf("failed to close default acct internal addr pool: %v",
+			err)
+	}
+	err = w.externalPool.Close()
+	if err != nil {
+		log.Errorf("failed to close default acct external addr pool: %v",
+			err)
+	}
 
 	return
 }

--- a/wallet/addresspool.go
+++ b/wallet/addresspool.go
@@ -57,6 +57,9 @@ func NewAddressPool() *addressPool {
 // to the address index given.
 func (a *addressPool) initialize(account uint32, branch uint32, index uint32,
 	w *Wallet) error {
+	a.mutex.Lock()
+	defer a.mutex.Unlock()
+
 	// Do not reinitialize an address pool that was already started.
 	// This can happen if the RPC client dies due to a disconnect
 	// from the daemon.

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -52,18 +52,6 @@ func (w *Wallet) handleChainNotifications() {
 		if err != nil && !w.ShuttingDown() {
 			log.Warnf("Unable to synchronize wallet to chain: %v", err)
 		}
-
-		// Spin up the address pools.
-		err = w.internalPool.initialize(waddrmgr.InternalBranch, w)
-		if err != nil {
-			log.Errorf("Failed to start the default internal branch address "+
-				"pool: %v", err)
-		}
-		err = w.externalPool.initialize(waddrmgr.ExternalBranch, w)
-		if err != nil {
-			log.Errorf("Failed to start the default external branch address "+
-				"pool: %v", err)
-		}
 	}
 
 	for n := range chainClient.Notifications() {


### PR DESCRIPTION
The old address pool code was faulty in that it could not scale to
more accounts than the default account and did address index alignment
using an actual address instead of an index. This updates the address
pools to be generalized so that in the future they can be multiaccount.
Address indexes for an account are now stored in the meta bucket of the
address manager database. The logic for the address pool has been
greatly simplified.