### PR TITLE
Call the more reliable GetStakeDifficulty for ticket prices

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1120,10 +1120,14 @@ func (w *Wallet) purchaseTicket(req purchaseTicketRequest) (interface{},
 	// address this better and prevent address burning.
 	account := req.account
 
-	// Get the current ticket price.
-	ticketPrice := dcrutil.Amount(w.GetStakeDifficulty().StakeDifficulty)
-	if ticketPrice == -1 {
-		return nil, ErrTicketPriceNotSet
+	// Get the current ticket price from the daemon.
+	ticketPricesF64, err := w.ChainClient().GetStakeDifficulty()
+	if err != nil {
+		return nil, err
+	}
+	ticketPrice, err := dcrutil.NewAmount(ticketPricesF64.NextStakeDifficulty)
+	if err != nil {
+		return nil, err
 	}
 
 	// Ensure the ticket price does not exceed the spend limit if set.


### PR DESCRIPTION
Tickets could sometimes be purchased at the wrong price if the
wallet was not yet synced to the best block. Instead, fetch the next
price from the daemon and use that instead.