### PR TITLE
RFP-10 milestone 3

### DIFF
--- a/rpctest/doc.go
+++ b/rpctest/doc.go
@@ -23,5 +23,4 @@
 //    3. High balance to maintain (2000000 DCR).
 // Thus, a harness wallet will automatically vote on owned tickets, but not
 // automatically purchase tickets.
-
 package rpctest

--- a/rpctest/doc.go
+++ b/rpctest/doc.go
@@ -1,2 +1,27 @@
-// Package rpctest ....
+// Package rpctest contains tests for dcrwallet's RPC server and a harness used
+// to facilitate the tests by setting up a temporary Simnet node and wallet. The
+// RPC client implementation in dcrrpcclient is used exclusively to test the RPC
+// server. A single test function, TestMain, is executed by go test, and is
+// responsible for setting up test harnesses and running the individual RPC test
+// functions.
+//
+// A Harness, as defined in rpcharness.go, manages a SimNet node and a wallet
+// that connects to the node. (*Harness).SetUp does the following:
+//   1. Start a new dcrd process with a fresh SimNet chain.
+//   2. Create a new temporary wallet connected to the running node.
+//   3. Get a new address from the wallet for mining subsidy.
+//   4. Restart dcrd with miningaddr set.
+//   5. Generate a number of blocks so that testing starts with a spendable
+//      balance.
+//
+// Multiple harnesses may be run concurrently. Temporary folders are created for
+// each harness, and cleaned up on shutdown.
+//
+// The default settings for a harness wallet are:
+//    1. Stake mining enabled (--enablestakemining).
+//    2. Zero max ticket price.
+//    3. High balance to maintain (2000000 DCR).
+// Thus, a harness wallet will automatically vote on owned tickets, but not
+// automatically purchase tickets.
+
 package rpctest

