### PR TITLE
Remove database if wallet.Loader.CreateNewWallet errors.

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1,6 +1,6 @@
 # RPC API Specification
 
-Version: 4.0.1
+Version: 4.0.2
 
 **Note:** This document assumes the reader is familiar with gRPC concepts.
 Refer to the [gRPC Concepts documentation](http://www.grpc.io/docs/guides/concepts.html)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -45,10 +45,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "4.0.1"
+	semverString = "4.0.2"
 	semverMajor  = 4
 	semverMinor  = 0
-	semverPatch  = 1
+	semverPatch  = 2
 )
 
 // translateError creates a new gRPC error with an appropiate error code for


### PR DESCRIPTION
This prevents future calls to CreateNewWallet from erroring due to the
database file existing.

Fixes #418.