### PR TITLE
Add goclean.sh script from btcd.

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -471,8 +471,8 @@ out:
 		case dequeue <- next:
 			if n, ok := next.(BlockConnected); ok {
 				bs = &waddrmgr.BlockStamp{
-					n.Height,
-					n.Hash,
+					Height: n.Height,
+					Hash:   n.Hash,
 				}
 			}
 

--- a/goclean.sh
+++ b/goclean.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# The script does automatic checking on a Go package and its sub-packages, including:
+# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 2. goimports     (https://github.com/bradfitz/goimports)
+# 3. golint        (https://github.com/golang/lint)
+# 4. go vet        (http://golang.org/cmd/vet)
+# 5. race detector (http://blog.golang.org/race-detector)
+# 6. test coverage (http://blog.golang.org/cover)
+
+set -ex
+
+# Automatic checks
+test -z "$(gofmt -l -w . | tee /dev/stderr)"
+test -z "$(goimports -l -w . | tee /dev/stderr)"
+test -z "$(golint ./... | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns\|api.pb.go\|StartConsensusRpc\|factory_test.go\|legacy' | tee /dev/stderr)"
+test -z "$(go tool vet . 2>&1 | grep -v 'Example\|newestSha\|rpcserver/server.go' | tee /dev/stderr)"
+env GORACE="halt_on_error=1" go test -v -race ./...
+
+# Run test coverage on each subdirectories and merge the coverage profile.
+
+set +x
+echo "mode: count" > profile.cov
+
+# Standard go tooling behavior is to ignore dirs with leading underscores.
+for dir in $(find . -maxdepth 10 -not -path '.' -not -path './.git*' \
+    -not -path '*/_*' -not -path './cmd*' -not -path './release*' -type d)
+do
+if ls $dir/*.go &> /dev/null; then
+  go test -covermode=count -coverprofile=$dir/profile.tmp $dir
+  if [ -f $dir/profile.tmp ]; then
+    cat $dir/profile.tmp | tail -n +2 >> profile.cov
+    rm $dir/profile.tmp
+  fi
+fi
+done
+
+# To submit the test coverage result to coveralls.io,
+# use goveralls (https://github.com/mattn/goveralls)
+# goveralls -coverprofile=profile.cov -service=travis-ci

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/decred/dcrutil"
 )
 
+// SumOutputValues sums up the list of TxOuts and returns an Amount.
 func SumOutputValues(outputs []*wire.TxOut) (totalOutput dcrutil.Amount) {
 	for _, txOut := range outputs {
 		totalOutput += dcrutil.Amount(txOut.Value)
@@ -19,6 +20,7 @@ func SumOutputValues(outputs []*wire.TxOut) (totalOutput dcrutil.Amount) {
 	return totalOutput
 }
 
+// SumOutputSerializeSizes sums up the serialized size of the supplied outputs.
 func SumOutputSerializeSizes(outputs []*wire.TxOut) (serializeSize int) {
 	for _, txOut := range outputs {
 		serializeSize += txOut.SerializeSize()

--- a/internal/rpchelp/methods.go
+++ b/internal/rpchelp/methods.go
@@ -18,8 +18,8 @@ var (
 	returnsLTRArray    = []interface{}{(*[]dcrjson.ListTransactionsResult)(nil)}
 )
 
-// Contains all methods and result types that help is generated for, for every
-// locale.
+// Methods contains all methods and result types that help is generated for,
+// for every locale.
 var Methods = []struct {
 	Method      string
 	ResultTypes []interface{}
@@ -95,6 +95,7 @@ var Methods = []struct {
 	{"setticketfee", returnsBool},
 }
 
+// HelpDescs contains the locale-specific help strings along with the locale.
 var HelpDescs = []struct {
 	Locale   string // Actual locale, e.g. en_US
 	GoLocale string // Locale used in Go names, e.g. EnUS

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-// This package implements the RPC API and is used by the main package to start
-// gRPC services.
+// Package rpcserver implements the RPC API and is used by the main package to
+// start gRPC services.
 //
 // Full documentation of the API implemented by this package is maintained in a
 // language-agnostic document:
@@ -854,10 +854,9 @@ func (s *loaderServer) StartConsensusRpc(ctx context.Context, req *pb.StartConse
 		if err == dcrrpcclient.ErrInvalidAuth {
 			return nil, grpc.Errorf(codes.InvalidArgument,
 				"Invalid RPC credentials: %v", err)
-		} else {
-			return nil, grpc.Errorf(codes.NotFound,
-				"Connection to RPC server failed: %v", err)
 		}
+		return nil, grpc.Errorf(codes.NotFound,
+			"Connection to RPC server failed: %v", err)
 	}
 
 	s.rpcClient = rpcClient

--- a/snacl/snacl.go
+++ b/snacl/snacl.go
@@ -23,12 +23,14 @@ var (
 	prng = rand.Reader
 )
 
+// Error types and messages.
 var (
 	ErrInvalidPassword = errors.New("invalid password")
 	ErrMalformed       = errors.New("malformed data")
 	ErrDecryptFailed   = errors.New("unable to decrypt")
 )
 
+// Various constants needed for encryption scheme.
 const (
 	// Expose secretbox's Overhead const here for convenience.
 	Overhead  = secretbox.Overhead

--- a/waddrmgr/manager.go
+++ b/waddrmgr/manager.go
@@ -125,8 +125,7 @@ type OpenCallbacks struct {
 	ObtainPrivatePass ObtainUserInputFunc
 }
 
-// DefaultConfig is an instance of the Options struct initialized with default
-// configuration options.
+// DefaultScryptOptions is the default options used with scrypt.
 var DefaultScryptOptions = ScryptOptions{
 	N: 262144, // 2^18
 	R: 8,

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -191,7 +191,7 @@ out:
 			log.Infof("Finished rescan for %d %s (synced to block "+
 				"%s, height %d)", len(addrs), noun, n.Hash,
 				n.Height)
-			bs := waddrmgr.BlockStamp{n.Height, *n.Hash}
+			bs := waddrmgr.BlockStamp{Height: n.Height, Hash: *n.Hash}
 			if err := w.Manager.SetSyncedTo(&bs); err != nil {
 				log.Errorf("Failed to update address manager "+
 					"sync state for hash %v (height %d): %v",

--- a/wtxmgr/query_test.go
+++ b/wtxmgr/query_test.go
@@ -559,8 +559,16 @@ func TestPreviousPkScripts(t *testing.T) {
 	buildTx := func(prevHash *chainhash.Hash, script0, script1 []byte) *wire.MsgTx {
 		return &wire.MsgTx{
 			TxIn: []*wire.TxIn{
-				&wire.TxIn{PreviousOutPoint: wire.OutPoint{*prevHash, 0, dcrutil.TxTreeRegular}},
-				&wire.TxIn{PreviousOutPoint: wire.OutPoint{*prevHash, 1, dcrutil.TxTreeRegular}},
+				&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+					Hash:  *prevHash,
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}},
+				&wire.TxIn{PreviousOutPoint: wire.OutPoint{
+					Hash:  *prevHash,
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}},
 			},
 			TxOut: []*wire.TxOut{
 				&wire.TxOut{Value: 1e8, PkScript: script0},

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -164,7 +164,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstRecvTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstRecvTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstRecvTx.Sha(): {},
@@ -188,7 +192,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstRecvTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstRecvTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstRecvTx.Sha(): {},
@@ -213,7 +221,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstRecvTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstRecvTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeREgular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{},
 		},
@@ -236,7 +248,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstRecvTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstRecvTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{},
 		},
@@ -249,7 +265,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstRecvTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstRecvTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstRecvTx.Sha(): {},
@@ -274,7 +294,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstDoubleSpendTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstDoubleSpendTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstDoubleSpendTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{},
 		},
@@ -330,7 +354,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstSpendingTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstSpendingTx.Sha(): {},
@@ -353,8 +381,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstSpendingTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
-				wire.OutPoint{*TstSpendingTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstSpendingTx.Sha(): {},
@@ -373,8 +409,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstSpendingTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
-				wire.OutPoint{*TstSpendingTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{},
 		},
@@ -387,8 +431,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstSpendingTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
-				wire.OutPoint{*TstSpendingTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{},
 		},
@@ -401,8 +453,16 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{*TstSpendingTx.Sha(), 0, dcrutil.TxTreeRegular}: {},
-				wire.OutPoint{*TstSpendingTx.Sha(), 1, dcrutil.TxTreeRegular}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 0,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
+				wire.OutPoint{
+					Hash:  *TstSpendingTx.Sha(),
+					Index: 1,
+					Tree:  dcrutil.TxTreeRegular,
+				}: {},
 			},
 			unmined: map[chainhash.Hash]struct{}{
 				*TstSpendingTx.Sha(): {},


### PR DESCRIPTION
This commit corrects various things found by the static checkers
(comments, unkeyed fields, return after some if/else).

Add generated files and legacy files to the whitelist to be ignored.

Catch .travis.yml up with btcd so goclean can be run.