### PR TITLE
Fix balance bug in AccountBalances

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -43,10 +43,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "2.1.0"
+	semverString = "2.1.1"
 	semverMajor  = 2
 	semverMinor  = 1
-	semverPatch  = 0
+	semverPatch  = 1
 )
 
 // translateError creates a new gRPC error with an appropiate error code for

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -3805,25 +3805,25 @@ func (s *Store) AccountBalances(syncHeight int32, minConf int32,
 
 	var bals Balances
 	err := scopedView(s.namespace, func(ns walletdb.Bucket) error {
-		bal, err := s.balanceFullScan(ns, syncHeight, minConf,
+		bal, err := s.balanceFullScan(ns, minConf, syncHeight,
 			false, account)
 		if err != nil {
 			return err
 		}
 
-		bal0Conf, err := s.balanceFullScan(ns, syncHeight, 0,
+		bal0Conf, err := s.balanceFullScan(ns, 0, syncHeight,
 			false, account)
 		if err != nil {
 			return err
 		}
 
-		balTotal, err := s.balanceAll(ns, syncHeight, minConf,
+		balTotal, err := s.balanceAll(ns, minConf, syncHeight,
 			false, account)
 		if err != nil {
 			return err
 		}
 
-		balAll, err := s.balanceAll(ns, syncHeight, 0,
+		balAll, err := s.balanceAll(ns, 0, syncHeight,
 			false, account)
 		if err != nil {
 			return err


### PR DESCRIPTION
The minConf and syncHeight variables were swapped in all calls
to balance functions in AccountBalances.