### PR TITLE
Update the wallet to begin allowing extended votebits setting

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,6 +34,7 @@ const (
 	defaultRPCMaxWebsockets    = 25
 	defaultEnableStakeMining   = false
 	defaultVoteBits            = 0x0001
+	defaultVoteBitsExtended    = "02000000"
 	defaultBalanceToMaintain   = 0.0
 	defaultReuseAddresses      = false
 	defaultRollbackTest        = false
@@ -84,6 +85,7 @@ type config struct {
 	DisallowFree        bool    `long:"disallowfree" description:"Force transactions to always include a fee"`
 	EnableStakeMining   bool    `long:"enablestakemining" description:"Enable stake mining"`
 	VoteBits            uint16  `long:"votebits" description:"Set your stake mining votebits to value (default: 0xFFFF)"`
+	VoteBitsExtended    string  `long:"votebitsextended" description:"Set your stake mining extended votebits to the hexademical value indicated by the passed string"`
 	BalanceToMaintain   float64 `long:"balancetomaintain" description:"Minimum amount of funds to leave in wallet when stake mining (default: 0.0)"`
 	ReuseAddresses      bool    `long:"reuseaddresses" description:"Reuse addresses for ticket purchase to cut down on address overuse"`
 	PruneTickets        bool    `long:"prunetickets" description:"Prune old tickets from the wallet and restore their inputs"`
@@ -303,6 +305,7 @@ func loadConfig() (*config, []string, error) {
 		LegacyRPCMaxWebsockets: defaultRPCMaxWebsockets,
 		EnableStakeMining:      defaultEnableStakeMining,
 		VoteBits:               defaultVoteBits,
+		VoteBitsExtended:       defaultVoteBitsExtended,
 		BalanceToMaintain:      defaultBalanceToMaintain,
 		ReuseAddresses:         defaultReuseAddresses,
 		RollbackTest:           defaultRollbackTest,

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -91,6 +91,7 @@ func walletMain() error {
 	dbDir := networkDir(cfg.AppDataDir, activeNet.Params)
 	stakeOptions := &wallet.StakeOptions{
 		VoteBits:            cfg.VoteBits,
+		VoteBitsExtended:    cfg.VoteBitsExtended,
 		StakeMiningEnabled:  cfg.EnableStakeMining,
 		BalanceToMaintain:   cfg.BalanceToMaintain,
 		RollbackTest:        cfg.RollbackTest,

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 5cc50197a8683b16e3e120937d59e244ba000d7c0d474d8b613e17a93b9723ef
-updated: 2016-10-13T09:08:42.0437835-04:00
+updated: 2016-10-14T13:42:35.5906491-04:00
 imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
@@ -30,11 +30,15 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 717040c9453370196efb0a3706c83f17456cc374
+  version: cc25399f6a78b09957d82e2c98960b24685e1475
   subpackages:
   - blockchain
-  - blockchain/dbnamespace
+  - blockchain/internal/dbnamespace
+  - blockchain/internal/progresslog
   - blockchain/stake
+  - blockchain/stake/internal/dbnamespace
+  - blockchain/stake/internal/ticketdb
+  - blockchain/stake/internal/tickettreap
   - chaincfg
   - chaincfg/chainec
   - chaincfg/chainhash
@@ -46,9 +50,9 @@ imports:
   - txscript
   - wire
 - name: github.com/decred/dcrrpcclient
-  version: 103ed11be3a7035554d3925fbfaa67742641510f
+  version: 0f562bb540de12dfd5248aee87063eaa4792705f
 - name: github.com/decred/dcrutil
-  version: 4fc91a08eea88e74539d42d6301fd298b9bd8230
+  version: 0484582bf5503574d824f110e836a8c48aa60c8c
   subpackages:
   - base58
   - hdkeychain
@@ -57,22 +61,23 @@ imports:
   subpackages:
   - edwards25519
 - name: github.com/golang/protobuf
-  version: c3cefd437628a0b7d31b34fe44b3a7a540e98527
+  version: 98fa357170587e470c5f27d3c3ea0947b71eb455
   subpackages:
   - proto
 - name: github.com/jessevdk/go-flags
   version: 1679536dcc895411a9f5848d9a0250be7856448c
 - name: golang.org/x/net
-  version: 04557861f124410b768b1ba5bb3a91b705afbfc6
+  version: 8b4af36cd21a1f85a7484b49feb7c79363106d8e
   subpackages:
   - context
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
   - lex/httplex
   - trace
 - name: golang.org/x/sys
-  version: 62bee037599929a6e9146f29d10dd5208c43507d
+  version: 9bb9f0998d48b31547d975974935ae9b48c7a03c
   subpackages:
   - unix
 - name: google.golang.org/grpc
@@ -88,14 +93,14 @@ imports:
   - transport
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -435,7 +435,7 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 	// the OP_SSTX tagged out, except if we're operating as a stake pool
 	// server. In that case, additionally consider the first commitment
 	// output as well.
-	if is, _ := stake.IsSStx(tx); is {
+	if is, _ := stake.IsSStx(&rec.MsgTx); is {
 		// Errors don't matter here.  If addrs is nil, the range below
 		// does nothing.
 		txOut := tx.MsgTx().TxOut[0]
@@ -513,14 +513,14 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 
 	// Handle incoming SSGen; store them if we own
 	// the ticket used to purchase them.
-	if is, _ := stake.IsSSGen(tx); is {
+	if is, _ := stake.IsSSGen(&rec.MsgTx); is {
 		if block != nil {
 			txInHash := tx.MsgTx().TxIn[1].PreviousOutPoint.Hash
 			if w.StakeMgr.CheckHashInStore(&txInHash) {
 				w.StakeMgr.InsertSSGen(stakemgrNs, &block.Hash,
 					int64(block.Height),
 					&txHash,
-					w.VoteBits,
+					w.VoteBits.Bits,
 					&txInHash)
 			}
 
@@ -564,7 +564,7 @@ func (w *Wallet) addRelevantTx(dbtx walletdb.ReadWriteTx, rec *wtxmgr.TxRecord,
 
 	// Handle incoming SSRtx; store them if we own
 	// the ticket used to purchase them.
-	if is, _ := stake.IsSSRtx(tx); is {
+	if is, _ := stake.IsSSRtx(&rec.MsgTx); is {
 		if block != nil {
 			txInHash := tx.MsgTx().TxIn[0].PreviousOutPoint.Hash
 

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -942,7 +942,7 @@ func makeTicket(params *chaincfg.Params, inputPool *extendedOutPoint,
 	mtx.AddTxOut(txOut)
 
 	// Make sure we generated a valid SStx.
-	if _, err := stake.IsSStx(dcrutil.NewTx(mtx)); err != nil {
+	if _, err := stake.IsSStx(mtx); err != nil {
 		return nil, err
 	}
 
@@ -1527,7 +1527,7 @@ func (w *Wallet) txToSStxInternal(dbtx walletdb.ReadWriteTx, pair map[string]dcr
 		}
 
 	}
-	if _, err := stake.IsSStx(dcrutil.NewTx(msgtx)); err != nil {
+	if _, err := stake.IsSStx(msgtx); err != nil {
 		return nil, err
 	}
 	err = walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -61,6 +61,7 @@ type Loader struct {
 // StakeOptions contains the various options necessary for stake mining.
 type StakeOptions struct {
 	VoteBits            uint16
+	VoteBitsExtended    string
 	StakeMiningEnabled  bool
 	BalanceToMaintain   float64
 	TicketFee           float64
@@ -157,11 +158,12 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (*W
 
 	// Open the newly-created wallet.
 	so := l.stakeOptions
-	w, err := Open(db, pubPassphrase, nil, so.VoteBits, so.StakeMiningEnabled,
-		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
-		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
-		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee, l.addrIdxScanLen,
-		so.StakePoolColdExtKey, l.autoRepair, l.allowHighFees, l.relayFee, l.chainParams)
+	w, err := Open(db, pubPassphrase, nil, so.VoteBits, so.VoteBitsExtended,
+		so.StakeMiningEnabled, so.BalanceToMaintain, so.AddressReuse,
+		so.RollbackTest, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
+		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
+		l.addrIdxScanLen, so.StakePoolColdExtKey, l.autoRepair,
+		l.allowHighFees, l.relayFee, l.chainParams)
 	if err != nil {
 		return nil, err
 	}
@@ -224,11 +226,12 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 		}
 	}
 	so := l.stakeOptions
-	w, err = Open(db, pubPassphrase, cbs, so.VoteBits, so.StakeMiningEnabled,
-		so.BalanceToMaintain, so.AddressReuse, so.RollbackTest,
-		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice, so.TicketBuyFreq,
-		so.PoolAddress, so.PoolFees, so.TicketFee, l.addrIdxScanLen, so.StakePoolColdExtKey,
-		l.autoRepair, l.allowHighFees, l.relayFee, l.chainParams)
+	w, err = Open(db, pubPassphrase, cbs, so.VoteBits, so.VoteBitsExtended,
+		so.StakeMiningEnabled, so.BalanceToMaintain, so.AddressReuse,
+		so.RollbackTest, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
+		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
+		l.addrIdxScanLen, so.StakePoolColdExtKey, l.autoRepair, l.allowHighFees,
+		l.relayFee, l.chainParams)
 	if err != nil {
 		return nil, err
 	}

--- a/wstakemgr/error.go
+++ b/wstakemgr/error.go
@@ -65,6 +65,15 @@ const (
 	// ErrStoreClosed indicates that a function was called after the stake
 	// store was closed.
 	ErrStoreClosed
+
+	// ErrData describes an error where data stored in the stake database
+	// is incorrect.  This may be due to missing values, values of
+	// wrong sizes, or data from different buckets that is inconsistent with
+	// itself.  Recovering from an ErrData requires rebuilding all
+	// stake database history or manual database surgery.  If the failure was
+	// not due to data corruption, this error category indicates a
+	// programming error in this package.
+	ErrData
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -80,6 +89,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrPoolUserInvalTcktsNotFound: "ErrPoolUserInvalTcktsNotFound",
 	ErrBadPoolUserAddr:            "ErrBadPoolUserAddr",
 	ErrStoreClosed:                "ErrStoreClosed",
+	ErrData:                       "ErrData",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/wtxmgr/db.go
+++ b/wtxmgr/db.go
@@ -605,7 +605,7 @@ func readRawTxRecord(txHash *chainhash.Hash, v []byte, rec *TxRecord) error {
 	}
 
 	// Calculate the stake TxType from the MsgTx.
-	rec.TxType = stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+	rec.TxType = stake.DetermineTxType(&rec.MsgTx)
 
 	return nil
 }

--- a/wtxmgr/tx.go
+++ b/wtxmgr/tx.go
@@ -120,7 +120,7 @@ func NewTxRecord(serializedTx []byte, received time.Time) (*TxRecord, error) {
 		str := "failed to deserialize transaction"
 		return nil, storeError(ErrInput, str, err)
 	}
-	rec.TxType = stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+	rec.TxType = stake.DetermineTxType(&rec.MsgTx)
 	hash := rec.MsgTx.TxSha()
 	copy(rec.Hash[:], hash[:])
 	return rec, nil
@@ -141,7 +141,7 @@ func NewTxRecordFromMsgTx(msgTx *wire.MsgTx, received time.Time) (*TxRecord,
 		Received:     received,
 		SerializedTx: buf.Bytes(),
 	}
-	rec.TxType = stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+	rec.TxType = stake.DetermineTxType(&rec.MsgTx)
 	hash := rec.MsgTx.TxSha()
 	copy(rec.Hash[:], hash[:])
 	return rec, nil
@@ -219,7 +219,7 @@ func (s *Store) PruneOldTickets(ns walletdb.ReadWriteBucket) error {
 			return err
 		}
 
-		txType := stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+		txType := stake.DetermineTxType(&rec.MsgTx)
 
 		// Prune all old tickets.
 		if current.Sub(rec.Received) > ticketCutoff &&
@@ -773,7 +773,7 @@ func (s *Store) insertMinedTx(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.Re
 		},
 		// index set for each iteration below
 	}
-	txType := stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+	txType := stake.DetermineTxType(&rec.MsgTx)
 
 	for i, input := range rec.MsgTx.TxIn {
 		unspentKey, credKey := existsUnspent(ns, &input.PreviousOutPoint)
@@ -1286,7 +1286,7 @@ func (s *Store) rollbackTransaction(hash chainhash.Hash, b *blockRecord,
 		return err
 	}
 
-	txType := stake.DetermineTxType(dcrutil.NewTx(&rec.MsgTx))
+	txType := stake.DetermineTxType(&rec.MsgTx)
 
 	// For each debit recorded for this transaction, mark
 	// the credit it spends as unspent (as long as it still
@@ -1513,8 +1513,7 @@ func (s *Store) rollback(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBuc
 				return err
 			}
 
-			if stake.DetermineTxType(dcrutil.NewTx(&txr.MsgTx)) !=
-				stake.TxTypeRegular {
+			if stake.DetermineTxType(&txr.MsgTx) != stake.TxTypeRegular {
 				stakeTxFromBlock = append(stakeTxFromBlock, hash)
 			}
 		}
@@ -1528,8 +1527,7 @@ func (s *Store) rollback(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBuc
 					return err
 				}
 
-				if stake.DetermineTxType(dcrutil.NewTx(&txr.MsgTx)) ==
-					stake.TxTypeRegular {
+				if stake.DetermineTxType(&txr.MsgTx) == stake.TxTypeRegular {
 					regularTxFromParent = append(regularTxFromParent, hash)
 				}
 			}


### PR DESCRIPTION
This fixes the TODO where wallet could not do the setting of extended
vote bits.  A new function allowing for the setting of multiple vote
bits for many tickets was also added.

The wallet is also updated to the latest dependencies.  Fixes #363.