### PR TITLE
Fix lockup by breaking UTXO notifications

### DIFF
--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -948,7 +948,10 @@ func (s *Store) AddCredit(rec *TxRecord, block *BlockMeta, index uint32,
 		return err
 	})
 	if err == nil && isNew && s.NotifyUnspent != nil {
-		s.NotifyUnspent(&rec.Hash, index)
+		// This causes a lockup because wtxmgr is non-reentrant.
+		// TODO: move this call outside of wtxmgr and do not use
+		// a passthrough to perform the notification.
+		// s.NotifyUnspent(&rec.Hash, index)
 	}
 	return err
 }


### PR DESCRIPTION
The UTXO notification logic needs to be moved from the transaction
manager to the wallet so that it doesn't cause lockups. The offending
code has been commented out.