### PR TITLE
RFP-10 Milestone 2

### DIFF
--- a/rpctest/.gitignore
+++ b/rpctest/.gitignore
@@ -1,0 +1,3 @@
+*.test
+.vscode/
+*.exe

--- a/rpctest/mkharness/main.go
+++ b/rpctest/mkharness/main.go
@@ -1,0 +1,65 @@
+// mkharness brings up a simnet node and wallet, prints the commands, and waits
+// for a keypress to terminate them.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	//"strings"
+	//"time"
+
+	"github.com/decred/dcrd/chaincfg"
+	//"github.com/decred/dcrrpcclient"
+	//"github.com/decred/dcrutil"
+	//"github.com/decred/dcrwallet/rpc/legacyrpc"
+	"github.com/decred/dcrwallet/rpctest"
+)
+
+func main() {
+	var err error
+	var primaryHarness *rpctest.Harness
+	primaryHarness, err = rpctest.NewHarness(&chaincfg.SimNetParams, nil, nil)
+	if err != nil {
+		fmt.Println("Unable to create primary harness: ", err)
+		os.Exit(1)
+	}
+
+	// Initialize the primary mining node with a chain of length 41,
+	// providing 25 mature coinbases to allow spending from for testing
+	// purposes (CoinbaseMaturity=16 for simnet).
+	if err = primaryHarness.SetUp(true, 25); err != nil {
+		fmt.Println("Unable to setup test chain: ", err)
+		err = primaryHarness.TearDown()
+		os.Exit(1)
+	}
+
+	fmt.Printf("Node command:\n\t%s\n", primaryHarness.FullNodeCommand())
+	fmt.Printf("Wallet command:\n\t%s\n", primaryHarness.FullWalletCommand())
+
+	cn := primaryHarness.RPCConfig()
+	nodeCertFile := primaryHarness.RPCCertFile()
+	fmt.Println("Command for node's dcrctl:")
+	fmt.Printf("\tdcrctl -u %s -P %s -s %s -c %s\n", cn.User, cn.Pass,
+		cn.Host, nodeCertFile) 
+
+	cw := primaryHarness.RPCWalletConfig()
+	walletCertFile := primaryHarness.RPCWalletCertFile()
+	fmt.Println("Command for wallet's dcrctl:")
+	fmt.Printf("\tdcrctl -u %s -P %s -s %s -c %s --wallet\n", cw.User, cw.Pass,
+		cw.Host, walletCertFile) 
+
+	fmt.Print("Press Enter to terminate harness.")
+	bufio.NewReader(os.Stdin).ReadBytes('\n')
+
+	// Clean up the primary harness created above. This includes removing
+	// all temporary directories, and shutting down any created processes.
+	if err := primaryHarness.TearDown(); err != nil {
+		fmt.Println("Unable to teardown test chain: ", err)
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+
+}

--- a/rpctest/mkharness/main.go
+++ b/rpctest/mkharness/main.go
@@ -42,13 +42,13 @@ func main() {
 	nodeCertFile := primaryHarness.RPCCertFile()
 	fmt.Println("Command for node's dcrctl:")
 	fmt.Printf("\tdcrctl -u %s -P %s -s %s -c %s\n", cn.User, cn.Pass,
-		cn.Host, nodeCertFile) 
+		cn.Host, nodeCertFile)
 
 	cw := primaryHarness.RPCWalletConfig()
 	walletCertFile := primaryHarness.RPCWalletCertFile()
 	fmt.Println("Command for wallet's dcrctl:")
 	fmt.Printf("\tdcrctl -u %s -P %s -s %s -c %s --wallet\n", cw.User, cw.Pass,
-		cw.Host, walletCertFile) 
+		cw.Host, walletCertFile)
 
 	fmt.Print("Press Enter to terminate harness.")
 	bufio.NewReader(os.Stdin).ReadBytes('\n')

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -133,6 +133,7 @@ func (n *nodeConfig) arguments() []string {
 		// --debuglevel
 		args = append(args, fmt.Sprintf("--debuglevel=%s", n.debugLevel))
 	}
+	args = append(args, "--txindex")
 	args = append(args, n.extra...)
 	return args
 }
