### PR TITLE
Add --txindex to node args.

### DIFF
--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -133,6 +133,7 @@ func (n *nodeConfig) arguments() []string {
 		// --debuglevel
 		args = append(args, fmt.Sprintf("--debuglevel=%s", n.debugLevel))
 	}
+	args = append(args, "--txindex")
 	args = append(args, n.extra...)
 	return args
 }

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -134,6 +134,7 @@ func (n *nodeConfig) arguments() []string {
 		args = append(args, fmt.Sprintf("--debuglevel=%s", n.debugLevel))
 	}
 	args = append(args, "--txindex")
+	args = append(args, "--addrindex")
 	args = append(args, n.extra...)
 	return args
 }


### PR DESCRIPTION
database update requires `--txindex` for `getrawtransaction` to function.  This means rpctest/rpcharness requires this as a node argument.

This is included in https://github.com/chappjc/dcrwallet/tree/rfp10-m2 but should probably make it into 0.4.0.