### PR TITLE
  Move decision to send attached block notifications to caller.

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1,6 +1,6 @@
 # RPC API Specification
 
-Version: 3.0.0
+Version: 3.0.1
 
 **Note:** This document assumes the reader is familiar with gRPC concepts.
 Refer to the [gRPC Concepts documentation](http://www.grpc.io/docs/guides/concepts.html)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -46,10 +46,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "3.0.0"
+	semverString = "3.0.1"
 	semverMajor  = 3
 	semverMinor  = 0
-	semverPatch  = 0
+	semverPatch  = 1
 )
 
 // translateError creates a new gRPC error with an appropiate error code for

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -318,6 +318,8 @@ func (w *Wallet) onBlockConnected(dbtx walletdb.ReadWriteTx, serializedBlockHead
 			"connecting block height %v: %s", height, err.Error())
 	}
 
+	w.NtfnServer.sendAttachedBlockNotification(dbtx)
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes duplicate tx notifications discovered when performing seed
restoring, jumps from 0 to 2 depth transactions, and probably other
bugs as well.

Bump the gRPC API patch version for this fix.

Fixes #402.