### PR TITLE
config: Add txfee and ticketfee to available config settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -95,6 +95,8 @@ type config struct {
 	AddrIdxScanLen      int     `long:"addridxscanlen" description:"The width of the scan for last used addresses on wallet restore and start up (default: 750)"`
 	StakePoolColdExtKey string  `long:"stakepoolcoldextkey" description:"Enables the wallet as a stake pool with an extended key in the format of \"xpub...:index\" to derive cold wallet addresses to send fees to"`
 	AllowHighFees       bool    `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
+	RelayFee            float64 `long:"txfee" description:"Sets the wallet's tx fee per kb (default: 0.01)"`
+	TicketFee           float64 `long:"ticketfee" description:"Sets the wallet's ticket fee per kb (default: 0.01)"`
 
 	// RPC client options
 	RPCConnect       string `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:18556)"`
@@ -592,6 +594,15 @@ func loadConfig() (*config, []string, error) {
 
 	if cfg.RPCConnect == "" {
 		cfg.RPCConnect = net.JoinHostPort("localhost", activeNet.RPCClientPort)
+	}
+
+	// Set ticketfee and txfee to defaults if none are set.  Avoiding using default
+	// confs because they are dcrutil.Amounts
+	if cfg.TicketFee == 0.0 {
+		cfg.TicketFee = wallet.DefaultTicketFeeIncrement.ToCoin()
+	}
+	if cfg.RelayFee == 0.0 {
+		cfg.RelayFee = txrules.DefaultRelayFeePerKb.ToCoin()
 	}
 
 	// Add default port to connect flag if missing.

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -102,10 +102,11 @@ func walletMain() error {
 		PoolAddress:         cfg.PoolAddress,
 		PoolFees:            cfg.PoolFees,
 		StakePoolColdExtKey: cfg.StakePoolColdExtKey,
+		TicketFee:           cfg.TicketFee,
 	}
 	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.AddrIdxScanLen,
-		cfg.AllowHighFees)
+		cfg.AllowHighFees, cfg.RelayFee)
 
 	// Create and start HTTP server to serve wallet client connections.
 	// This will be updated with the wallet and chain server RPC client

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -15,6 +15,11 @@
 ; directory for mainnet and testnet wallets, respectively.
 ; appdata=~/.drcwallet
 
+; Set txfee and ticketfee that will be used on startup.  They can be changed with
+; dcrctl --wallet settxfee/setticketfee as well
+; txfee=0.01
+; ticketfee=0.01
+
 
 ; ------------------------------------------------------------------------------
 ; RPC client settings

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -129,9 +129,9 @@ func FeeForSize(incr dcrutil.Amount, sz int) dcrutil.Amount {
 	return feeForSize(incr, sz)
 }
 
-// TicketFeeIncrement is the default minimum stake transaction fees per KB (0.01
+// DefaultTicketFeeIncrement is the default minimum stake transaction fees per KB (0.01
 // coin, measured in atoms).
-const TicketFeeIncrement = 1e6
+const DefaultTicketFeeIncrement dcrutil.Amount = 1e6
 
 // EstMaxTicketFeeAmount is the estimated max ticket fee to be used for size
 // calculation for eligible utxos for ticket purchasing.

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -55,6 +55,7 @@ type Loader struct {
 	unsafeMainNet  bool
 	addrIdxScanLen int
 	allowHighFees  bool
+	relayFee       float64
 }
 
 // StakeOptions contains the various options necessary for stake mining.
