### PR TITLE
Fix bugs relating to reorganizations

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -811,7 +811,7 @@ func (w *Wallet) syncWithChain() error {
 			curBlock = &bl.MsgBlock().Header.PrevBlock
 
 			// Break early if we hit the genesis block.
-			if i == 1 {
+			if i == 0 {
 				break
 			}
 		}


### PR DESCRIPTION
Two bugs relating to reorganizations were fixed. The first was an off
by one bug on initial sync which rarely would ever affect the end user.
The second was that logic causing the removal of all blocks to the
genesis block on a disconnection of an unknown block would cause
irreversible corruption of the wallet. The new code ignores the hash
of the block to remove and assumes that daemon removing blocks to some
common unknown forking point between the daemon and wallet before
connecting the side chain's blocks.