### PR TITLE
Open and return wallet from CreateNewWallet.

### DIFF
--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -150,9 +150,20 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (*W
 		return nil, err
 	}
 
-	l.onLoaded(nil, db)
-	db.Close()
-	return nil, nil
+	// Open the newly-created wallet.
+	so := l.stakeOptions
+	w, err := Open(db, pubPassphrase, nil, so.VoteBits, so.StakeMiningEnabled,
+		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
+		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
+		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, l.addrIdxScanLen,
+		l.autoRepair, l.chainParams)
+	if err != nil {
+		return nil, err
+	}
+	w.Start()
+
+	l.onLoaded(w, db)
+	return w, nil
 }
 
 var errNoConsole = errors.New("db upgrade requires console access for additional input")


### PR DESCRIPTION
This fixes a dcrwallet-specific bug introduced by
4b64adf52f873a4ec5237d3fb16b5252ddef3846 which removed the call to
wallet.Open from wallet.Loader.CreateNewWallet, replacing the wallet
pointer with nil, and removes the addition of a call to close the
wallet database.  The introduction of a nil pointer caused runtime
panics when executing Loader callbacks that dereferenced the wallet
pointer, and by the caller who would dereference the return value.

This makes the LoaderService.CreateNewWallet RPC useful again.