### PR TITLE
Isolate address pool to prevent excessive address creation

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -922,7 +922,7 @@ out:
 			txr.resp <- consolidateResponse{txh, err}
 
 		case txr := <-w.createTxRequests:
-			tx, err := w.txToOutputs(txr.outputs, txr.account, txr.minconf, true)
+			tx, err := w.TxToOutputs(txr.outputs, txr.account, txr.minconf, true)
 			txr.resp <- createTxResponse{tx, err}
 
 		case txr := <-w.createMultisigTxRequests:


### PR DESCRIPTION
Automatic ticket purchases by the wallet could cause excessive usage
of the default account internal branch because the address for the
split transaction outputs was created using the exported new address
function for the wallet. The API for txToOutputs has been modified and
a new function that calls it, TxToOutputs, created. This new function
does all the locking required, so that the internal function txToOutputs
may be called by other functions in wallet that already have the
relevant locks held.