### PR TITLE
Allow running either the new or old ticket buyer.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -2671,19 +2671,15 @@ func sendToSSRtx(icmd interface{}, w *wallet.Wallet, chainClient *chain.RPCClien
 	return txSha.String(), nil
 }
 
-// getGenerate returns if stake mining is enabled for the wallet.
+// getGenerate returns if the wallet is set to auto purchase tickets.
 func getGenerate(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
-	return w.StakeMiningEnabled, nil
+	return w.TicketPurchasingEnabled(), nil
 }
 
-// setGenerate enables or disables stake mining the wallet (ticket
-// autopurchase, vote generation, and revocation generation). The
-// number of processors may be declared but is ignored (as this is
-// non-PoW work).
+// setGenerate enables or disables the wallet's auto ticket purchaser.
 func setGenerate(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetGenerateCmd)
-	err := w.SetGenerate(cmd.Generate)
-
+	err := w.SetTicketPurchasingEnabled(cmd.Generate)
 	return nil, err
 }
 
@@ -3337,7 +3333,7 @@ func walletInfo(icmd interface{}, w *wallet.Wallet, chainClient *chain.RPCClient
 	tfi := w.TicketFeeIncrement()
 	tmp := w.GetTicketMaxPrice()
 	btm := w.BalanceToMaintain()
-	sm := w.Generate()
+	sm := w.TicketPurchasingEnabled()
 
 	return &dcrjson.WalletInfoResult{
 		DaemonConnected:   connected,

--- a/ticketbuyer/purchase.go
+++ b/ticketbuyer/purchase.go
@@ -46,11 +46,9 @@ out:
 	for {
 		select {
 		case v := <-p.ntfnChan:
-			if p.w.Generate() {
-				if v != nil {
-					for _, block := range v.AttachedBlocks {
-						go p.purchase(int64(block.Height))
-					}
+			if v != nil {
+				for _, block := range v.AttachedBlocks {
+					go p.purchase(int64(block.Height))
 				}
 			}
 		case <-p.quit:

--- a/wallet/loader.go
+++ b/wallet/loader.go
@@ -60,19 +60,20 @@ type Loader struct {
 
 // StakeOptions contains the various options necessary for stake mining.
 type StakeOptions struct {
-	VoteBits            uint16
-	VoteBitsExtended    string
-	StakeMiningEnabled  bool
-	BalanceToMaintain   float64
-	TicketFee           float64
-	PruneTickets        bool
-	AddressReuse        bool
-	TicketAddress       string
-	TicketMaxPrice      float64
-	TicketBuyFreq       int
-	PoolAddress         string
-	PoolFees            float64
-	StakePoolColdExtKey string
+	VoteBits                uint16
+	VoteBitsExtended        string
+	TicketPurchasingEnabled bool
+	VotingEnabled           bool
+	BalanceToMaintain       float64
+	TicketFee               float64
+	PruneTickets            bool
+	AddressReuse            bool
+	TicketAddress           string
+	TicketMaxPrice          float64
+	TicketBuyFreq           int
+	PoolAddress             string
+	PoolFees                float64
+	StakePoolColdExtKey     string
 }
 
 // NewLoader constructs a Loader.
@@ -164,8 +165,8 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 	// Open the newly-created wallet.
 	so := l.stakeOptions
 	w, err = Open(db, pubPassphrase, nil, so.VoteBits, so.VoteBitsExtended,
-		so.StakeMiningEnabled, so.BalanceToMaintain, so.AddressReuse,
-		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
+		so.TicketPurchasingEnabled, so.VotingEnabled, so.BalanceToMaintain,
+		so.AddressReuse, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
 		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
 		l.addrIdxScanLen, so.StakePoolColdExtKey, l.autoRepair,
 		l.allowHighFees, l.relayFee, l.chainParams)
@@ -232,8 +233,8 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 	}
 	so := l.stakeOptions
 	w, err = Open(db, pubPassphrase, cbs, so.VoteBits, so.VoteBitsExtended,
-		so.StakeMiningEnabled, so.BalanceToMaintain, so.AddressReuse,
-		so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
+		so.TicketPurchasingEnabled, so.VotingEnabled, so.BalanceToMaintain,
+		so.AddressReuse, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
 		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
 		l.addrIdxScanLen, so.StakePoolColdExtKey, l.autoRepair, l.allowHighFees,
 		l.relayFee, l.chainParams)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -461,8 +461,9 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 
 	ticketPurchasingEnabled := w.TicketPurchasingEnabled()
 	if ticketPurchasingEnabled {
-		log.Infof("Wallet ticket purchasing enabled: vote bits = %v, "+
-			"balance to maintain = %v", w.VoteBits, w.BalanceToMaintain)
+		log.Infof("Wallet ticket purchasing enabled: vote bits = %#x, "+
+			"extended vote bits = %x, balance to maintain = %v, max ticket price = %v",
+			w.VoteBits.Bits, w.VoteBits.ExtendedBits, w.balanceToMaintain, w.ticketMaxPrice)
 	}
 	if w.votingEnabled {
 		log.Infof("Wallet voting enabled")

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -98,17 +98,18 @@ type Wallet struct {
 	StakeMgr *wstakemgr.StakeStore
 
 	// Handlers for stake system.
-	stakeSettingsLock  sync.Mutex
-	VoteBits           stake.VoteBits
-	StakeMiningEnabled bool
-	CurrentVotingInfo  *VotingInfo
-	ticketMaxPrice     dcrutil.Amount
-	ticketBuyFreq      int
-	balanceToMaintain  dcrutil.Amount
-	poolAddress        dcrutil.Address
-	poolFees           float64
-	stakePoolEnabled   bool
-	stakePoolColdAddrs map[string]struct{}
+	stakeSettingsLock       sync.Mutex
+	VoteBits                stake.VoteBits
+	ticketPurchasingEnabled bool
+	votingEnabled           bool
+	CurrentVotingInfo       *VotingInfo
+	ticketMaxPrice          dcrutil.Amount
+	ticketBuyFreq           int
+	balanceToMaintain       dcrutil.Amount
+	poolAddress             dcrutil.Address
+	poolFees                float64
+	stakePoolEnabled        bool
+	stakePoolColdAddrs      map[string]struct{}
 
 	// Start up flags/settings
 	automaticRepair   bool
@@ -170,8 +171,8 @@ type Wallet struct {
 
 // newWallet creates a new Wallet structure with the provided address manager
 // and transaction store.
-func newWallet(vb uint16, vbe []byte, esm bool, btm dcrutil.Amount,
-	addressReuse bool, ticketAddress dcrutil.Address,
+func newWallet(vb uint16, vbe []byte, ticketPurchasingEnabled bool, votingEnabled bool,
+	btm dcrutil.Amount, addressReuse bool, ticketAddress dcrutil.Address,
 	tmp dcrutil.Amount, ticketBuyFreq int, poolAddress dcrutil.Address, pf float64,
 	relayFee, ticketFee dcrutil.Amount, addrIdxScanLen int,
 	stakePoolColdAddrs map[string]struct{}, autoRepair, AllowHighFees bool,
@@ -187,7 +188,8 @@ func newWallet(vb uint16, vbe []byte, esm bool, btm dcrutil.Amount,
 		Manager:                  mgr,
 		TxStore:                  txs,
 		StakeMgr:                 smgr,
-		StakeMiningEnabled:       esm,
+		ticketPurchasingEnabled:  ticketPurchasingEnabled,
+		votingEnabled:            votingEnabled,
 		VoteBits:                 vbs,
 		balanceToMaintain:        btm,
 		lockedOutpoints:          map[wire.OutPoint]struct{}{},
@@ -265,21 +267,22 @@ func (w *Wallet) SetBalanceToMaintain(balance dcrutil.Amount) {
 	w.stakeSettingsLock.Unlock()
 }
 
-// Generate returns the current status of the generation stake of the wallet.
-func (w *Wallet) Generate() bool {
+// TicketPurchasingEnabled returns whether the wallet is configured to purchase tickets.
+func (w *Wallet) TicketPurchasingEnabled() bool {
 	w.stakeSettingsLock.Lock()
-	defer w.stakeSettingsLock.Unlock()
-	return w.StakeMiningEnabled
+	enabled := w.ticketPurchasingEnabled
+	w.stakeSettingsLock.Unlock()
+	return enabled
 }
 
-// SetGenerate is used to enable or disable stake mining in the
+// SetTicketPurchasingEnabled is used to enable or disable ticket purchasing in the
 // wallet.
-func (w *Wallet) SetGenerate(flag bool) error {
+func (w *Wallet) SetTicketPurchasingEnabled(flag bool) error {
 	w.stakeSettingsLock.Lock()
 	defer w.stakeSettingsLock.Unlock()
 
-	isChanged := w.StakeMiningEnabled != flag
-	w.StakeMiningEnabled = flag
+	isChanged := w.ticketPurchasingEnabled != flag
+	w.ticketPurchasingEnabled = flag
 
 	// If stake mining has been enabled again, make sure to
 	// try to submit any possible votes on the current top
@@ -304,10 +307,10 @@ func (w *Wallet) SetGenerate(flag bool) error {
 		}
 	}
 
-	if w.StakeMiningEnabled && isChanged {
-		log.Infof("Stake mining enabled")
-	} else if !w.StakeMiningEnabled && isChanged {
-		log.Infof("Stake mining disabled")
+	if w.ticketPurchasingEnabled && isChanged {
+		log.Infof("Wallet ticket purchasing enabled")
+	} else if !w.ticketPurchasingEnabled && isChanged {
+		log.Infof("wallet ticket purchasing disabled")
 	}
 
 	return nil
@@ -456,11 +459,17 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 			"and missed tickets. Error: ", err.Error())
 	}
 
-	if w.StakeMiningEnabled {
-		log.Infof("Stake mining is enabled. Votebits: %v, minimum wallet "+
-			"balance %v", w.VoteBits, w.BalanceToMaintain().ToCoin())
-		log.Infof("PLEASE ENSURE YOUR WALLET REMAINS UNLOCKED SO IT MAY " +
-			"VOTE ON BLOCKS AND RECEIVE STAKE REWARDS")
+	ticketPurchasingEnabled := w.TicketPurchasingEnabled()
+	if ticketPurchasingEnabled {
+		log.Infof("Wallet ticket purchasing enabled: vote bits = %v, "+
+			"balance to maintain = %v", w.VoteBits, w.BalanceToMaintain)
+	}
+	if w.votingEnabled {
+		log.Infof("Wallet voting enabled")
+	}
+	if ticketPurchasingEnabled || w.votingEnabled {
+		log.Infof("Please ensure your wallet remains unlocked so it may " +
+			"create stake transactions")
 	}
 }
 
@@ -3682,8 +3691,8 @@ func decodeStakePoolColdExtKey(encStr string,
 
 // Open loads an already-created wallet from the passed database and namespaces.
 func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
-	voteBits uint16, voteBitsExtended string, stakeMiningEnabled bool,
-	balanceToMaintain float64, addressReuse bool,
+	voteBits uint16, voteBitsExtended string, ticketPurchasingEnabled bool,
+	votingEnabled bool, balanceToMaintain float64, addressReuse bool,
 	pruneTickets bool, ticketAddress string, ticketMaxPrice float64,
 	ticketBuyFreq int, poolAddress string, poolFees float64, ticketFee float64,
 	addrIdxScanLen int, stakePoolColdExtKey string, autoRepair, allowHighFees bool,
@@ -3825,7 +3834,8 @@ func Open(db walletdb.DB, pubPass []byte, cbs *waddrmgr.OpenCallbacks,
 
 	w := newWallet(voteBits,
 		voteBitsExtendedB,
-		stakeMiningEnabled,
+		ticketPurchasingEnabled,
+		votingEnabled,
 		btm,
 		addressReuse,
 		ticketAddr,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -48,14 +48,15 @@ func networkDir(dataDir string, chainParams *chaincfg.Params) string {
 func createWallet(cfg *config) error {
 	dbDir := networkDir(cfg.AppDataDir, activeNet.Params)
 	stakeOptions := &wallet.StakeOptions{
-		VoteBits:           cfg.VoteBits,
-		StakeMiningEnabled: cfg.EnableStakeMining,
-		BalanceToMaintain:  cfg.BalanceToMaintain,
-		PruneTickets:       cfg.PruneTickets,
-		AddressReuse:       cfg.ReuseAddresses,
-		TicketAddress:      cfg.TicketAddress,
-		TicketMaxPrice:     cfg.TicketMaxPrice,
-		TicketFee:          cfg.TicketFee,
+		VoteBits:                cfg.VoteBits,
+		TicketPurchasingEnabled: cfg.EnableStakeMining && !cfg.EnableTicketBuyer,
+		VotingEnabled:           cfg.EnableVoting,
+		BalanceToMaintain:       cfg.BalanceToMaintain,
+		PruneTickets:            cfg.PruneTickets,
+		AddressReuse:            cfg.ReuseAddresses,
+		TicketAddress:           cfg.TicketAddress,
+		TicketMaxPrice:          cfg.TicketMaxPrice,
+		TicketFee:               cfg.TicketFee,
 	}
 	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.AddrIdxScanLen, cfg.AllowHighFees,


### PR DESCRIPTION
An --enableticketbuyer option has been added.  It must be used to
enable the new ticket buyer.

An --enablevoting option has been added to turn on the wallet's
automatic creation of vote and revocation transactions when using the
new ticket purchaser.

The --enablestakemining option has been deprecated for the above two
options.  To use the old ticket buyer from the wallet package, use
this option and do NOT set --enableticketbuyer (doing so would enable
the new ticket buyer).

All RPCs to interact with the ticket buyer remain, but only affect the
old deprecated ticket buyer, and are also deprecated by extension.

Fixes #468.