### PR TITLE
Change --profile to take a listen address (or many).

### DIFF
--- a/config.go
+++ b/config.go
@@ -61,22 +61,22 @@ var (
 
 type config struct {
 	// General application behavior
-	ConfigFile         string `short:"C" long:"configfile" description:"Path to configuration file"`
-	ShowVersion        bool   `short:"V" long:"version" description:"Display version information and exit"`
-	Create             bool   `long:"create" description:"Create the wallet if it does not exist"`
-	CreateTemp         bool   `long:"createtemp" description:"Create a temporary simulation wallet (pass=password) in the data directory indicated; must call with --datadir"`
-	CreateWatchingOnly bool   `long:"createwatchingonly" description:"Create the wallet and instantiate it as watching only with an HD extended pubkey; must call with --create"`
-	AppDataDir         string `short:"A" long:"appdata" description:"Application data directory for wallet config, databases and logs"`
-	TestNet            bool   `long:"testnet" description:"Use the test network (default mainnet)"`
-	SimNet             bool   `long:"simnet" description:"Use the simulation test network (default mainnet)"`
-	NoInitialLoad      bool   `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
-	DebugLevel         string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
-	LogDir             string `long:"logdir" description:"Directory to log output."`
-	Profile            string `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	MemProfile         string `long:"memprofile" description:"Write mem profile to the specified file"`
-	RollbackTest       bool   `long:"rollbacktest" description:"Rollback testing is a simnet testing mode that eventually stops wallet and examines wtxmgr database integrity"`
-	AutomaticRepair    bool   `long:"automaticrepair" description:"Attempt to repair the wallet automatically if a database inconsistency is found"`
-	UnsafeMainNet      bool   `long:"unsafemainnet" description:"Enable storage of master seed in mainnet wallet when calling --create and enable unsafe private information RPC commands"`
+	ConfigFile         string   `short:"C" long:"configfile" description:"Path to configuration file"`
+	ShowVersion        bool     `short:"V" long:"version" description:"Display version information and exit"`
+	Create             bool     `long:"create" description:"Create the wallet if it does not exist"`
+	CreateTemp         bool     `long:"createtemp" description:"Create a temporary simulation wallet (pass=password) in the data directory indicated; must call with --datadir"`
+	CreateWatchingOnly bool     `long:"createwatchingonly" description:"Create the wallet and instantiate it as watching only with an HD extended pubkey; must call with --create"`
+	AppDataDir         string   `short:"A" long:"appdata" description:"Application data directory for wallet config, databases and logs"`
+	TestNet            bool     `long:"testnet" description:"Use the test network (default mainnet)"`
+	SimNet             bool     `long:"simnet" description:"Use the simulation test network (default mainnet)"`
+	NoInitialLoad      bool     `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
+	DebugLevel         string   `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
+	LogDir             string   `long:"logdir" description:"Directory to log output."`
+	Profile            []string `long:"profile" description:"Enable HTTP profiling this interface/port"`
+	MemProfile         string   `long:"memprofile" description:"Write mem profile to the specified file"`
+	RollbackTest       bool     `long:"rollbacktest" description:"Rollback testing is a simnet testing mode that eventually stops wallet and examines wtxmgr database integrity"`
+	AutomaticRepair    bool     `long:"automaticrepair" description:"Attempt to repair the wallet automatically if a database inconsistency is found"`
+	UnsafeMainNet      bool     `long:"unsafemainnet" description:"Enable storage of master seed in mainnet wallet when calling --create and enable unsafe private information RPC commands"`
 
 	// Wallet options
 	WalletPass          string  `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -64,10 +64,10 @@ func walletMain() error {
 		for _, listenAddr := range cfg.Profile {
 			listenAddr := listenAddr // copy for closure
 			go func() {
-				log.Infof("Profile server listening on %s", listenAddr)
+				log.Infof("Starting profile server on %s", listenAddr)
 				err := http.ListenAndServe(listenAddr, nil)
 				if err != nil {
-					fatalf(err.Error())
+					fatalf("Unable to run profiler: %v", err)
 				}
 			}()
 		}

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -59,18 +58,19 @@ func walletMain() error {
 	// Show version at startup.
 	log.Infof("Version %s", version())
 
-	if cfg.Profile != "" {
-		go func() {
-			listenAddr := net.JoinHostPort("", cfg.Profile)
-			log.Infof("Profile server listening on %s", listenAddr)
-			profileRedirect := http.RedirectHandler("/debug/pprof",
-				http.StatusSeeOther)
-			http.Handle("/", profileRedirect)
-			err := http.ListenAndServe(listenAddr, nil)
-			if err != nil {
-				fatalf(err.Error())
-			}
-		}()
+	if len(cfg.Profile) > 0 {
+		profileRedirect := http.RedirectHandler("/debug/pprof", http.StatusSeeOther)
+		http.Handle("/", profileRedirect)
+		for _, listenAddr := range cfg.Profile {
+			listenAddr := listenAddr // copy for closure
+			go func() {
+				log.Infof("Profile server listening on %s", listenAddr)
+				err := http.ListenAndServe(listenAddr, nil)
+				if err != nil {
+					fatalf(err.Error())
+				}
+			}()
+		}
 	}
 
 	// Write mem profile if requested.

--- a/log.go
+++ b/log.go
@@ -165,9 +165,10 @@ func pickNoun(n int, singular, plural string) string {
 	return plural
 }
 
-// fatalf logs a string, then cleanly exits.
-func fatalf(str string) {
-	log.Errorf("Unable to create profiler: %v", str)
+// fatalf logs a message, flushes the logger, and finally exit the process with
+// a non-zero return code.
+func fatalf(format string, args ...interface{}) {
+	log.Errorf(format, args...)
 	backendLog.Flush()
 	os.Exit(1)
 }

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -118,6 +118,6 @@
 ; server will only be enabled if any listen addresses are specified.  The
 ; profile information can be accessed at http://<address>/debug/pprof once
 ; running.
-; profile=:6062             ; listen on port 6062 on all interfaces
+; profile=:6062             ; listen on port 6062 on all interfaces (NOT recommended)
 ; profile=127.0.0.1:6062    ; listen on port 6062 on IPv4 loopback
 ; profile=[::1]:6062        ; listen on port 6062 on IPv6 loopback

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -114,7 +114,10 @@
 ; Valid options are {trace, debug, info, warn, error, critical}
 ; debuglevel=info
 
-; The port used to listen for HTTP profile requests.  The profile server will
-; be disabled if this option is not specified.  The profile information can be
-; accessed at http://localhost:<profileport>/debug/pprof once running.
-; profile=6062
+; The listen address(es) used to listen for HTTP profile requests.  The profile
+; server will only be enabled if any listen addresses are specified.  The
+; profile information can be accessed at http://<address>/debug/pprof once
+; running.
+; profile=:6062             ; listen on port 6062 on all interfaces
+; profile=127.0.0.1:6062    ; listen on port 6062 on IPv4 loopback
+; profile=[::1]:6062        ; listen on port 6062 on IPv6 loopback


### PR DESCRIPTION
This changes the --profile option from taking just a port and opening
the HTTP profiler on all interfaces, to requiring a listen address.

The old behavior can be restored by using ':port' instead of 'port'.

Fixes #404.