@@ -62,6 +63,7 @@ type StakeOptions struct {
 	VoteBits            uint16
 	StakeMiningEnabled  bool
 	BalanceToMaintain   float64
+	TicketFee           float64
 	RollbackTest        bool
 	PruneTickets        bool
 	AddressReuse        bool
@@ -76,7 +78,7 @@ type StakeOptions struct {
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string,
 	stakeOptions *StakeOptions, autoRepair bool, unsafeMainNet bool,
-	addrIdxScanLen int, allowHighFees bool) *Loader {
+	addrIdxScanLen int, allowHighFees bool, relayFee float64) *Loader {
 	return &Loader{
 		chainParams:    chainParams,
 		dbDirPath:      dbDirPath,
@@ -85,6 +87,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string,
 		unsafeMainNet:  unsafeMainNet,
 		addrIdxScanLen: addrIdxScanLen,
 		allowHighFees:  allowHighFees,
+		relayFee:       relayFee,
 	}
 }
 
@@ -157,8 +160,8 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (*W
 	w, err := Open(db, pubPassphrase, nil, so.VoteBits, so.StakeMiningEnabled,
 		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
 		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
-		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, l.addrIdxScanLen,
-		so.StakePoolColdExtKey, l.autoRepair, l.allowHighFees, l.chainParams)
+		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee, l.addrIdxScanLen,
+		so.StakePoolColdExtKey, l.autoRepair, l.allowHighFees, l.relayFee, l.chainParams)
 	if err != nil {
 		return nil, err
 	}
@@ -224,8 +227,8 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	w, err = Open(db, pubPassphrase, cbs, so.VoteBits, so.StakeMiningEnabled,
 		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
 		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, so.TicketBuyFreq,
-		so.PoolAddress, so.PoolFees, l.addrIdxScanLen, so.StakePoolColdExtKey,
-		l.autoRepair, l.allowHighFees, l.chainParams)
+		so.PoolAddress, so.PoolFees, so.TicketFee, l.addrIdxScanLen, so.StakePoolColdExtKey,
+		l.autoRepair, l.allowHighFees, l.relayFee, l.chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -187,8 +187,8 @@ type Wallet struct {
 // and transaction store.
 func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 	rollbackTest bool, ticketAddress dcrutil.Address, tmp dcrutil.Amount,
-	ticketBuyFreq int, poolAddress dcrutil.Address, pf float64,
-	addrIdxScanLen int, stakePoolColdAddrs map[string]struct{},
+	ticketBuyFreq int, poolAddress dcrutil.Address, pf float64, relayFee,
+	ticketFee dcrutil.Amount, addrIdxScanLen int, stakePoolColdAddrs map[string]struct{},
 	autoRepair, AllowHighFees bool, mgr *waddrmgr.Manager, txs *wtxmgr.Store,
 	smgr *wstakemgr.StakeStore, db *walletdb.DB,
 	params *chaincfg.Params) *Wallet {
@@ -206,8 +206,8 @@ func newWallet(vb uint16, esm bool, btm dcrutil.Amount, addressReuse bool,
 		VoteBits:                 vb,
 		balanceToMaintain:        btm,
 		lockedOutpoints:          map[wire.OutPoint]struct{}{},
-		relayFee:                 txrules.DefaultRelayFeePerKb,
-		ticketFeeIncrement:       TicketFeeIncrement,
+		relayFee:                 relayFee,
+		ticketFeeIncrement:       ticketFee,
 		AllowHighFees:            AllowHighFees,
 		rescanAddJob:             make(chan *RescanJob),
 		rescanBatch:              make(chan *rescanBatch),
@@ -3195,8 +3195,8 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 	voteBits uint16, stakeMiningEnabled bool, balanceToMaintain float64,
 	addressReuse bool, rollbackTest bool, pruneTickets bool, ticketAddress string,
 	ticketMaxPrice float64, ticketBuyFreq int, poolAddress string,
-	poolFees float64, addrIdxScanLen int, stakePoolColdExtKey string,
-	autoRepair, allowHighFees bool, params *chaincfg.Params) (*Wallet, error) {
+	poolFees float64, ticketFee float64, addrIdxScanLen int, stakePoolColdExtKey string,
+	autoRepair, allowHighFees bool, relayFee float64, params *chaincfg.Params) (*Wallet, error) {
 	addrMgrNS, err := db.Namespace(waddrmgrNamespaceKey)
 	if err != nil {
 		return nil, err
@@ -3274,6 +3274,16 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		return nil, err
 	}
 
+	ticketFeeAmt, err := dcrutil.NewAmount(ticketFee)
+	if err != nil {
+		return nil, err
+	}
+
+	relayFeeAmt, err := dcrutil.NewAmount(relayFee)
+	if err != nil {
+		return nil, err
+	}
+
 	log.Infof("Opened wallet") // TODO: log balance? last sync height?
 
 	w := newWallet(voteBits,
@@ -3286,6 +3296,8 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 		ticketBuyFreq,
 		poolAddr,
 		poolFees,
+		relayFeeAmt,
+		ticketFeeAmt,
 		addrIdxScanLen,
 		stakePoolColdAddrs,
 		autoRepair,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -116,9 +116,11 @@ func createWallet(cfg *config) error {
 		AddressReuse:       cfg.ReuseAddresses,
 		TicketAddress:      cfg.TicketAddress,
 		TicketMaxPrice:     cfg.TicketMaxPrice,
+		TicketFee:          cfg.TicketFee,
 	}
 	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.AddrIdxScanLen, cfg.AllowHighFees)
+		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.AddrIdxScanLen, cfg.AllowHighFees,
+		cfg.RelayFee)
 
 	reader := bufio.NewReader(os.Stdin)
 	privPass, pubPass, seed, err := prompt.Setup(reader,


### PR DESCRIPTION
Fixes #211

Now users can either set them on startup with --txfee and --ticketfee
flags or set them in their dcrwallet.conf.  If unused they will default
to 0.01 as before and are using the previous defaults in txrules and
wallet