### PR TITLE
Fully update PoolTickets when using AddTicket rpc

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -500,6 +500,12 @@ func addTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	err = w.AddTicket(dcrutil.NewTx(mtx))
+	if err != nil {
+		return nil, err
+	}
+
 	pkVersion := mtx.TxOut[0].Version
 	pkScript := mtx.TxOut[0].PkScript
 	_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkVersion,
@@ -507,8 +513,12 @@ func addTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Infof("%v", addrs)
-	err = w.AddTicket(dcrutil.NewTx(mtx))
+
+	ticketHash := mtx.TxSha()
+	err = w.UpdateStakePoolTicket(addrs[0], &ticketHash)
+	if err != nil {
+		return nil, err
+	}
 	return nil, err
 }
 

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -500,6 +500,14 @@ func addTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	pkVersion := mtx.TxOut[0].Version
+	pkScript := mtx.TxOut[0].PkScript
+	_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkVersion,
+		pkScript, w.ChainParams())
+	if err != nil {
+		return nil, err
+	}
+	log.Infof("%v", addrs)
 	err = w.AddTicket(dcrutil.NewTx(mtx))
 	return nil, err
 }

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -500,11 +500,7 @@ func addTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	err = w.AddTicket(dcrutil.NewTx(mtx))
-	if err != nil {
-		return nil, err
-	}
 
 	return nil, err
 }

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -506,19 +506,6 @@ func addTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 		return nil, err
 	}
 
