### PR TITLE
Allow --piperx=0 (stdin).

### DIFF
--- a/config.go
+++ b/config.go
@@ -98,7 +98,7 @@ type config struct {
 	AllowHighFees       bool    `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
 	RelayFee            float64 `long:"txfee" description:"Sets the wallet's tx fee per kb (default: 0.01)"`
 	TicketFee           float64 `long:"ticketfee" description:"Sets the wallet's ticket fee per kb (default: 0.01)"`
-	PipeRx              uint    `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
+	PipeRx              *uint   `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
 
 	// RPC client options
 	RPCConnect       string `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to (default localhost:9109, testnet: localhost:19109, simnet: localhost:18556)"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -149,8 +149,8 @@ func walletMain() error {
 		}
 	}
 
-	if cfg.PipeRx != 0 {
-		go serviceControlPipeRx(uintptr(cfg.PipeRx))
+	if cfg.PipeRx != nil {
+		go serviceControlPipeRx(uintptr(*cfg.PipeRx))
 	}
 
 	// Add interrupt handlers to shutdown the various process components


### PR DESCRIPTION
This will allow attaching stdin as the receive end pipe for a child
dcrwallet process.  Particularly useful for applications that are
unable to create pipes for one reason or another.

Closes #451.