### PR TITLE
Update TravisCI configs. (#409)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: go
+go:
+  - 1.5.3
+  - 1.6
+sudo: false
+before_install:
+  - gotools=golang.org/x/tools
+install:
+  - go get -d -t -v ./...
+  - go get -v $gotools/cmd/cover
+  - go get -v github.com/bradfitz/goimports
+  - go get -v github.com/golang/lint/golint
+script:
+  - export PATH=$PATH:$HOME/gopath/bin
+  - ./goclean.sh


### PR DESCRIPTION
The vet tool moved to the Go tree as of go1.5 so it does not
need to be installed seperately.  With the x/tools repo now gone,
remove the install step for vet since it fails.