### PR TITLE
Fix --create by creating the transaction manager.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3583,13 +3583,21 @@ func Create(db walletdb.DB, pubPass, privPass, seed []byte, params *chaincfg.Par
 		if err != nil {
 			return err
 		}
+		txmgrNs, err := tx.CreateTopLevelBucket(wtxmgrNamespaceKey)
+		if err != nil {
+			return err
+		}
 
 		err = waddrmgr.Create(addrmgrNs, seed, pubPass, privPass,
 			params, nil, unsafeMainNet)
 		if err != nil {
 			return err
 		}
-		return wstakemgr.Create(stakemgrNs)
+		err = wstakemgr.Create(stakemgrNs)
+		if err != nil {
+			return err
+		}
+		return wtxmgr.Create(txmgrNs, params)
 	})
 }
 


### PR DESCRIPTION
The wallet.Create func was not creating the transaction manager
bucket.  With dropwtxmgr now gone, the wtxmgr namespace is now always
required.

Fixes #436.