### PR TITLE
Add stake txscript types in ListUnspent to be spendable

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2055,6 +2055,12 @@ func (w *Wallet) ListUnspent(minconf, maxconf int32,
 			spendable = true
 		case txscript.ScriptHashTy:
 			spendable = true
+		case txscript.StakeGenTy:
+			spendable = true
+		case txscript.StakeRevocationTy:
+			spendable = true
+		case txscript.StakeSubChangeTy:
+			spendable = true
 		case txscript.MultiSigTy:
 			for _, a := range addrs {
 				_, err := w.Manager.Address(a)


### PR DESCRIPTION
Before, stake txscript types were being avoided so they were not being flagged as spendable, which would result in them being left out of ListUnspent response

Fixes #131 