### PR TITLE
Use same fee policies across all networks.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -2514,16 +2514,7 @@ func redeemMultiSigOut(icmd interface{}, w *wallet.Wallet, chainClient *chain.RP
 	// Calculate the fees required, and make sure we have enough.
 	// Then produce the txout.
 	size := wallet.EstimateTxSize(1, 1)
-	var feeIncrement dcrutil.Amount
-	switch {
-	case w.ChainParams() == &chaincfg.MainNetParams:
-		feeIncrement = wallet.FeeIncrementMainnet
-	case w.ChainParams() == &chaincfg.TestNetParams:
-		feeIncrement = wallet.FeeIncrementTestnet
-	default:
-		feeIncrement = wallet.FeeIncrementTestnet
-	}
-	feeEst := wallet.FeeForSize(feeIncrement, size)
+	feeEst := wallet.FeeForSize(w.RelayFee(), size)
 	if feeEst >= msCredit.Amount {
 		return nil, fmt.Errorf("multisig out amt is too small "+
 			"(have %v, %v fee suggested)", msCredit.Amount, feeEst)

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -129,21 +129,9 @@ func FeeForSize(incr dcrutil.Amount, sz int) dcrutil.Amount {
 	return feeForSize(incr, sz)
 }
 
-// FeeIncrementMainnet is the default minimum transaction fees per KB (0.01 coin,
-// measured in atoms) added to transactions requiring a fee for MainNet.
-const FeeIncrementMainnet = 1e6
-
-// FeeIncrementTestnet is the default minimum transaction fees per KB (0.00001
-// coin, measured in atoms) added to transactions requiring a fee for TestNet.
-const FeeIncrementTestnet = 1e3
-
 // TicketFeeIncrement is the default minimum stake transaction fees per KB (0.01
 // coin, measured in atoms).
 const TicketFeeIncrement = 1e6
-
-// TicketFeeIncrementTestnet is the default minimum stake transaction fees per KB
-// (0.00001 coin, measured in atoms) for Testnet.
-const TicketFeeIncrementTestnet = 1e3
 
 // EstMaxTicketFeeAmount is the estimated max ticket fee to be used for size
 // calculation for eligible utxos for ticket purchasing.
@@ -620,8 +608,7 @@ func (w *Wallet) txToMultisig(account uint32, amount dcrutil.Amount,
 	// we don't need to add a change output in this
 	// case.
 	feeSize := estimateTxSize(numInputs, 2)
-	var feeIncrement dcrutil.Amount
-	feeIncrement = w.RelayFee()
+	feeIncrement := w.RelayFee()
 
 	feeEst := feeForSize(feeIncrement, feeSize)
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -197,20 +197,6 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		rollbackBlockDB = make(map[uint32]*wtxmgr.DatabaseContents)
 	}
 
-	var feeIncrement dcrutil.Amount
-	var ticketFeeIncrement dcrutil.Amount
-	switch {
-	case params == &chaincfg.MainNetParams:
-		feeIncrement = FeeIncrementMainnet
-		ticketFeeIncrement = TicketFeeIncrement
-	case params == &chaincfg.TestNetParams:
-		feeIncrement = FeeIncrementTestnet
-		ticketFeeIncrement = TicketFeeIncrementTestnet
-	default:
-		feeIncrement = FeeIncrementTestnet
-		ticketFeeIncrement = TicketFeeIncrementTestnet
-	}
-
 	w := &Wallet{
 		db:                       *db,
 		Manager:                  mgr,
@@ -221,8 +207,8 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		balanceToMaintain:        btm,
 		CurrentStakeDiff:         &StakeDifficultyInfo{nil, -1, -1},
 		lockedOutpoints:          map[wire.OutPoint]struct{}{},
-		relayFee:                 feeIncrement,
-		ticketFeeIncrement:       ticketFeeIncrement,
+		relayFee:                 txrules.DefaultRelayFeePerKb,
+		ticketFeeIncrement:       TicketFeeIncrement,
 		AllowHighFees:            AllowHighFees,
 		rescanAddJob:             make(chan *RescanJob),
 		rescanBatch:              make(chan *rescanBatch),


### PR DESCRIPTION
While here, fix an error in legacyrpc's redeemMultiSigOut function
which used the default relay fees and ignored the wallet's current
settings.