### PR TITLE
Bump for v0.1.0

### DIFF
--- a/version.go
+++ b/version.go
@@ -18,12 +18,12 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 0
-	appPatch uint = 10
+	appMinor uint = 1
+	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	appPreRelease = "alpha"
+	appPreRelease = "beta"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
Change wallet from alpha to beta.  Since wallet is used
in production this seems more accurate at this time.