### PR TITLE
Fix fee calculation for revocations and rebroastcast on start up

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -201,7 +201,7 @@ func startPromptPass(w *wallet.Wallet) {
 		promptPass = true
 	}
 	if promptPass {
-		w.SetResyncAccounts(true)
+		w.SetInitiallyUnlocked(true)
 		backendLog.Flush()
 		fmt.Println("*** ATTENTION ***")
 		fmt.Println("Since this is your first time running we need to sync accounts. Please enter")

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -50,7 +50,7 @@ func (w *Wallet) accountIsUsed(account uint32, chainClient *chain.RPCClient) boo
 	// exists in accounts that have not yet been created, while
 	// AddressDerivedFromDbAcct can not.
 	addrFunc := w.Manager.AddressDerivedFromDbAcct
-	if w.resyncAccounts {
+	if w.initiallyUnlocked {
 		addrFunc = w.Manager.AddressDerivedFromCointype
 	}
 
@@ -459,7 +459,7 @@ func (w *Wallet) rescanActiveAddresses() error {
 	// performed if we're restoring our wallet from seed.
 	lastAcct := uint32(0)
 	var err error
-	if w.resyncAccounts {
+	if w.initiallyUnlocked {
 		min := 0
 		max := waddrmgr.MaxAccountNum
 		lastAcct, err = w.scanAccountIndex(min, max)

--- a/wstakemgr/feeest.go
+++ b/wstakemgr/feeest.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016 The Decred developers
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package wstakemgr
+
+const (
+	// All transactions have 4 bytes for version, 4 bytes of locktime,
+	// 4 bytes of expiry, and 2 varints for the number of inputs and
+	// outputs, and 1 varint for the witnesses.
+	txOverheadEstimate = 4 + 4 + 4 + 1 + 1 + 1
+
+	// A worst case signature script to redeem a P2PKH output for a
+	// compressed pubkey has 73 bytes of the possible DER signature
+	// (with no leading 0 bytes for R and S), 65 bytes of serialized pubkey,
+	// and data push opcodes for both, plus one byte for the hash type flag
+	// appended to the end of the signature.
+	sigScriptEstimate = 1 + 73 + 1 + 65 + 1
+
+	// A best case tx input serialization cost is 32 bytes of sha, 4 bytes
+	// of output index, 1 byte for tree, 4 bytes of sequence, 12 bytes for
+	// fraud proof, one byte for both the txin signature size (0) and the
+	// witness signature script size, and the estimated signature script
+	// size.
+	txInEstimate = 32 + 4 + 1 + 12 + 4 + 1 + 1 + sigScriptEstimate
+
+	// An SSRtx P2PKH pkScript contains the following bytes:
+	//  - OP_SSRTX
+	//  - OP_DUP
+	//  - OP_HASH160
+	//  - OP_DATA_20 + 20 bytes of pubkey hash
+	//  - OP_EQUALVERIFY
+	//  - OP_CHECKSIG
+	ssrtxPkScriptEstimate = 1 + 1 + 1 + 1 + 20 + 1 + 1
+
+	// txOutEstimate is a best case tx output serialization cost is 8 bytes
+	// of value, two bytes of version, one byte of varint, and the pkScript
+	// size.
+	txOutEstimate = 8 + 2 + 1 + ssrtxPkScriptEstimate
+)
+
+func estimateSSRtxTxSize(numInputs, numOutputs int) int {
+	return txOverheadEstimate + txInEstimate*numInputs +
+		txOutEstimate*numOutputs
+}


### PR DESCRIPTION
The fee calculation for revocations was stuck at a very high fixed
rate. The fees for revocations are now calculated on a per kilobyte
basis. The wallet now also triggers winner and missed ticket
notifications on start up, so that revocations for tickets that
were missed while the wallet was offline will be triggered when
the wallet is started.

Fixes #51.