### PR TITLE
Remove -v from go test on travis.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,7 +12,7 @@ test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 # test -z "$(goimports -l -w . | tee /dev/stderr)"
 test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns\|api.pb.go\|StartConsensusRpc\|factory_test.go\|legacy\|UnstableAPI' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | grep -v '^exit status \|Example\|newestSha\| not a string in call to Errorf$' | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -v -race -short $(glide novendor)
+env GORACE="halt_on_error=1" go test -race -short $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 


### PR DESCRIPTION
This just clutters the logs and makes it more difficult to determine
what the actual failing test was.  For tests that do fail, all logs
from the test is already outputted.