### PR TITLE
make maxfee behavior sane

### DIFF
--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -128,7 +128,8 @@
 ; Ticket Buyer settings
 ; ------------------------------------------------------------------------------
 
-; The max price to pay for tickets relative to the average price
+; Scaling factor for setting the maximum price, multiplies by the average price
+; e.g. 1.25 = 125%
 ; ticketbuyer.maxpricerelative=1.25
 
 ; Attempt to prevent the stake difficulty from going above this
@@ -147,9 +148,9 @@
 ; every 1-in-n blocks
 ; ticketbuyer.maxperblock=5
 
-; The amount above the mean fee in the previous blocks to purchase tickets with,
-; proportional e.g. 1.05 = 105%
-; ticketbuyer.feetargetscaling=1.05
+; Scaling factor for setting the ticket fee, multiplies by the average fee
+; e.g. 1.0 = 100%
+; ticketbuyer.feetargetscaling=1.0
 
 ; The mode to use for calculating the average price if pricetarget is disabled
 ; (vwap, pool, dual)
@@ -159,13 +160,13 @@
 ; ticketbuyer.avgpricevwapdelta=2880
 
 ; Maximum ticket fee per KB
-; ticketbuyer.maxfee=1.0
+; ticketbuyer.maxfee=0.1
 
 ; Minimum ticket fee per KB
 ; ticketbuyer.minfee=0.01
 
 ; The fee source to use for ticket fee per KB (median or mean)
-; ticketbuyer.feesource=mean
+; ticketbuyer.feesource=median
 
 ; Number of blocks to average for fees calculation
 ; ticketbuyer.blockstoavg=11

--- a/ticketbuyer/buyer.go
+++ b/ticketbuyer/buyer.go
@@ -408,9 +408,9 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	// for by the user.
 	feeToUse := chainFee * t.cfg.FeeTargetScaling
 	if feeToUse > t.cfg.MaxFee {
-		log.Tracef("Scaled fee is %v, but max fee is %v; using max",
+		log.Infof("Aborting ticket purchases because the scaled fee %v is above max fee %v",
 			feeToUse, t.cfg.MaxFee)
-		feeToUse = t.cfg.MaxFee
+		return ps, nil
 	}
 	if feeToUse < t.cfg.MinFee {
 		log.Tracef("Scaled fee is %v, but min fee is %v; using min",
@@ -423,8 +423,8 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	}
 	t.wallet.SetTicketFeeIncrement(feeToUseAmt)
 
-	log.Debugf("Mean fee for the last blocks or window period was %v; "+
-		"this was scaled to %v", chainFee, feeToUse)
+	log.Debugf("Mean fee for the last blocks or window period was %.8f; "+
+		"this was scaled to %.8f", chainFee, feeToUse)
 	ps.FeeOwn = feeToUse
 
 	// Calculate how many tickets we can buy at this difficulty.


### PR DESCRIPTION
Change default so as to not unintentionally join bidding wars.
Do not buy tickets when scaled fee exceeds your specified maxfee.

Closes https://github.com/decred/dcrticketbuyer/issues/71