### PR TITLE
Fix attempted sync when connected to empty chain

### DIFF
--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -419,7 +419,6 @@ func (w *Wallet) rescanActiveAddresses() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(blockCount)
 	// Check to see if block count != 0.  If it is then don't rescan
 	if blockCount == 0 {
 		log.Infof("No chain to sync, therefore skipping sync")

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -419,7 +419,6 @@ func (w *Wallet) rescanActiveAddresses() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println("here")
 	// Check to see if block count != 0.  If it is then don't rescan
 	if blockCount == 0 {
 		log.Infof("No chain to sync, therefore skipping sync")
@@ -514,7 +513,6 @@ func (w *Wallet) rescanActiveAddresses() error {
 		}
 	}
 
-	fmt.Println("here not skipped", blockCount)
 	lastAcctMgr, err := w.Manager.LastAccount()
 	if err != nil {
 		return err

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -423,10 +423,6 @@ func (w *Wallet) rescanActiveAddresses() error {
 	// Check to see if block count != 0.  If it is then don't rescan
 	if blockCount == 0 {
 		log.Infof("No chain to sync, therefore skipping sync")
-		pool, err := newAddressPools(waddrmgr.DefaultAccountNum, 0, 0, w)
-		if err != nil {
-			return err
-		}
 
 		// initialize internal
 		_, err = w.Manager.AddressDerivedFromDbAcct(
@@ -494,6 +490,10 @@ func (w *Wallet) rescanActiveAddresses() error {
 			log.Errorf("Failed to store next to use pool idx for "+
 				"%s pool in the manager on init sync: %v",
 				"internal", err.Error())
+		}
+		pool, err := newAddressPools(waddrmgr.DefaultAccountNum, 0, 0, w)
+		if err != nil {
+			return err
 		}
 		w.addrPools[waddrmgr.DefaultAccountNum] = pool
 		return nil

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -328,6 +328,16 @@ func (w *Wallet) scanAddressIndex(start int, end int, account uint32,
 		return 0, nil, err
 	}
 
+	blockCount, err := chainClient.GetBlockCount()
+	if err != nil {
+		return 0, nil, err
+	}
+	fmt.Println(blockCount)
+	// Check to see if block count != 0.  If it is then don't rescan
+	if blockCount == 0 {
+		return 0, nil, fmt.Errorf("No chain to sync, therefore skipping sync")
+	}
+
 	// Find the last used address. Scan from it to the end in case there was a
 	// gap from that position, which is possible. Then, return the address
 	// in that position.


### PR DESCRIPTION
Currently for cold wallets, dcrwallet needs to be connected to an empty chain.  But the current way address rescan works, it renders that process impossible.
So a check has been added to see if the blockcount = 0.  If it is empty, create 1 address pool for the default account and set the internal and external address indices to 0.