### PR TITLE
Upgrade wtxmgr from version 1 to 2.

### DIFF
--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -1934,6 +1934,22 @@ func existsMultisigOutUS(ns walletdb.ReadBucket, k []byte) bool {
 	return v != nil
 }
 
+// upgradeToVersion2 upgrades the transaction store from version 1 to version 2.
+// This must only be called after the caller has asserted the database is
+// currently at version 1.  This upgrade is only a version bump as the new DB
+// format is forwards compatible with version 1, but old software that does not
+// know about version 2 should not be opening the upgraded DBs.
+func upgradeToVersion2(ns walletdb.ReadWriteBucket) error {
+	versionBytes := make([]byte, 4)
+	byteOrder.PutUint32(versionBytes, 2)
+	err := ns.Put(rootVersion, versionBytes)
+	if err != nil {
+		str := "failed to write database version"
+		return storeError(ErrDatabase, str, err)
+	}
+	return nil
+}
+
 // openStore opens an existing transaction store from the passed namespace.
 func openStore(ns walletdb.ReadBucket) error {
 	v := ns.Get(rootVersion)


### PR DESCRIPTION
While version 2 was added a long time ago, there was never a database
version bump for the new format when there should have been.  After
the database atomicity changes landed, the version checks became
stricter.  To accomidate very old wallets that still record the
version as 1 even though they have been writing using version 2 all
this time, a new upgrade path was added that bumps the version.  No
other upgrade logic is required here as the new format was forwards
compatible with the old format.

Fixes #357.