### PR TITLE
ticketbuyer: Stop purchaser on client shutdown

### DIFF
--- a/ticketbuyer.go
+++ b/ticketbuyer.go
@@ -196,8 +196,9 @@ func startTicketPurchase(w *wallet.Wallet, dcrdClient *dcrrpcclient.Client,
 	n := w.NtfnServer.TransactionNotifications()
 	pm := ticketbuyer.NewPurchaseManager(w, p, n.C, quit)
 	go pm.NotificationHandler()
-	addInterruptHandler(func() {
+	go func() {
+		dcrdClient.WaitForShutdown()
 		n.Done()
 		close(quit)
-	})
+	}()
 }


### PR DESCRIPTION
This addresses an issue discovered in #466 

Updated to cleanup and exit the purchaser when a chain client is disconnected.