--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -145,10 +145,7 @@ func (n *nodeConfig) String() string {
 
 // cleanup removes the tmp data and log directories.
 func (n *nodeConfig) cleanup() error {
-	if err := os.RemoveAll(n.appDataDir); err != nil {
-		return err
-	}
-	return nil
+	return os.RemoveAll(n.appDataDir)
 }
 
 // node houses the neccessary state required to configure, launch, and manaage
@@ -253,14 +250,18 @@ func genCertPair(certFile, keyFile, certFileWallet, keyFileWallet string) error 
 		return err
 	}
 	if err = ioutil.WriteFile(keyFile, key, 0600); err != nil {
-		os.Remove(certFile)
+		if errR := os.Remove(certFile); errR != nil {
+			fmt.Printf("Failed to remove %s, %v", certFile, err)
+		}
 		return err
 	}
 	if err = ioutil.WriteFile(certFileWallet, cert, 0666); err != nil {
 		return err
 	}
 	if err = ioutil.WriteFile(keyFileWallet, key, 0600); err != nil {
-		os.Remove(certFile)
+		if errR := os.Remove(certFile); errR != nil {
+			fmt.Printf("Failed to remove %s, %v", certFile, err)
+		}
 		return err
 	}
 	return nil

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -309,6 +309,10 @@ out:
 // TearDown stops the running RPC test instance. All created processes killed,
 // and temporary directories removed.
 func (h *Harness) TearDown() error {
+	if h == nil {
+		return nil
+	}
+
 	if h.Node != nil {
 		h.Node.Shutdown()
 	}
@@ -341,6 +345,9 @@ func (h *Harness) TearDown() error {
 
 // IsUp checks if the harness is still being tracked by rpctest
 func (h *Harness) IsUp() bool {
+	if h == nil {
+		return false
+	}
 	_, up := testInstances[h.testNodeDir]
 	return up
 }

--- a/rpctest/rpcharness.go
+++ b/rpctest/rpcharness.go
@@ -95,7 +95,7 @@ func NewHarness(activeNet *chaincfg.Params, handlers *rpc.NotificationHandlers,
 	defer harnessStateMtx.Unlock()
 
 	// Create data folders for this Harness instance
-	harnessID := strconv.Itoa(int(numTestInstances))
+	harnessID := strconv.Itoa(numTestInstances)
 	testDataPath := "rpctest-" + harnessID
 
 	testData, err := ioutil.TempDir("", testDataPath)
@@ -121,7 +121,7 @@ func NewHarness(activeNet *chaincfg.Params, handlers *rpc.NotificationHandlers,
 	keyFileWallet := filepath.Join(walletTestData, "rpc.key")
 
 	// Generate the default config if needed.
-	if err := genCertPair(certFile, keyFile, certFileWallet, keyFileWallet); err != nil {
+	if err = genCertPair(certFile, keyFile, certFileWallet, keyFileWallet); err != nil {
 		return nil, err
 	}
 
@@ -192,7 +192,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 		return err
 	}
 	time.Sleep(200 * time.Millisecond)
-	if err := h.connectRPCClient(); err != nil {
+	if err = h.connectRPCClient(); err != nil {
 		return err
 	}
 	fmt.Println("Node RPC client connected.")
@@ -240,7 +240,7 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	extraArgs = append(extraArgs, miningArg)
 
 	// Stop node so we can restart it with --miningaddr
-	if err := h.node.Stop(); err != nil {
+	if err = h.node.Stop(); err != nil {
 		return err
 	}
 
@@ -287,16 +287,13 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	ticker := time.NewTicker(time.Millisecond * 500)
 	desiredHeight := int64(numMatureOutputs + uint32(h.ActiveNet.CoinbaseMaturity))
 out:
-	for {
-		select {
-		case <-ticker.C:
-			count, err := h.WalletRPC.GetBlockCount()
-			if err != nil {
-				return err
-			}
-			if count == desiredHeight {
-				break out
-			}
+	for range ticker.C {
+		count, err := h.WalletRPC.GetBlockCount()
+		if err != nil {
+			return err
+		}
+		if count == desiredHeight {
+			break out
 		}
 	}
 	ticker.Stop()
@@ -457,7 +454,7 @@ func (h *Harness) GenerateBlock(startHeight uint32) ([]*chainhash.Hash, error) {
 	}
 	newHeight := block.MsgBlock().Header.Height
 	for newHeight == startHeight {
-		blockHashes, err := h.Node.Generate(1)
+		blockHashes, err = h.Node.Generate(1)
 		if err != nil {
 			return nil, fmt.Errorf("unable to generate single block: %v", err)
 		}

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -99,7 +99,7 @@ func funcName(tc rpcTestCase) string {
 // TestMain manages the test harnesses and runs the tests instead of go test
 // running the tests directly.
 func TestMain(m *testing.M) {
-	// To timing of block generation, create a OnBlockConnected notification
+	// For timing of block generation, create an OnBlockConnected notification
 	ntfnHandlersNode := dcrrpcclient.NotificationHandlers{
 		OnBlockConnected: func(hash *chainhash.Hash, height int32,
 			time time.Time, vb uint16) {
@@ -357,7 +357,7 @@ func testWalletPassphrase(r *Harness, t *testing.T) {
 	defaultWalletPassphrase := "password"
 	defer func() {
 		if err := wcl.WalletPassphrase(defaultWalletPassphrase, 0); err != nil {
-			t.Fatal("Unable to lock wallet:", err)
+			t.Fatal("Unable to unlock wallet:", err)
 		}
 	}()
 

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -1932,7 +1932,8 @@ func testPurchaseTickets(r *Harness, t *testing.T) {
 		if err != nil {
 			t.Fatal("Failed to purchase tickets:", err)
 		}
-		newBestBlock(r, t)
+		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
+		time.Sleep(600 * time.Millisecond)
 	}
 
 	// Validate last tx
@@ -2079,7 +2080,6 @@ func testGetSetTicketMaxPrice(r *Harness, t *testing.T) {
 	// One should be enough for the test, but buy more to keep the chain alive
 	for i := 0; i < 4; i++ {
 		newBestBlock(r, t)
-		time.Sleep(2 * time.Second)
 	}
 
 	// Check for new tickets after enabling auto-purchasing, but with low price
@@ -2281,6 +2281,8 @@ func mustGetStakeDiffNext(r *Harness, t *testing.T) float64 {
 	return stakeDiffResult.NextStakeDifficulty
 }
 
+// TODO: test that advanceToNewWindow goes to the right block, e.g. not one
+// before or one afttr
 func advanceToNewWindow(r *Harness, t *testing.T) uint32 {
 	// ensure there are many blocks left in this price window
 	var blocksLeftInWindow = func(height uint32) int64 {
@@ -2293,8 +2295,9 @@ func advanceToNewWindow(r *Harness, t *testing.T) uint32 {
 	initHeight := curBlockHeight
 	for blocksLeftInWindow(curBlockHeight) !=
 		chaincfg.SimNetParams.StakeDiffWindowSize {
-		curBlockHeight, _, _ = newBestBlock(r, t)
-		time.Sleep(time.Second)
+		//curBlockHeight, _, _ = newBestBlock(r, t)
+		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
+		time.Sleep(500 * time.Millisecond)
 	}
 	t.Logf("Advanced %d blocks to block height %d", curBlockHeight-initHeight,
 		curBlockHeight)
@@ -2310,8 +2313,9 @@ func advanceToHeight(r *Harness, t *testing.T, height uint32) {
 	}
 
 	for curBlockHeight != height {
-		curBlockHeight, _, _ = newBestBlock(r, t)
-		time.Sleep(time.Second)
+		//curBlockHeight, _, _ = newBestBlock(r, t)
+		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
+		time.Sleep(500 * time.Millisecond)
 	}
 	t.Logf("Advanced %d blocks to block height %d", curBlockHeight-initHeight,
 		curBlockHeight)

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -35,24 +35,24 @@ import (
 type rpcTestCase func(r *Harness, t *testing.T)
 
 var rpcTestCases = []rpcTestCase{
-	// testGetNewAddress,
-	// testValidateAddress,
-	// testWalletPassphrase,
-	// testGetBalance,
-	// testListAccounts,
-	// testListUnspent,
-	// testSendToAddress,
-	// testSendFrom,
-	// testSendMany,
-	// testListTransactions,
-	// testGetSetRelayFee,
-	// testGetSetTicketFee,
-	// testGetTickets,
-	// testPurchaseTickets,
-	// testGetSetTicketMaxPrice,
-	// testGetSetBalanceToMaintain,
+	testGetNewAddress,
+	testValidateAddress,
+	testWalletPassphrase,
+	testGetBalance,
+	testListAccounts,
+	testListUnspent,
+	testSendToAddress,
+	testSendFrom,
+	testSendMany,
+	testListTransactions,
+	testGetSetRelayFee,
+	testGetSetTicketFee,
+	testGetTickets,
+	testPurchaseTickets,
+	testGetSetTicketMaxPrice,
+	testGetSetBalanceToMaintain,
 	testGetStakeInfo,
-	//testWalletinfo,
+	testWalletInfo,
 }
 
 // Not all tests need their own harness. Indicate here which get a dedicaed
@@ -76,7 +76,7 @@ var needOwnHarness = map[string]bool{
 	"testGetSetTicketMaxPrice":    false,
 	"testGetSetBalanceToMaintain": false,
 	"testGetStakeInfo":            true,
-	"testWalletinfo":              false,
+	"testWalletInfo":              false,
 }
 
 // Get function name from module name
@@ -2372,7 +2372,7 @@ func testGetStakeInfo(r *Harness, t *testing.T) {
 	// validate the purchase
 	//newBestBlock(r, t)
 
-	// Compute the height at which these tickets matures
+	// Compute the height at which these tickets mature
 	ticketsTx, err := wcl.GetRawTransactionVerbose(tickets[0])
 	if err != nil {
 		t.Fatalf("Unable to gettransaction for ticket.")
@@ -2455,6 +2455,50 @@ func testGetStakeInfo(r *Harness, t *testing.T) {
 	// proportionLive = float64(stakeInfo.Live) / float64(stakeInfo.PoolSize)
 	// proportionMissed = float64(stakeInfo.Missed) /
 	//	(float64(stakeInfo.Voted) + float64(stakeInfo.Missed))
+}
+
+// testWalletInfo
+func testWalletInfo(r *Harness, t *testing.T) {
+	// Wallet RPC client
+	wcl := r.WalletRPC
+
+	// WalletInfo is tested exhaustively in other test, so only do some basic
+	// checks here
+	walletInfo, err := wcl.WalletInfo()
+	if err != nil {
+		t.Fatal("walletinfo failed.")
+	}
+	if !walletInfo.DaemonConnected {
+		t.Fatal("WalletInfo indicates that daemon is not connected.")
+	}
+
+	// Turn off stake mining
+	if err := wcl.SetGenerate(false, 0); err != nil {
+		t.Fatal("SetGenerate failed:", err)
+	}
+
+	// WalletInfo is tested exhaustively in other test, so only do a basic check
+	walletInfo, err = wcl.WalletInfo()
+	if err != nil {
+		t.Fatal("walletinfo failed.")
+	}
+	if walletInfo.StakeMining {
+		t.Fatalf("WalletInfo indicades that stake mining is enabled.")
+	}
+
+	// Now turn on stake mining
+	if err = wcl.SetGenerate(true, 0); err != nil {
+		t.Fatal("SetGenerate failed:", err)
+	}
+
+	// WalletInfo is tested exhaustively in other test, so only do a basic check
+	walletInfo, err = wcl.WalletInfo()
+	if err != nil {
+		t.Fatal("walletinfo failed.")
+	}
+	if !walletInfo.StakeMining {
+		t.Fatalf("WalletInfo indicades that stake mining is disabled.")
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -1965,7 +1965,7 @@ func testGetSetTicketMaxPrice(r *Harness, t *testing.T) {
 
 	expiry = 0
 	numTickets := 1
-	// This purchase should fail
+	// This purchase should fail since stake difficulty is above wallet's price
 	tooLowPriceTicketHashes, err := wcl.PurchaseTicket("default", lowPriceAmt,
 		&minConf, ticketAddr, &numTickets, nil, nil, &expiry)
 	if err == nil {

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -2320,11 +2320,11 @@ func testGetStakeInfo(r *Harness, t *testing.T) {
 			stakeinfo.Missed, stakeinfo.Revoked)
 	}
 	if stakeinfo.ProportionLive != 0 {
-		t.Fatalf("ProportionLive incorrect. Expected %d, got %d.", 0,
+		t.Fatalf("ProportionLive incorrect. Expected %f, got %f.", 0.0,
 			stakeinfo.ProportionLive)
 	}
 	if stakeinfo.ProportionMissed != 0 {
-		t.Fatalf("ProportionMissed incorrect. Expected %d, got %d.", 0,
+		t.Fatalf("ProportionMissed incorrect. Expected %f, got %f.", 0.0,
 			stakeinfo.ProportionMissed)
 	}
 

--- a/rpctest/rpcharness_test.go
+++ b/rpctest/rpcharness_test.go
@@ -441,7 +441,7 @@ func testWalletPassphrase(r *Harness, t *testing.T) {
 	}
 
 	// Unlock with timeout
-	timeOut := int64(10)
+	timeOut := int64(6)
 	err = wcl.WalletPassphrase(defaultWalletPassphrase, timeOut)
 	if err != nil {
 		t.Fatalf("WalletPassphrase failed: %v", err)
@@ -835,7 +835,7 @@ func testListUnspent(r *Harness, t *testing.T) {
 	}
 
 	newBestBlock(r, t)
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	// TODO: why is above necessary for GetRawTransaction to give a tx with
 	// sensible MsgTx().TxIn[:].ValueIn values?
 
@@ -868,7 +868,7 @@ func testListUnspent(r *Harness, t *testing.T) {
 	newBestBlock(r, t)
 
 	// Make sure these txInIDS are not in the new UTXO set
-	time.Sleep(4 * time.Second)
+	time.Sleep(2 * time.Second)
 	list, err = wcl.ListUnspent()
 	if err != nil {
 		t.Fatalf("Failed to get UTXOs")
@@ -936,7 +936,7 @@ func testSendToAddress(r *Harness, t *testing.T) {
 	}
 
 	// Check each PreviousOutPoint for the sending tx.
-	time.Sleep(2 * time.Second)
+	time.Sleep(1 * time.Second)
 	// Get the sending Tx
 	Tx, err := wcl.GetRawTransaction(txid)
 	if err != nil {
@@ -1035,7 +1035,7 @@ func testSendFrom(r *Harness, t *testing.T) {
 	newBestBlock(r, t)
 
 	// Get rawTx of sent txid so we can calculate the fee that was used
-	time.Sleep(3 * time.Second)
+	time.Sleep(1 * time.Second)
 	rawTx, err := r.WalletRPC.GetRawTransaction(txid)
 	if err != nil {
 		t.Fatalf("getrawtransaction failed: %v", err)
@@ -1142,7 +1142,7 @@ func testSendMany(r *Harness, t *testing.T) {
 		t.Fatalf("sendmany failed: %v", err)
 	}
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(250 * time.Millisecond)
 	// Check spendable balance of default account
 	defaultBalanceAfterSendUnmined, err := r.WalletRPC.GetBalanceMinConfType("default", 0, "all")
 	if err != nil {
@@ -1552,7 +1552,7 @@ func testGetSetRelayFee(r *Harness, t *testing.T) {
 	}
 
 	newBestBlock(r, t)
-	time.Sleep(2 * time.Second)
+	//time.Sleep(1 * time.Second)
 	// Give the tx a sensible MsgTx().TxIn[:].ValueIn values
 
 	// Compute the fee
@@ -1648,7 +1648,7 @@ func testGetSetTicketFee(r *Harness, t *testing.T) {
 	// Not yet at StakeValidationHeight, so no voting.
 	newBestBlock(r, t)
 	newBestBlock(r, t)
-	time.Sleep(2 * time.Second)
+	//time.Sleep(2 * time.Second)
 
 	// Compute the actual fee for the ticket purchase
 	rawTx, err := wcl.GetRawTransaction(hashes[0])
@@ -1735,7 +1735,6 @@ func testGetTickets(r *Harness, t *testing.T) {
 	// Mine the split tx and THEN stake submission itself
 	newBestBlock(r, t)
 	_, block, _ := newBestBlock(r, t)
-	//time.Sleep(2 * time.Second)
 
 	// Verify stake submissions were mined
 	for _, hash := range hashes {
@@ -1914,33 +1913,18 @@ func testPurchaseTickets(r *Harness, t *testing.T) {
 
 	// Keep generating blocks until desiredHeight is achieved
 	desiredHeight := uint32(150)
-	expiry = 0
 	numTicket = int(chaincfg.SimNetParams.MaxFreshStakePerBlock)
 	for curBlockHeight < desiredHeight {
 		priceLimit, _ = dcrutil.NewAmount(2 * mustGetStakeDiffNext(r, t))
 		_, err = r.WalletRPC.PurchaseTicket("default", priceLimit,
-			&minConf, addr, &numTicket, nil, nil, &expiry)
+			&minConf, addr, &numTicket, nil, nil, nil)
 
 		// Do not allow even ErrSStxPriceExceedsSpendLimit since price is set
-		if err != nil {
-			t.Fatal(err)
-		}
-		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
-		time.Sleep(600 * time.Millisecond)
-	}
-
-	// and some more for the chain's good health
-	numBlocksWorth := 4
-	for i := 0; i < numBlocksWorth; i++ {
-		priceLimit, _ = dcrutil.NewAmount(2 * mustGetStakeDiffNext(r, t))
-		numTicket = int(chaincfg.SimNetParams.MaxFreshStakePerBlock)
-		_, err = r.WalletRPC.PurchaseTicket("default", priceLimit,
-			&minConf, addr, &numTicket, nil, nil, nil)
 		if err != nil {
 			t.Fatal("Failed to purchase tickets:", err)
 		}
 		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
-		time.Sleep(600 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	// Validate last tx
@@ -2031,7 +2015,7 @@ func testGetSetTicketMaxPrice(r *Harness, t *testing.T) {
 
 	newBestBlock(r, t)
 	// SSTx would be happening now with high enough price
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	newBestBlock(r, t)
 
 	// Check for new tickets after enabling auto-purchasing, but with low price
@@ -2056,7 +2040,7 @@ func testGetSetTicketMaxPrice(r *Harness, t *testing.T) {
 
 	newBestBlock(r, t)
 	// SSTx would be happening now with high enough price
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	newBestBlock(r, t)
 
 	// Check for new tickets after enabling auto-purchasing, but with low price
@@ -2082,7 +2066,7 @@ func testGetSetTicketMaxPrice(r *Harness, t *testing.T) {
 
 	newBestBlock(r, t)
 	// SSTx would be happening now with high enough price
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	//newBestBlock(r, t)
 	// One should be enough for the test, but buy more to keep the chain alive
 	numBlocksToStakeMine := 4
@@ -2204,7 +2188,7 @@ func testGetSetBalanceToMaintain(r *Harness, t *testing.T) {
 
 	newBestBlock(r, t)
 	// SSTx would be happening now with high enough price and low enough BTM
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	newBestBlock(r, t)
 
 	// Check for new tickets after enabling auto-purchasing, but with high BTM
@@ -2235,7 +2219,7 @@ func testGetSetBalanceToMaintain(r *Harness, t *testing.T) {
 
 	newBestBlock(r, t)
 	// SSTx would be happening now with high enough price
-	time.Sleep(5 * time.Second)
+	time.Sleep(1 * time.Second)
 	newBestBlock(r, t)
 
 	// Check for new tickets with low enough BTM and high enough max price
@@ -2376,7 +2360,7 @@ func testGetStakeInfo(r *Harness, t *testing.T) {
 	// actual SSTx
 	height = getBestBlockHeight(r, t)
 	height, _, _ = newBlockAtQuick(height, r, t)
-	time.Sleep(500 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 	// Mine SSTx
 	height, _, _ = newBestBlock(r, t)
 	// validate the purchase
@@ -2441,7 +2425,7 @@ func testGetStakeInfo(r *Harness, t *testing.T) {
 	// Advance to voting height and votes should happen right away
 	votingHeight := chaincfg.SimNetParams.StakeValidationHeight
 	advanceToHeight(r, t, uint32(votingHeight))
-	time.Sleep(time.Second)
+	time.Sleep(250 * time.Millisecond)
 
 	// voted should be TicketsPerBlock
 	stakeinfo = mustGetStakeInfo(wcl, t)
@@ -2565,9 +2549,8 @@ func advanceToNewWindow(r *Harness, t *testing.T) uint32 {
 	initHeight := curBlockHeight
 	for blocksLeftInWindow(curBlockHeight) !=
 		chaincfg.SimNetParams.StakeDiffWindowSize {
-		//curBlockHeight, _, _ = newBestBlock(r, t)
 		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(75 * time.Millisecond)
 	}
 	t.Logf("Advanced %d blocks to block height %d", curBlockHeight-initHeight,
 		curBlockHeight)
@@ -2583,9 +2566,8 @@ func advanceToHeight(r *Harness, t *testing.T, height uint32) {
 	}
 
 	for curBlockHeight != height {
-		//curBlockHeight, _, _ = newBestBlock(r, t)
 		curBlockHeight, _, _ = newBlockAtQuick(curBlockHeight, r, t)
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(75 * time.Millisecond)
 	}
 	t.Logf("Advanced %d blocks to block height %d", curBlockHeight-initHeight,
 		curBlockHeight)
@@ -2596,7 +2578,7 @@ func newBlockAt(currentHeight uint32, r *Harness,
 	t *testing.T) (uint32, *dcrutil.Block, []*chainhash.Hash) {
 	height, block, blockHashes := newBlockAtQuick(currentHeight, r, t)
 
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(700 * time.Millisecond)
 
 	return height, block, blockHashes
 }

--- a/rpctest/walletnode.go
+++ b/rpctest/walletnode.go
@@ -27,7 +27,7 @@ type walletTestConfig struct {
 	rpcConnect string
 	dataDir    string
 	logDir     string
-	profile    string
+	//profile    string // TODO: Decide if this is needed
 	debugLevel string
 	extra      []string
 	prefix     string


### PR DESCRIPTION
Requires unmerged dcrrpcclient PR: https://github.com/decred/dcrrpcclient/pull/35 (and an updated glide.yaml/glide.lock).

Milestone 3 of RFP-10 includes the following legacy RPC tests:
- [x] gettickets,
- [x] purchaseticket
- [x] get/setticketmaxprice
- [x] get/setbalancetomaintain
- [x] getstakeinfo
- [x] walletinfo

Note that there are no getticketmaxprice or getbalancetomaintain commands and as such walletinfo is used to test the mutators.
