### PR TITLE
Import bdb driver from wallet package.

### DIFF
--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/decred/dcrwallet/internal/prompt"
 	"github.com/decred/dcrwallet/waddrmgr"
 	"github.com/decred/dcrwallet/walletdb"
+	_ "github.com/decred/dcrwallet/walletdb/bdb" // driver loaded during init
 )
 
 const (


### PR DESCRIPTION
This allows consumers of wallet.Loader to use the type without needing
to import the database driver themselves.