@@ -229,8 +230,8 @@ func (n *node) FullCommand() string {
 	args := strings.Join(n.cmd.Args, " ")
 	return n.cmd.Path + args
 }
- 
-// CertFile returns the node RPC's TLS certificate 
+
+// CertFile returns the node RPC's TLS certificate
 func (n *node) CertFile() string {
 	return n.config.certFile
 }

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -224,9 +224,19 @@ func (n *node) Start() error {
 	return nil
 }
 
-// Stop interrupts the running dcrd process process, and waits until it exits
-// properly. On windows, interrupt is not supported, so a kill signal is used
-// instead
+// FullCommand returns the full command used to start the node
+func (n *node) FullCommand() string {
+	args := strings.Join(n.cmd.Args, " ")
+	return n.cmd.Path + args
+}
+ 
+// CertFile returns the node RPC's TLS certificate 
+func (n *node) CertFile() string {
+	return n.config.certFile
+}
+
+// Stop interrupts the running dcrd process, and waits until it exits properly.
+// On windows, interrupt is not supported, so a kill signal is used instead.
 func (n *node) Stop() error {
 	if n.cmd == nil || n.cmd.Process == nil {
 		// return if not properly initialized

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -134,6 +134,7 @@ func (n *nodeConfig) arguments() []string {
 		args = append(args, fmt.Sprintf("--debuglevel=%s", n.debugLevel))
 	}
 	args = append(args, "--txindex")
+	args = append(args, "--addrindex")
 	args = append(args, n.extra...)
 	return args
 }

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -7,6 +7,7 @@ package rpctest
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
@@ -193,6 +194,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	if err = h.node.Start(); err != nil {
 		return err
 	}
+	time.Sleep(7 * time.Second)
 	if err := h.connectRPCClient(); err != nil {
 		return err
 	}
@@ -205,9 +207,9 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	// Connect walletClient so we can get the mining address
 	var walletClient *rpc.Client
 	walletRPCConf := h.wallet.config.rpcConnConfig()
-	for i := 0; i < 200; i++ {
+	for i := 1; i < 2000; i++ {
 		if walletClient, err = rpc.New(&walletRPCConf, nil); err != nil {
-			time.Sleep(time.Duration(i) * 50 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
 			continue
 		}
 		break
@@ -222,7 +224,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	var miningAddr dcrutil.Address
 	for i := 0; i < 100; i++ {
 		if miningAddr, err = walletClient.GetNewAddress("default"); err != nil {
-			time.Sleep(time.Duration(i) * 50 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
 			continue
 		}
 		break
@@ -356,9 +358,9 @@ func (h *Harness) connectRPCClient() error {
 	var err error
 
 	rpcConf := h.node.config.rpcConnConfig()
-	for i := 0; i < h.maxConnRetries; i++ {
+	for i := 1; i < h.maxConnRetries; i++ {
 		if client, err = rpc.New(&rpcConf, h.handlers); err != nil {
-			time.Sleep(time.Duration(i) * 50 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
 			continue
 		}
 		break

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -194,7 +194,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	if err = h.node.Start(); err != nil {
 		return err
 	}
-	time.Sleep(7 * time.Second)
+	time.Sleep(4 * time.Second)
 	if err := h.connectRPCClient(); err != nil {
 		return err
 	}
@@ -203,13 +203,14 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	if err = h.wallet.Start(); err != nil {
 		return err
 	}
+	time.Sleep(4 * time.Second)
 
 	// Connect walletClient so we can get the mining address
 	var walletClient *rpc.Client
 	walletRPCConf := h.wallet.config.rpcConnConfig()
-	for i := 1; i < 2000; i++ {
+	for i := 0; i < 2000; i++ {
 		if walletClient, err = rpc.New(&walletRPCConf, nil); err != nil {
-			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i+3))) * 50 * time.Millisecond)
 			continue
 		}
 		break
@@ -224,7 +225,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	var miningAddr dcrutil.Address
 	for i := 0; i < 100; i++ {
 		if miningAddr, err = walletClient.GetNewAddress("default"); err != nil {
-			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i+3))) * 50 * time.Millisecond)
 			continue
 		}
 		break
@@ -263,6 +264,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	if err = h.node.Start(); err != nil {
 		return err
 	}
+	time.Sleep(4 * time.Second)
 	if err := h.connectRPCClient(); err != nil {
 		return err
 	}
@@ -358,9 +360,9 @@ func (h *Harness) connectRPCClient() error {
 	var err error
 
 	rpcConf := h.node.config.rpcConnConfig()
-	for i := 1; i < h.maxConnRetries; i++ {
+	for i := 0; i < h.maxConnRetries; i++ {
 		if client, err = rpc.New(&rpcConf, h.handlers); err != nil {
-			time.Sleep(time.Duration(math.Log(float64(i))) * 100 * time.Millisecond)
+			time.Sleep(time.Duration(math.Log(float64(i+3))) * 50 * time.Millisecond)
 			continue
 		}
 		break

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"strconv"
 	"sync"
 	"time"
@@ -195,8 +196,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 		return err
 	}
 
-	// Start the dcrd node itself. This spawns a new process which will be
-	// managed
+	// Start dcrwallet. This spawns a new process which will be managed
 	if err = h.wallet.Start(); err != nil {
 		return err
 	}
@@ -369,6 +369,35 @@ func (h *Harness) connectRPCClient() error {
 // instance.
 func (h *Harness) RPCConfig() rpc.ConnConfig {
 	return h.node.config.rpcConnConfig()
+}
+
+// RPCWalletConfig returns the harnesses current rpc configuration. This allows other
+// potential RPC clients created within tests to connect to a given test harness
+// instance.
+func (h *Harness) RPCWalletConfig() rpc.ConnConfig {
+	return h.wallet.config.rpcConnConfig()
+}
+
+// RPCCertFile returns the full path the node RPC's TLS certifiate 
+func (h *Harness) RPCCertFile() string {
+	return h.node.CertFile()
+}
+
+// RPCWalletCertFile returns the full path the wallet RPC's TLS certifiate 
+func (h *Harness) RPCWalletCertFile() string {
+	return h.wallet.CertFile()
+}
+
+// FullNodeCommand returns the full command line of the node
+func (h *Harness) FullNodeCommand() string {
+	args := strings.Join(h.node.cmd.Args[1:], " ")
+	return h.node.cmd.Path + " " + args
+}
+
+// FullWalletCommand returns the full command line of the wallet
+func (h *Harness) FullWalletCommand() string {
+	args := strings.Join(h.wallet.cmd.Args[1:], " ")
+	return h.wallet.cmd.Path + " " + args
 }
 
 // generateListeningAddresses returns three strings representing listening

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -10,8 +10,8 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -81,6 +81,7 @@ type Harness struct {
 	testWalletDir  string
 	maxConnRetries int
 	nodeNum        int
+	miningAddr     dcrutil.Address
 }
 
 // NewHarness creates and initializes a new instance of the rpc test harness.
@@ -230,6 +231,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 		return fmt.Errorf("RPC not up for mining addr %v %v", h.testNodeDir,
 			h.testWalletDir)
 	}
+	h.miningAddr = miningAddr
 
 	var extraArgs []string
 	miningArg := fmt.Sprintf("--miningaddr=%s", miningAddr)
@@ -338,6 +340,12 @@ func (h *Harness) TearDown() error {
 	return nil
 }
 
+// IsUp checks if the harness is still being tracked by rpctest
+func (h *Harness) IsUp() bool {
+	_, up := testInstances[h.testNodeDir]
+	return up
+}
+
 // connectRPCClient attempts to establish an RPC connection to the created
 // dcrd process belonging to this Harness instance. If the initial connection
 // attempt fails, this function will retry h.maxConnRetries times, backing off
@@ -378,12 +386,12 @@ func (h *Harness) RPCWalletConfig() rpc.ConnConfig {
 	return h.wallet.config.rpcConnConfig()
 }
 
-// RPCCertFile returns the full path the node RPC's TLS certifiate 
+// RPCCertFile returns the full path the node RPC's TLS certifiate
 func (h *Harness) RPCCertFile() string {
 	return h.node.CertFile()
 }
 
-// RPCWalletCertFile returns the full path the wallet RPC's TLS certifiate 
+// RPCWalletCertFile returns the full path the wallet RPC's TLS certifiate
 func (h *Harness) RPCWalletCertFile() string {
 	return h.wallet.CertFile()
 }

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -1309,10 +1309,12 @@ func testListTransactions(r *Harness, t *testing.T) {
 	if err != nil {
 		t.Fatal("ListTransactionsCount failed:", err)
 	}
-	// TODO: There are 3 extras, 2 for the amount sent/received, and one for
-	// send of generated funds (?).  Look into this.
-	if len(txListAll) != initNumTx+2 {
-		t.Fatalf("Expected %v listtransactions results, got %v", initNumTx+2,
+	// Expect 3 more results in the list: a receive for the owned address in
+	// the amount sent, a send in the amount sent, and the a send from the
+	// original outpoint for the mined coins.
+	expectedAdditional := 3
+	if len(txListAll) != initNumTx+expectedAdditional {
+		t.Fatalf("Expected %v listtransactions results, got %v", initNumTx+expectedAdditional,
 			len(txListAll))
 	}
 

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -1172,7 +1172,27 @@ func testListTransactions(r *Harness, t *testing.T) {
 	}
 
 	if txList1[0].Address != r.miningAddr.String() {
-		fmt.Printf("Unexpected address in transaction: %v", txList1[0].Address)
+		fmt.Printf("Unexpected address in latest transaction: %v",
+			txList1[0].Address)
+	}
+
+	if !txList1[0].Generated {
+		fmt.Printf("Latest transaction output not a coinbase output.")
+	}
+
+	if txList1[0].Category != "immature" {
+		fmt.Printf("Latest transaction not immature. Category: %v",
+			txList1[0].Category)
+	}
+
+	// Verify blockhash is non-nil and valid
+	hash, err := chainhash.NewHashFromStr(txList1[0].BlockHash)
+	if err != nil {
+		fmt.Printf("Blockhash not valid")
+	}
+	_, err = wcl.GetBlock(hash)
+	if err != nil {
+		fmt.Printf("Blockhash does not refer to valid block")
 	}
 
 	// Another wallet to keep transaction list clearer

--- a/rpctest/walletnode.go
+++ b/rpctest/walletnode.go
@@ -220,6 +220,17 @@ func (n *walletTest) Start() error {
 	return nil
 }
 
+// FullCommand returns the full command used to start the wallet
+func (n *walletTest) FullCommand() string {
+	args := strings.Join(n.cmd.Args, " ")
+	return n.cmd.Path + args
+}
+
+// CertFile returns the wallet RPC's TLS certificate
+func (n *walletTest) CertFile() string {
+	return n.config.certFile
+}
+
 // Stop interrupts the running dcrwalletTest process process, and waits until it exits
 // properly. On windows, interrupt is not supported, so a kill signal is used
 // instead

--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 // versioning 2.0.0 spec (http://semver.org/).
 const (
 	appMajor uint = 0
-	appMinor uint = 3
+	appMinor uint = 4
 	appPatch uint = 0
 
 	// appPreRelease MUST only contain characters from semanticAlphabet

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -337,13 +337,13 @@ func (w *Wallet) TxToOutputs(outputs []*wire.TxOut, account uint32, minconf int3
 		if err != nil {
 			return nil, err
 		}
-		pool = w.addrPools[waddrmgr.DefaultAccountNum].internal
+		pool = w.getAddressPools(waddrmgr.DefaultAccountNum).internal
 	} else {
 		err := w.CheckAddressPoolsInitialized(account)
 		if err != nil {
 			return nil, err
 		}
-		pool = w.addrPools[account].internal
+		pool = w.getAddressPools(account).internal
 	}
 	changeAddrUsed := false
 	txSucceeded := false
@@ -489,13 +489,13 @@ func (w *Wallet) txToMultisig(account uint32, amount dcrutil.Amount,
 		if err != nil {
 			return txToMultisigError(err)
 		}
-		pool = w.addrPools[waddrmgr.DefaultAccountNum].internal
+		pool = w.getAddressPools(waddrmgr.DefaultAccountNum).internal
 	} else {
 		err := w.CheckAddressPoolsInitialized(account)
 		if err != nil {
 			return txToMultisigError(err)
 		}
-		pool = w.addrPools[account].internal
+		pool = w.getAddressPools(account).internal
 	}
 	txSucceeded := false
 	pool.mutex.Lock()
@@ -719,13 +719,13 @@ func (w *Wallet) compressWallet(maxNumIns int, account uint32,
 		if err != nil {
 			return nil, err
 		}
-		pool = w.addrPools[waddrmgr.DefaultAccountNum].internal
+		pool = w.getAddressPools(waddrmgr.DefaultAccountNum).internal
 	} else {
 		err := w.CheckAddressPoolsInitialized(account)
 		if err != nil {
 			return nil, err
 		}
-		pool = w.addrPools[account].internal
+		pool = w.getAddressPools(account).internal
 	}
 	txSucceeded := false
 	pool.mutex.Lock()
@@ -846,7 +846,7 @@ func (w *Wallet) compressEligible(eligible []wtxmgr.Credit) error {
 	if err != nil {
 		return err
 	}
-	pool = w.addrPools[waddrmgr.DefaultAccountNum].internal
+	pool = w.getAddressPools(waddrmgr.DefaultAccountNum).internal
 	if pool == nil {
 		log.Errorf("tried to use uninitialized pool for acct %v "+
 			"when attempting to make a transaction",
@@ -1070,7 +1070,7 @@ func (w *Wallet) purchaseTicket(req purchaseTicketRequest) (interface{},
 	if err != nil {
 		return nil, err
 	}
-	pool = w.addrPools[req.account].internal
+	pool = w.getAddressPools(req.account).internal
 
 	// Address manager must be unlocked to compose tickets.  Grab
 	// the unlock if possible (to prevent future unlocks), or return the

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -630,7 +630,9 @@ func (w *Wallet) rescanActiveAddresses() error {
 			return err
 		}
 
+		w.addrPoolsMtx.Lock()
 		w.addrPools[acct] = pool
+		w.addrPoolsMtx.Unlock()
 	}
 
 	log.Infof("Successfully synchronized wallet accounts to account "+

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -158,6 +158,7 @@ type Wallet struct {
 
 	// Internal address handling.
 	addrPools     map[uint32]*addressPools
+	addrPoolsMtx  sync.RWMutex
 	addressReuse  bool
 	ticketAddress dcrutil.Address
 
@@ -926,7 +927,7 @@ out:
 
 		case txr := <-w.createSStxRequests:
 			// Initialize the address pool for use.
-			pool := w.addrPools[waddrmgr.DefaultAccountNum].internal
+			pool := w.getAddressPools(waddrmgr.DefaultAccountNum).internal
 			pool.mutex.Lock()
 			addrFunc := pool.getNewAddress
 
@@ -1467,6 +1468,8 @@ func (w *Wallet) NextAccount(name string) (uint32, error) {
 	}
 
 	// Initialize a new address pool for this account.
+	w.addrPoolsMtx.Lock()
+	defer w.addrPoolsMtx.Unlock()
 	w.addrPools[account], err = newAddressPools(account, 0, 0, w)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Milestone 2 of RFP-10 includes the following legacy RPC tests:

- [x] sendtoaddress
- [x] sendfrom
- [x] sendmany
- [x] listtransactions
- [x] getwalletfee/settxfee
- [x] getticketfee/setticketfee

Note that transaction fee (aka relay or wallet fee) and ticket fee gets are tested via walletinfo since there are no more direct methods available via dcrrpcclient.  Wallet.RelayFee() is the shared underlying call.  The milestone 3 test, purchaseticket, is also completed.

Final tasks:
- [x] Review test procedures
- [x] Improve documentation
- [x] Provide summary for squash merge.

This PR also includes the addition of the mkharness command (dcrwallet/rpctest/mkharness/main.go), which brings up a simnet node and wallet configured for mining.  Once set up, mkharness will print the commands for the running node and wallet, and suggested dcrctl command constructions.

Some questions and possible TODO:
 * In comparing nominal vs actual/observed fees, an arbitrary tolerance is used.  absFeeDiffTolerance = 0.0005  Is this appropriate?
 * Is it correct that ListUnspent should only return coinbase tx that are validated (>=2 confirmations)?
 * Is it expected that GetRawTransaction (and similar) will have incorrect values, at least in vin, until the transaction is mined and in the caes of sstx, validated?  Generating a block before getrawtransaction is needed to compute fee.
 * For milestone 3: doc.go