### PR TITLE
Slightly improve logging formatting.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -461,7 +461,7 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 
 	ticketPurchasingEnabled := w.TicketPurchasingEnabled()
 	if ticketPurchasingEnabled {
-		log.Infof("Wallet ticket purchasing enabled: vote bits = %#x, "+
+		log.Infof("Wallet ticket purchasing enabled: vote bits = %#04x, "+
 			"extended vote bits = %x, balance to maintain = %v, max ticket price = %v",
 			w.VoteBits.Bits, w.VoteBits.ExtendedBits, w.balanceToMaintain, w.ticketMaxPrice)
 	}


### PR DESCRIPTION
This changes the logged votebits when logging that wallet ticket
purchasing is enabled to always display with leading 0s.  For example,
currently for a votebits value of 1, it will be logged as 0x1.  This
changes it to be logged as 0x0001.