-	pkVersion := mtx.TxOut[0].Version
-	pkScript := mtx.TxOut[0].PkScript
-	_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkVersion,
-		pkScript, w.ChainParams())
-	if err != nil {
-		return nil, err
-	}
-
-	ticketHash := mtx.TxSha()
-	err = w.UpdateStakePoolTicket(addrs[0], &ticketHash)
-	if err != nil {
-		return nil, err
-	}
 	return nil, err
 }
 

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -158,7 +158,7 @@ func (w *Wallet) AddTicket(ticket *dcrutil.Tx) error {
 	return walletdb.Update(w.db, func(tx walletdb.ReadWriteTx) error {
 		stakemgrNs := tx.ReadWriteBucket(wstakemgrNamespaceKey)
 
-		// Insert the ticket to be tracked and voted
+		// Insert the ticket to be tracked and voted.
 		err := w.StakeMgr.InsertSStx(stakemgrNs, ticket, w.VoteBits)
 		if err != nil {
 			return err
@@ -167,7 +167,7 @@ func (w *Wallet) AddTicket(ticket *dcrutil.Tx) error {
 		if w.stakePoolEnabled {
 			addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 
-			// Pluck the ticketaddress to indentify the stakepool user
+			// Pluck the ticketaddress to indentify the stakepool user.
 			pkVersion := ticket.MsgTx().TxOut[0].Version
 			pkScript := ticket.MsgTx().TxOut[0].PkScript
 			_, addrs, _, err := txscript.ExtractPkScriptAddrs(pkVersion,
@@ -188,7 +188,7 @@ func (w *Wallet) AddTicket(ticket *dcrutil.Tx) error {
 			}
 
 			// Update the pool ticket stake. This will include removing it from the
-			// invalid slice and adding a ImmatureOrLive ticket to the valid ones
+			// invalid slice and adding a ImmatureOrLive ticket to the valid ones.
 			err = w.updateStakePoolInvalidTicket(stakemgrNs, addrmgrNs, addrs[0], &ticketHash, rawTx.BlockHeight)
 			if err != nil {
 				return err

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -131,9 +131,9 @@ func (w *Wallet) TicketHashesForVotingAddress(votingAddr dcrutil.Address) ([]cha
 	return ticketHashes, err
 }
 
-// UpdateStakePoolInvalidTicket properly updates a previously marked Invalid pool ticket,
+// updateStakePoolInvalidTicket properly updates a previously marked Invalid pool ticket,
 // it then creates a new entry in the validly tracked pool ticket db.
-func (w *Wallet) UpdateStakePoolInvalidTicket(stakemgrNs walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBucket,
+func (w *Wallet) updateStakePoolInvalidTicket(stakemgrNs walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBucket,
 	addr dcrutil.Address, ticket *chainhash.Hash) error {
 	err := w.StakeMgr.RemoveStakePoolUserInvalTickets(stakemgrNs, addr, ticket)
 	if err != nil {
@@ -178,7 +178,7 @@ func (w *Wallet) AddTicket(ticket *dcrutil.Tx) error {
 
 		// Update the pool ticket stake. This will include removing it from the
 		// invalid slice and adding a ImmatureOrLive ticket to the valid ones
-		err = w.UpdateStakePoolInvalidTicket(stakemgrNs, addrmgrNs, addrs[0], &ticketHash)
+		err = w.updateStakePoolInvalidTicket(stakemgrNs, addrmgrNs, addrs[0], &ticketHash)
 		if err != nil {
 			return err
 		}

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1172,8 +1172,8 @@ func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20
 	var newRecords []*chainhash.Hash
 	for i := range oldRecords {
 		if record.IsEqual(oldRecords[i]) {
-			newRecords = make([]*chainhash.Hash, len(oldRecords)-1)
-			newRecords = append(oldRecords[0:i], oldRecords[i+1:]...)
+			copy(newRecords[:], oldRecords[0:i])
+			copy(newRecords[i:], oldRecords[i+1:])
 		}
 	}
 

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1154,7 +1154,7 @@ func duplicateExistsInInvalTickets(record *chainhash.Hash,
 }
 
 // removeStakePoolInvalUserTickets removes the ticket hash from the inval
-// ticket bucket
+// ticket bucket.
 func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20]byte,
 	record *chainhash.Hash) error {
 	oldRecords, _ := fetchStakePoolUserInvalTickets(ns, scriptHash)

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1157,6 +1157,11 @@ func duplicateExistsInInvalTickets(record *chainhash.Hash,
 // ticket bucket.
 func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20]byte,
 	record *chainhash.Hash) error {
+
+	// Fetch the current content of the key.
+	// Possible buggy behaviour: If deserialization fails,
+	// we won't detect it here. We assume we're throwing
+	// ErrPoolUserInvalTcktsNotFound.
 	oldRecords, _ := fetchStakePoolUserInvalTickets(ns, scriptHash)
 
 	// Don't need to remove records that don't exist.

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1153,6 +1153,8 @@ func duplicateExistsInInvalTickets(record *chainhash.Hash,
 	return false
 }
 
+// removeStakePoolInvalUserTickets removes the ticket hash from the inval
+// ticket bucket
 func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20]byte,
 	record *chainhash.Hash) error {
 	oldRecords, _ := fetchStakePoolUserInvalTickets(ns, scriptHash)

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1173,7 +1173,6 @@ func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20
 	for i := range oldRecords {
 		if record.IsEqual(oldRecords[i]) {
 			newRecords = append(oldRecords[:i:i], oldRecords[i+1:]...)
-
 		}
 	}
 

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1164,7 +1164,7 @@ func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20
 
 	var newRecords []*chainhash.Hash
 	for i := range oldRecords {
-		if record == oldRecords[i] {
+		if record.IsEqual(oldRecords[i]) {
 			newRecords = make([]*chainhash.Hash, len(oldRecords)-1)
 			newRecords = append(oldRecords[0:i], oldRecords[i+1:]...)
 		}

--- a/wstakemgr/db.go
+++ b/wstakemgr/db.go
@@ -1172,8 +1172,8 @@ func removeStakePoolInvalUserTickets(ns walletdb.ReadWriteBucket, scriptHash [20
 	var newRecords []*chainhash.Hash
 	for i := range oldRecords {
 		if record.IsEqual(oldRecords[i]) {
-			copy(newRecords[:], oldRecords[0:i])
-			copy(newRecords[i:], oldRecords[i+1:])
+			newRecords = append(oldRecords[:i:i], oldRecords[i+1:]...)
+
 		}
 	}
 

--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -1109,6 +1109,33 @@ func (s *StakeStore) UpdateStakePoolUserTickets(ns walletdb.ReadWriteBucket, wad
 	return s.updateStakePoolUserTickets(ns, waddrmgrNs, user, ticket)
 }
 
+func (s *StakeStore) removeStakePoolUserInvalTickets(ns walletdb.ReadWriteBucket, user dcrutil.Address,
+	ticket *chainhash.Hash) error {
+
+	_, isScriptHash := user.(*dcrutil.AddressScriptHash)
+	_, isP2PKH := user.(*dcrutil.AddressPubKeyHash)
+	if !(isScriptHash || isP2PKH) {
+		str := fmt.Sprintf("user %v is invalid", user.EncodeAddress())
+		return stakeStoreError(ErrBadPoolUserAddr, str, nil)
+	}
+	scriptHashB := user.ScriptAddress()
+	scriptHash := new([20]byte)
+	copy(scriptHash[:], scriptHashB)
+
+	return removeStakePoolInvalUserTickets(ns, *scriptHash, ticket)
+}
+
+// RemoveStakePoolUserInvalTickets is the exported and concurrency safe form of
+// removetStakePoolUserInvalTickets.
+func (s *StakeStore) RemoveStakePoolUserInvalTickets(ns walletdb.ReadWriteBucket, user dcrutil.Address,
+	ticket *chainhash.Hash) error {
+
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	return s.removeStakePoolUserInvalTickets(ns, user, ticket)
+}
+
 // updateStakePoolUserInvalTickets updates the list of invalid stake pool
 // tickets for a given user. If the ticket does not currently exist in the
 // database, it adds it.

--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -1110,7 +1110,7 @@ func (s *StakeStore) UpdateStakePoolUserTickets(ns walletdb.ReadWriteBucket, wad
 }
 
 // removeStakePoolUserInvalTickets prepares the user.Address and asks stakedb
-// to remove the formerly invalid tickets
+// to remove the formerly invalid tickets.
 func (s *StakeStore) removeStakePoolUserInvalTickets(ns walletdb.ReadWriteBucket, user dcrutil.Address,
 	ticket *chainhash.Hash) error {
 

--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -1109,6 +1109,8 @@ func (s *StakeStore) UpdateStakePoolUserTickets(ns walletdb.ReadWriteBucket, wad
 	return s.updateStakePoolUserTickets(ns, waddrmgrNs, user, ticket)
 }
 
+// removeStakePoolUserInvalTickets prepares the user.Address and asks stakedb
+// to remove the formerly invalid tickets
 func (s *StakeStore) removeStakePoolUserInvalTickets(ns walletdb.ReadWriteBucket, user dcrutil.Address,
 	ticket *chainhash.Hash) error {
 


### PR DESCRIPTION
Prior to this there was no updating of PoolTicket state when manually using AddTicket for formerly invalid tickets.  Now they are properly removed from the invalid slice and a new PoolTicket is added to the valid slice.  This along with some more upgrades will help stakepool operators ensure that all of their wallets are in sync with one another.