### PR TITLE
Modify the logic for password prompting

### DIFF
--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -193,13 +193,12 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	w, err := Open(db, pubPassphrase, cbs, so.VoteBits, so.StakeMiningEnabled,
 		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
 		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, l.autoRepair,
-		l.promptPass, l.chainParams)
+		l.chainParams)
 	if err != nil {
 		return nil, err
 	}
 
 	w.Start()
-
 	l.onLoaded(w, db)
 	return w, nil
 }

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -47,7 +47,7 @@ func (w *Wallet) accountIsUsed(account uint32, chainClient *chain.RPCClient) boo
 	// exists in accounts that have not yet been created, while
 	// AddressDerivedFromDbAcct can not.
 	addrFunc := w.Manager.AddressDerivedFromDbAcct
-	if w.promptPass {
+	if w.resyncAccounts {
 		addrFunc = w.Manager.AddressDerivedFromCointype
 	}
 
@@ -439,7 +439,7 @@ func (w *Wallet) rescanActiveAddresses() error {
 	// current account index is. This scan should only ever be
 	// performed if we're restoring our wallet from seed.
 	lastAcct := uint32(0)
-	if w.promptPass {
+	if w.resyncAccounts {
 		min := 0
 		max := waddrmgr.MaxAccountNum
 		lastAcct, err = w.scanAccountIndex(min, max)


### PR DESCRIPTION
Password prompting on first run or when --promptpass has been
set now prompts before the RPC server has started. If the wrong
password is entered, the user is reprompted to enter their
password.