### PR TITLE
Fix a bug in the semver compatibility check.

### DIFF
--- a/chain/semver.go
+++ b/chain/semver.go
@@ -4,13 +4,15 @@
 
 package chain
 
+import "fmt"
+
 type semver struct {
 	major, minor, patch uint32
 }
 
 func semverCompatible(required, actual semver) bool {
 	switch {
-	case required.major != required.major:
+	case required.major != actual.major:
 		return false
 	case required.minor > actual.minor:
 		return false
@@ -19,4 +21,8 @@ func semverCompatible(required, actual semver) bool {
 	default:
 		return true
 	}
+}
+
+func (s semver) String() string {
+	return fmt.Sprintf("%d.%d.%d", s.major, s.minor, s.patch)
 }

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -266,6 +266,7 @@ func rpcClientConnectLoop(legacyRPCServer *legacyrpc.Server, loader *wallet.Load
 		chainClient, err := startChainRPC(certs)
 		if err != nil {
 			log.Errorf("Unable to open connection to consensus RPC server: %v", err)
+			time.Sleep(30 * time.Second)
 			continue
 		}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e8d332f58ad0a43b3d06d428ac2df127cbbff2042b3bfffa5e94cf90d0fd36b0
-updated: 2016-11-10T09:59:37.8888972-05:00
+updated: 2016-11-10T10:47:44.1156577-05:00
 imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
@@ -50,7 +50,7 @@ imports:
   - txscript
   - wire
 - name: github.com/decred/dcrrpcclient
-  version: c872526c08ce3caddab82434bf5f4616e38b527b
+  version: e0f7ad39ed6a39b6d91ab78e5fad490f87504477
 - name: github.com/decred/dcrutil
   version: 0484582bf5503574d824f110e836a8c48aa60c8c
   subpackages:


### PR DESCRIPTION
While here, improve the error returned by RPCClient.Connect to include
both the required and advertised API versions.  These versions are
independent of the program and/or project's release versions, but it
should still be useful in determining whether dcrd must be downgraded
or upgraded for compatibility with this wallet software.

Add a 30 second sleep after any connection or compatibility errors
(where compatibility errors are not just incorrect API versions, but
mismatched currency networks as well).  This prevents an immediate
reconnect to the server.

Fixes #379.