### PR TITLE
Refactor address index syncing code

### DIFF
--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ const (
 	defaultAutomaticRepair   = false
 	defaultUnsafeMainNet     = false
 	defaultPromptPass        = false
+	defaultAddrIdxScanLen    = 750
 
 	walletDbName = "wallet.db"
 )
@@ -86,6 +87,7 @@ type config struct {
 	TicketMaxPrice    float64 `long:"ticketmaxprice" description:"The maximum price the user is willing to spend on buying a ticket"`
 	PoolAddress       string  `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
 	PoolFees          float64 `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool, in coins"`
+	AddrIdxScanLen    int     `long:"addridxscanlen" description:"The width of the scan for last used addresses on wallet restore and start up (default: 750)"`
 
 	// RPC client options
 	RPCConnect       string `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:18556)"`
@@ -262,6 +264,7 @@ func loadConfig() (*config, []string, error) {
 		TicketMaxPrice:         defaultTicketMaxPrice,
 		AutomaticRepair:        defaultAutomaticRepair,
 		UnsafeMainNet:          defaultUnsafeMainNet,
+		AddrIdxScanLen:         defaultAddrIdxScanLen,
 	}
 
 	// A config file in the current directory takes precedence.

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -99,7 +99,9 @@ func walletMain() error {
 		TicketAddress:      cfg.TicketAddress,
 		TicketMaxPrice:     cfg.TicketMaxPrice,
 	}
-	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions, cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.PromptPass)
+	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
+		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.PromptPass,
+		cfg.AddrIdxScanLen)
 
 	// Create and start HTTP server to serve wallet client connections.
 	// This will be updated with the wallet and chain server RPC client

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -49,10 +49,11 @@ type Loader struct {
 	db          walletdb.DB
 	mu          sync.Mutex
 
-	stakeOptions  *StakeOptions
-	autoRepair    bool
-	unsafeMainNet bool
-	promptPass    bool
+	stakeOptions   *StakeOptions
+	autoRepair     bool
+	unsafeMainNet  bool
+	promptPass     bool
+	addrIdxScanLen int
 }
 
 // StakeOptions contains the various options necessary for stake mining.
@@ -70,13 +71,17 @@ type StakeOptions struct {
 }
 
 // NewLoader constructs a Loader.
-func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, autoRepair bool, unsafeMainNet bool, promptPass bool) *Loader {
+func NewLoader(chainParams *chaincfg.Params, dbDirPath string,
+	stakeOptions *StakeOptions, autoRepair bool, unsafeMainNet bool,
+	promptPass bool, addrIdxScanLen int) *Loader {
 	return &Loader{
-		chainParams:  chainParams,
-		dbDirPath:    dbDirPath,
-		stakeOptions: stakeOptions,
-		autoRepair:   autoRepair,
-		promptPass:   promptPass,
+		chainParams:    chainParams,
+		dbDirPath:      dbDirPath,
+		stakeOptions:   stakeOptions,
+		autoRepair:     autoRepair,
+		unsafeMainNet:  unsafeMainNet,
+		promptPass:     promptPass,
+		addrIdxScanLen: addrIdxScanLen,
 	}
 }
 
@@ -196,7 +201,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	w, err := Open(db, pubPassphrase, cbs, so.VoteBits, so.StakeMiningEnabled,
 		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
 		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, so.PoolAddress,
-		so.PoolFees, l.autoRepair, l.chainParams)
+		so.PoolFees, l.addrIdxScanLen, l.autoRepair, l.chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -115,6 +115,7 @@ type Wallet struct {
 	// Start up flags/settings
 	automaticRepair bool
 	resyncAccounts  bool
+	addrIdxScanLen  int
 
 	chainClient        *chain.RPCClient
 	chainClientLock    sync.Mutex
@@ -180,9 +181,10 @@ type Wallet struct {
 // and transaction store.
 func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 	rollbackTest bool, ticketAddress dcrutil.Address, tmp dcrutil.Amount,
-	poolAddress dcrutil.Address, pf dcrutil.Amount, autoRepair bool,
-	mgr *waddrmgr.Manager, txs *wtxmgr.Store, smgr *wstakemgr.StakeStore,
-	db *walletdb.DB, params *chaincfg.Params) *Wallet {
+	poolAddress dcrutil.Address, pf dcrutil.Amount, addrIdxScanLen int,
+	autoRepair bool, mgr *waddrmgr.Manager, txs *wtxmgr.Store,
+	smgr *wstakemgr.StakeStore, db *walletdb.DB,
+	params *chaincfg.Params) *Wallet {
 	var rollbackBlockDB map[uint32]*wtxmgr.DatabaseContents
 	if rollbackTest {
 		rollbackBlockDB = make(map[uint32]*wtxmgr.DatabaseContents)
@@ -231,6 +233,7 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		TicketMaxPrice:           tmp,
 		poolAddress:              poolAddress,
 		poolFees:                 pf,
+		addrIdxScanLen:           addrIdxScanLen,
 		automaticRepair:          autoRepair,
 		resyncAccounts:           false,
 		rollbackTesting:          rollbackTest,
@@ -2761,8 +2764,9 @@ func CreateWatchOnly(db walletdb.DB, extendedPubKey string, pubPass []byte, para
 func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	voteBits uint16, stakeMiningEnabled bool, balanceToMaintain float64,
 	addressReuse bool, rollbackTest bool, pruneTickets bool, ticketAddress string,
-	ticketMaxPrice float64, poolAddress string, poolFees float64, autoRepair bool,
-	params *chaincfg.Params) (*Wallet, error) {
+	ticketMaxPrice float64, poolAddress string, poolFees float64,
+	addrIdxScanLen int, autoRepair bool, params *chaincfg.Params) (*Wallet,
+	error) {
 	addrMgrNS, err := db.Namespace(waddrmgrNamespaceKey)
 	if err != nil {
 		return nil, err
@@ -2851,6 +2855,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		tmp,
 		poolAddr,
 		pf,
+		addrIdxScanLen,
 		autoRepair,
 		addrMgr,
 		txMgr,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -121,7 +121,9 @@ func createWallet(cfg *config) error {
 		TicketAddress:      cfg.TicketAddress,
 		TicketMaxPrice:     cfg.TicketMaxPrice,
 	}
-	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions, cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.PromptPass)
+	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
+		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.PromptPass,
+		cfg.AddrIdxScanLen)
 
 	// When there is a legacy keystore, open it now to ensure any errors
 	// don't end up exiting the process after the user has spent time


### PR DESCRIPTION
The new RPC function existsaddresses is not used in place of
existsaddress, which should enhance the synchronization speed of
dcrwallet on restore from seed and start up.

A new flag has been added to allow users to optionally set their 
final address index scan lengths.