### PR TITLE
Fix gRPC account address index responses

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1,6 +1,6 @@
 # RPC API Specification
 
-Version: 2.2.0
+Version: 2.2.1
 
 **Note:** This document assumes the reader is familiar with gRPC concepts.
 Refer to the [gRPC Concepts documentation](http://www.grpc.io/docs/guides/concepts.html)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -44,10 +44,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "2.2.0"
+	semverString = "2.2.1"
 	semverMajor  = 2
 	semverMinor  = 2
-	semverPatch  = 0
+	semverPatch  = 1
 )
 
 // translateError creates a new gRPC error with an appropiate error code for

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1910,6 +1910,24 @@ func (w *Wallet) Accounts() (*AccountsResult, error) {
 		if err != nil {
 			return err
 		}
+
+		// Look up where the address pool index is, not the address forward
+		// buffer. Skip the imported account, which is not a BIP32-like
+		// account.
+		if acct != waddrmgr.ImportedAddrAccount {
+			extIdx, err := w.AddressPoolIndex(acct, waddrmgr.ExternalBranch)
+			if err != nil {
+				return err
+			}
+			props.ExternalKeyCount = extIdx
+
+			intIdx, err := w.AddressPoolIndex(acct, waddrmgr.InternalBranch)
+			if err != nil {
+				return err
+			}
+			props.InternalKeyCount = intIdx
+		}
+
 		accounts = append(accounts, AccountResult{
 			AccountProperties: *props,
 			// TotalBalance set below


### PR DESCRIPTION
Accounts would formerly return the index of the address buffers
for the address manager instead of the last used address index.
The correct value is now set and the version for the gRPC bumped
to 2.2.1