### PR TITLE
Fix watching only wallets

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -170,6 +170,11 @@ func walletMain() error {
 func startPromptPass(w *wallet.Wallet) {
 	promptPass := cfg.PromptPass
 
+	// Watching only wallets never require a password.
+	if w.Manager.WatchingOnly() {
+		return
+	}
+
 	// The wallet is totally desynced, so we need to resync accounts.
 	// Prompt for the password. Then, set the flag it wallet so it
 	// knows which address functions to call when resyncing.


### PR DESCRIPTION
A bug where the password was prompted for on a new watching only
wallet start up caused the watching only wallet to never sync.
Now the password check is skipped. Fixes #148.