### PR TITLE
Enable vendor experiment earlier in travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,14 @@ go:
 sudo: false
 before_install:
   - gotools=golang.org/x/tools
+  - export GO15VENDOREXPERIMENT=1
 install:
   - go get -v github.com/Masterminds/glide
   - glide install
-  - go get -v $(glide novendor)
+  - go install -v . ./cmd/...
   - go get -v $gotools/cmd/cover
   - go get -v github.com/golang/lint/golint
   - go get -v github.com/davecgh/go-spew/spew
 script:
   - export PATH=$PATH:$HOME/gopath/bin
-  - export GO15VENDOREXPERIMENT=1
   - ./goclean.sh


### PR DESCRIPTION
This ensures that the vendor experiment is enabled when building not
just dcrwallet, but glide itself as well (glide vendors dependencies
and checks them into its git repo).

While here, switch from using 'go get $(glide novendor)' to 'go
install . ./cmd/...' to build the project and all related commands.
This won't hide errors when glide fails to restore a required
dependency or the vendor experiment is disabled.