### PR TITLE
Add ability to change autopurchase frequency

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,6 +36,7 @@ const (
 	defaultRollbackTest      = false
 	defaultPruneTickets      = false
 	defaultTicketMaxPrice    = 50.0
+	defaultTicketBuyFreq     = 1
 	defaultAutomaticRepair   = false
 	defaultUnsafeMainNet     = false
 	defaultPromptPass        = false
@@ -85,6 +86,7 @@ type config struct {
 	PruneTickets      bool    `long:"prunetickets" description:"Prune old tickets from the wallet and restore their inputs"`
 	TicketAddress     string  `long:"ticketaddress" description:"Send all ticket outputs to this address (P2PKH or P2SH only)"`
 	TicketMaxPrice    float64 `long:"ticketmaxprice" description:"The maximum price the user is willing to spend on buying a ticket"`
+	TicketBuyFreq     int     `long:"ticketbuyfreq" description:"The number of tickets to try to buy per block (default: 1), where negative numbers indicate one ticket for each 1-in-? blocks"`
 	PoolAddress       string  `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
 	PoolFees          float64 `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool, in coins"`
 	AddrIdxScanLen    int     `long:"addridxscanlen" description:"The width of the scan for last used addresses on wallet restore and start up (default: 750)"`
@@ -262,6 +264,7 @@ func loadConfig() (*config, []string, error) {
 		RollbackTest:           defaultRollbackTest,
 		PruneTickets:           defaultPruneTickets,
 		TicketMaxPrice:         defaultTicketMaxPrice,
+		TicketBuyFreq:          defaultTicketBuyFreq,
 		AutomaticRepair:        defaultAutomaticRepair,
 		UnsafeMainNet:          defaultUnsafeMainNet,
 		AddrIdxScanLen:         defaultAddrIdxScanLen,

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -98,6 +98,7 @@ func walletMain() error {
 		AddressReuse:       cfg.ReuseAddresses,
 		TicketAddress:      cfg.TicketAddress,
 		TicketMaxPrice:     cfg.TicketMaxPrice,
+		TicketBuyFreq:      cfg.TicketBuyFreq,
 	}
 	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.PromptPass,

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -66,6 +66,7 @@ type StakeOptions struct {
 	AddressReuse       bool
 	TicketAddress      string
 	TicketMaxPrice     float64
+	TicketBuyFreq      int
 	PoolAddress        string
 	PoolFees           float64
 }
@@ -200,8 +201,9 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	so := l.stakeOptions
 	w, err := Open(db, pubPassphrase, cbs, so.VoteBits, so.StakeMiningEnabled,
 		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
-		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, so.PoolAddress,
-		so.PoolFees, l.addrIdxScanLen, l.autoRepair, l.chainParams)
+		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, so.TicketBuyFreq,
+		so.PoolAddress, so.PoolFees, l.addrIdxScanLen, l.autoRepair,
+		l.chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -108,6 +108,7 @@ type Wallet struct {
 	CurrentStakeDiff   *StakeDifficultyInfo
 	CurrentVotingInfo  *VotingInfo
 	TicketMaxPrice     dcrutil.Amount
+	ticketBuyFreq      int
 	balanceToMaintain  dcrutil.Amount
 	poolAddress        dcrutil.Address
 	poolFees           dcrutil.Amount
@@ -181,8 +182,8 @@ type Wallet struct {
 // and transaction store.
 func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 	rollbackTest bool, ticketAddress dcrutil.Address, tmp dcrutil.Amount,
-	poolAddress dcrutil.Address, pf dcrutil.Amount, addrIdxScanLen int,
-	autoRepair bool, mgr *waddrmgr.Manager, txs *wtxmgr.Store,
+	ticketBuyFreq int, poolAddress dcrutil.Address, pf dcrutil.Amount,
+	addrIdxScanLen int, autoRepair bool, mgr *waddrmgr.Manager, txs *wtxmgr.Store,
 	smgr *wstakemgr.StakeStore, db *walletdb.DB,
 	params *chaincfg.Params) *Wallet {
 	var rollbackBlockDB map[uint32]*wtxmgr.DatabaseContents
@@ -232,6 +233,7 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		addressReuse:             addressReuse,
 		ticketAddress:            ticketAddress,
 		TicketMaxPrice:           tmp,
+		ticketBuyFreq:            ticketBuyFreq,
 		poolAddress:              poolAddress,
 		poolFees:                 pf,
 		addrIdxScanLen:           addrIdxScanLen,
@@ -2765,9 +2767,9 @@ func CreateWatchOnly(db walletdb.DB, extendedPubKey string, pubPass []byte, para
 func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	voteBits uint16, stakeMiningEnabled bool, balanceToMaintain float64,
 	addressReuse bool, rollbackTest bool, pruneTickets bool, ticketAddress string,
-	ticketMaxPrice float64, poolAddress string, poolFees float64,
-	addrIdxScanLen int, autoRepair bool, params *chaincfg.Params) (*Wallet,
-	error) {
+	ticketMaxPrice float64, ticketBuyFreq int, poolAddress string,
+	poolFees float64, addrIdxScanLen int, autoRepair bool,
+	params *chaincfg.Params) (*Wallet, error) {
 	addrMgrNS, err := db.Namespace(waddrmgrNamespaceKey)
 	if err != nil {
 		return nil, err
@@ -2854,6 +2856,7 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		rollbackTest,
 		ticketAddr,
 		tmp,
+		ticketBuyFreq,
 		poolAddr,
 		pf,
 		addrIdxScanLen,


### PR DESCRIPTION
The automatic ticket purchase frequency has been changed to default
to 1. The frequency can be changed with the command line argument
--ticketbuyfreq=.