### PR TITLE
Reenable tests on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: go
 go:
-  - 1.6.3
-  - 1.7
+  - 1.6.4
+  - 1.7.4
 sudo: false
-install:
-  - go get -v github.com/Masterminds/glide
+before_install:
+  - GLIDE_TAG=v0.12.3
+  - GLIDE_DOWNLOAD="https://github.com/Masterminds/glide/releases/download/$GLIDE_TAG/glide-$GLIDE_TAG-linux-amd64.tar.gz"
+  - curl -L $GLIDE_DOWNLOAD | tar -xvz
+  - export PATH=$PATH:$PWD/linux-amd64/
   - glide install
-  - go install -v . ./cmd/...
+install:
+  - go install -v $(glide novendor)
   - go get -v golang.org/x/tools/cmd/cover
   - go get -v github.com/golang/lint/golint
   - go get -v github.com/davecgh/go-spew/spew

--- a/goclean.sh
+++ b/goclean.sh
@@ -12,8 +12,7 @@ test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 # test -z "$(goimports -l -w . | tee /dev/stderr)"
 test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns\|api.pb.go\|StartConsensusRpc\|factory_test.go\|legacy\|UnstableAPI' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | grep -v '^exit status \|Example\|newestSha\| not a string in call to Errorf$' | tee /dev/stderr)"
-############RE-ENABLE THIS WHEN TESTS ARE FIXED!!!!!!!!!!!###############
-#env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
+env GORACE="halt_on_error=1" go test -v -race -short $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 


### PR DESCRIPTION
While here update to the latest Go and use a glide release rather than
the latest development version.

Fixes #421.