### PR TITLE
Update project dependencies.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
-hash: bc512f42285c0afbef5adad730e5bbf97f7581f4e859b13bc9505c285d3f8c42
-updated: 2016-08-01T11:05:05.3170756-04:00
+hash: 5cc50197a8683b16e3e120937d59e244ba000d7c0d474d8b613e17a93b9723ef
+updated: 2016-08-24T10:08:50.2439991-04:00
 imports:
 - name: github.com/boltdb/bolt
-  version: 831b652a7f8dbefaf94da0eb66abd46c0c4bcf23
+  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
 - name: github.com/btcsuite/btclog
-  version: f96df2375f37300305f329b8e5258764b4f19a7f
+  version: 73889fb79bd687870312b6e40effcecffbd57d30
 - name: github.com/btcsuite/fastsha256
-  version: 302ad4db268b46f9ebda3078f6f7397f96047735
+  version: 637e656429416087660c84436a2a035d69d54e2e
 - name: github.com/btcsuite/go-socks
   version: cfe8b59e565c1a5bd4e2005d77cd9aa8b2e14524
   subpackages:
@@ -15,12 +15,12 @@ imports:
   version: 53f62d9b43e87a6c56975cf862af7edf33a8d0df
   subpackages:
   - nacl/secretbox
+  - pbkdf2
+  - poly1305
   - ripemd160
+  - salsa20/salsa
   - scrypt
   - ssh/terminal
-  - poly1305
-  - salsa20/salsa
-  - pbkdf2
 - name: github.com/btcsuite/seelog
   version: 313961b101eb55f65ae0f03ddd4e322731763b6c
 - name: github.com/btcsuite/websocket
@@ -30,27 +30,27 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: b88cf9e80c3fee5dd3a38826b5fe79fb14d225f1
+  version: 0a9a0f1969c21d520e2676c55a4f80518b7c37aa
   subpackages:
   - blockchain
   - blockchain/stake
   - chaincfg
   - chaincfg/chainec
   - chaincfg/chainhash
+  - database
+  - dcrec/edwards
+  - dcrec/secp256k1
+  - dcrec/secp256k1/schnorr
   - dcrjson
   - txscript
   - wire
-  - dcrec/secp256k1
-  - dcrec/edwards
-  - dcrec/secp256k1/schnorr
-  - database
 - name: github.com/decred/dcrrpcclient
-  version: f3c620d63cb02aec0c1152a72d3c8669b92a2fb5
+  version: 0b8d19f926da6b33a36c2e680be8db55e7c15d52
 - name: github.com/decred/dcrutil
-  version: 4a3bdb1cb08b49811674750998363b8b8ccfd66e
+  version: 4fc91a08eea88e74539d42d6301fd298b9bd8230
   subpackages:
-  - hdkeychain
   - base58
+  - hdkeychain
 - name: github.com/decred/ed25519
   version: b0909d3f798b97a03c9e77023f97a5301a2a7900
   subpackages:
@@ -66,16 +66,16 @@ imports:
   subpackages:
   - context
   - http2
-  - trace
   - http2/hpack
-  - lex/httplex
   - internal/timeseries
+  - lex/httplex
+  - trace
 - name: golang.org/x/sys
   version: 62bee037599929a6e9146f29d10dd5208c43507d
   subpackages:
   - unix
 - name: google.golang.org/grpc
-  version: 452f01f3ae159dcec83bbf0c6b0d96860e07b5e6
+  version: 0032a855ba5c8a3c8e0d71c2deef354b70af1584
   subpackages:
   - codes
   - credentials
@@ -83,8 +83,8 @@ imports:
   - internal
   - metadata
   - naming
-  - transport
   - peer
+  - transport
 testImports:
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,17 +1,24 @@
 package: github.com/decred/dcrwallet
 import:
 - package: github.com/btcsuite/btclog
+  version: master
 - package: github.com/btcsuite/fastsha256
+  version: master
 - package: github.com/btcsuite/golangcrypto
+  version: master
   subpackages:
   - nacl/secretbox
   - ripemd160
   - scrypt
   - ssh/terminal
 - package: github.com/btcsuite/seelog
+  version: master
 - package: github.com/btcsuite/websocket
+  version: master
 - package: github.com/decred/bitset
+  version: master
 - package: github.com/decred/dcrd
+  version: master
   subpackages:
   - blockchain
   - blockchain/stake
@@ -22,7 +29,9 @@ import:
   - txscript
   - wire
 - package: github.com/decred/dcrrpcclient
+  version: master
 - package: github.com/decred/dcrutil
+  version: master
   subpackages:
   - hdkeychain
 - package: github.com/golang/protobuf
@@ -32,6 +41,7 @@ import:
   subpackages:
   - context
 - package: google.golang.org/grpc
+  version: ^1.0.0
   subpackages:
   - codes
   - credentials
@@ -39,4 +49,4 @@ import:
 - package: github.com/jessevdk/go-flags
   version: 1679536dcc895411a9f5848d9a0250be7856448c
 - package: github.com/boltdb/bolt
-  version: 831b652a7f8dbefaf94da0eb66abd46c0c4bcf23
+  version: ^1.3.0


### PR DESCRIPTION
Add 'version: master' to all btcsuite and decred projects, since we
always want the latest versions of these.  This works around a bug in
the latest version of glide where it does not track the master branch
correctly.

Update gRPC for the 1.0.0 release and update bolt to 1.3.0 to pick up
a fix for a memory handling error that was exposed by the Go 1.7 SSA
compiler backend.

Fixes #325.

Fixes #328.