### PR TITLE
fix off by one when initializing a wallet

### DIFF
--- a/wallet/addresspool.go
+++ b/wallet/addresspool.go
@@ -123,7 +123,7 @@ func (a *addressPool) initialize(account uint32, branch uint32, index uint32,
 	if mgrIdx == index {
 		a.addresses = make([]string, 0)
 	} else {
-		fetchNum := mgrIdx - index
+		fetchNum := mgrIdx - index + 1
 		a.addresses = make([]string, fetchNum)
 		for i := uint32(0); i < fetchNum; i++ {
 			addr, err := w.Manager.AddressDerivedFromDbAcct(index+i, account,


### PR DESCRIPTION
I was doing some testing of auto-synchronizing of wallets and noticed that a wallet synced from seed had an off by one where address 21 was in place of address 20:

wallet1:

[DBG] WLLT: Get new address for branch 0 returned TsVtthQ8ivLETX7AK1AWzaXawSxwgkrpgSb (idx 19) from the address pool
[DBG] WLLT: Get new address for branch 0 returned TsbPAa7m2dJ2y6b3Nsbrr2jECmcM4my4PP3 (idx 20) from the address pool

wallet2:

[DBG] WLLT: Get new address for branch 0 returned TsVtthQ8ivLETX7AK1AWzaXawSxwgkrpgSb (idx 19) from the address pool
DBG] WLLT: Get new address for branch 0 returned TsbPAa7m2dJ2y6b3Nsbrr2jECmcM4my4PP3 (idx 20) from the address pool

newly synced wallet3:

WLLT: Get new address for branch 0 returned TsVtthQ8ivLETX7AK1AWzaXawSxwgkrpgSb (idx 19) from the address pool
[DBG] WLLT: Get new address for branch 0 returned TseYj6dQyBy9H9iECRPYtXnJuDFnchGiSnX (idx 20) from the address pool

With this fix, the wallets are properly synchronized.