### PR TITLE
loader: Move Loader to new pkg loader

### DIFF
--- a/loader/doc.go
+++ b/loader/doc.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package loader provides a concurrent safe implementation of a wallet loader.
+
+It is intended to allow creating and opening wallets as well as managing
+services like ticket buyer by RPC servers as well other subsystems.
+*/
+package loader

--- a/loader/errors.go
+++ b/loader/errors.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package loader
+
+import "errors"
+
+var (
+	// ErrWalletLoaded describes the error condition of attempting to load or
+	// create a wallet when the loader has already done so.
+	ErrWalletLoaded = errors.New("wallet already loaded")
+
+	// ErrWalletNotLoaded describes the error condition of attempting to close
+	// a loaded wallet when a wallet has not been loaded.
+	ErrWalletNotLoaded = errors.New("wallet is not loaded")
+
+	// ErrWalletExists describes the error condition of attempting to create a
+	// new wallet when one exists already.
+	ErrWalletExists = errors.New("wallet already exists")
+
+	// ErrTicketBuyerStarted describes the error condition of attempting to
+	// start ticketbuyer when it is already started.
+	ErrTicketBuyerStarted = errors.New("ticketbuyer already started")
+
+	// ErrTicketBuyerStopped describes the error condition of attempting to
+	// stop ticketbuyer when it is already stopped.
+	ErrTicketBuyerStopped = errors.New("ticketbuyer not running")
+
+	// ErrNoChainClient describes the error condition of attempting to start
+	// ticketbuyer when no chain client is available.
+	ErrNoChainClient = errors.New("chain client not available")
+)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -2,37 +2,27 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package wallet
+package loader
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 
 	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrwallet/internal/prompt"
+	"github.com/decred/dcrwallet/ticketbuyer"
 	"github.com/decred/dcrwallet/waddrmgr"
+	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/walletdb"
 	_ "github.com/decred/dcrwallet/walletdb/bdb" // driver loaded during init
 )
 
 const (
 	walletDbName = "wallet.db"
-)
-
-var (
-	// ErrLoaded describes the error condition of attempting to load or
-	// create a wallet when the loader has already done so.
-	ErrLoaded = errors.New("wallet already loaded")
-
-	// ErrNotLoaded describes the error condition of attempting to close a
-	// loaded wallet when a wallet has not been loaded.
-	ErrNotLoaded = errors.New("wallet is not loaded")
-
-	// ErrExists describes the error condition of attempting to create a new
-	// wallet when one exists already.
-	ErrExists = errors.New("wallet already exists")
 )
 
 // Loader implements the creating of new and opening of existing wallets, while
@@ -43,20 +33,22 @@ var (
 //
 // Loader is safe for concurrent access.
 type Loader struct {
-	loadCallbacks   []func(*Wallet)
-	unloadCallbacks []func(*Wallet)
-	chainParams     *chaincfg.Params
-	dbDirPath       string
-	wallet          *Wallet
-	db              walletdb.DB
-	mu              sync.Mutex
+	callbacks   []func(*wallet.Wallet)
+	chainClient *dcrrpcclient.Client
+	chainParams *chaincfg.Params
+	dbDirPath   string
+	wallet      *wallet.Wallet
+	db          walletdb.DB
+	mu          sync.Mutex
 
-	stakeOptions   *StakeOptions
-	autoRepair     bool
-	unsafeMainNet  bool
-	addrIdxScanLen int
-	allowHighFees  bool
-	relayFee       float64
+	purchaseManager *ticketbuyer.PurchaseManager
+	ntfnClient      wallet.MainTipChangedNotificationsClient
+	stakeOptions    *StakeOptions
+	autoRepair      bool
+	unsafeMainNet   bool
+	addrIdxScanLen  int
+	allowHighFees   bool
+	relayFee        float64
 }
 
 // StakeOptions contains the various options necessary for stake mining.
@@ -95,57 +87,56 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string,
 
 // onLoaded executes each added callback and prevents loader from loading any
 // additional wallets.  Requires mutex to be locked.
-func (l *Loader) onLoaded(w *Wallet, db walletdb.DB) {
-	for _, fn := range l.loadCallbacks {
+func (l *Loader) onLoaded(w *wallet.Wallet, db walletdb.DB) {
+	for _, fn := range l.callbacks {
 		fn(w)
 	}
 
 	l.wallet = w
 	l.db = db
-	l.loadCallbacks = nil // not needed anymore
-}
-
-// onUnload executes each added unload callback.  Requires mutex to be locked.
-func (l *Loader) onUnload(w *Wallet) {
-	for _, fn := range l.unloadCallbacks {
-		fn(w)
-	}
-	l.unloadCallbacks = nil // not needed anymore
+	l.callbacks = nil // not needed anymore
 }
 
 // RunAfterLoad adds a function to be executed when the loader creates or opens
 // a wallet.  Functions are executed in a single goroutine in the order they are
 // added.
-func (l *Loader) RunAfterLoad(fn func(*Wallet)) {
+func (l *Loader) RunAfterLoad(fn func(*wallet.Wallet)) {
 	l.mu.Lock()
 	if l.wallet != nil {
 		w := l.wallet
 		l.mu.Unlock()
 		fn(w)
 	} else {
-		l.loadCallbacks = append(l.loadCallbacks, fn)
+		l.callbacks = append(l.callbacks, fn)
 		l.mu.Unlock()
 	}
-}
-
-// RunBeforeUnload adds a function to be executed before the loader unloads a
-// wallet.  Functions are executed in a single goroutine in the order they are
-// added.
-func (l *Loader) RunBeforeUnload(fn func(*Wallet)) {
-	l.mu.Lock()
-	l.unloadCallbacks = append(l.unloadCallbacks, fn)
-	l.mu.Unlock()
 }
 
 // CreateNewWallet creates a new wallet using the provided public and private
 // passphrases.  The seed is optional.  If non-nil, addresses are derived from
 // this seed.  If nil, a secure random seed is generated.
-func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w *Wallet, err error) {
+func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w *wallet.Wallet, err error) {
 	defer l.mu.Unlock()
 	l.mu.Lock()
 
 	if l.wallet != nil {
-		return nil, ErrLoaded
+		return nil, ErrWalletLoaded
+	}
+
+	// Ensure that the network directory exists.
+	if fi, err := os.Stat(l.dbDirPath); err != nil {
+		if os.IsNotExist(err) {
+			// Attempt data directory creation
+			if err = os.MkdirAll(l.dbDirPath, 0700); err != nil {
+				return nil, fmt.Errorf("cannot create directory: %s", err)
+			}
+		} else {
+			return nil, fmt.Errorf("error checking directory: %s", err)
+		}
+	} else {
+		if !fi.IsDir() {
+			return nil, fmt.Errorf("path '%s' is not a directory", l.dbDirPath)
+		}
 	}
 
 	dbPath := filepath.Join(l.dbDirPath, walletDbName)
@@ -154,7 +145,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 		return nil, err
 	}
 	if exists {
-		return nil, ErrExists
+		return nil, ErrWalletExists
 	}
 
 	// Create the wallet database backed by bolt db.
@@ -174,7 +165,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 	}()
 
 	// Initialize the newly created database for the wallet before opening.
-	err = Create(db, pubPassphrase, privPassphrase, seed, l.chainParams,
+	err = wallet.Create(db, pubPassphrase, privPassphrase, seed, l.chainParams,
 		l.unsafeMainNet)
 	if err != nil {
 		return nil, err
@@ -182,7 +173,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 
 	// Open the newly-created wallet.
 	so := l.stakeOptions
-	w, err = Open(db, pubPassphrase, nil, so.VoteBits, so.VoteBitsExtended,
+	w, err = wallet.Open(db, pubPassphrase, nil, so.VoteBits, so.VoteBitsExtended,
 		so.TicketPurchasingEnabled, so.VotingEnabled, so.BalanceToMaintain,
 		so.AddressReuse, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
 		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
@@ -207,17 +198,12 @@ func noConsole() ([]byte, error) {
 // and the public passphrase.  If the loader is being called by a context where
 // standard input prompts may be used during wallet upgrades, setting
 // canConsolePrompt will enable these prompts.
-func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool) (w *Wallet, rerr error) {
+func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool) (w *wallet.Wallet, rerr error) {
 	defer l.mu.Unlock()
 	l.mu.Lock()
 
 	if l.wallet != nil {
-		return nil, ErrLoaded
-	}
-
-	// Ensure that the network directory exists.
-	if err := checkCreateDir(l.dbDirPath); err != nil {
-		return nil, err
+		return nil, ErrWalletLoaded
 	}
 
 	// Open the database using the boltdb backend.
@@ -250,7 +236,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte, canConsolePrompt bool)
 		}
 	}
 	so := l.stakeOptions
-	w, err = Open(db, pubPassphrase, cbs, so.VoteBits, so.VoteBitsExtended,
+	w, err = wallet.Open(db, pubPassphrase, cbs, so.VoteBits, so.VoteBitsExtended,
 		so.TicketPurchasingEnabled, so.VotingEnabled, so.BalanceToMaintain,
 		so.AddressReuse, so.PruneTickets, so.TicketAddress, so.TicketMaxPrice,
 		so.TicketBuyFreq, so.PoolAddress, so.PoolFees, so.TicketFee,
@@ -275,25 +261,24 @@ func (l *Loader) WalletExists() (bool, error) {
 // LoadedWallet returns the loaded wallet, if any, and a bool for whether the
 // wallet has been loaded or not.  If true, the wallet pointer should be safe to
 // dereference.
-func (l *Loader) LoadedWallet() (*Wallet, bool) {
+func (l *Loader) LoadedWallet() (*wallet.Wallet, bool) {
 	l.mu.Lock()
 	w := l.wallet
 	l.mu.Unlock()
 	return w, w != nil
 }
 
-// UnloadWallet stops the loaded wallet, if any, and closes the wallet database.
-// This returns ErrNotLoaded if the wallet has not been loaded with
-// CreateNewWallet or LoadExistingWallet.  The Loader may be reused if this
-// function returns without error.
+// UnloadWallet stops the loaded wallet, if any, and closes the wallet
+// database.  This returns ErrWalletNotLoaded if the wallet has not been loaded
+// with CreateNewWallet or LoadExistingWallet.  The Loader may be reused if
+// this function returns without error.
 func (l *Loader) UnloadWallet() error {
 	defer l.mu.Unlock()
 	l.mu.Lock()
 
 	if l.wallet == nil {
-		return ErrNotLoaded
+		return ErrWalletNotLoaded
 	}
-	l.onUnload(l.wallet)
 
 	l.wallet.Stop()
 	l.wallet.WaitForShutdown()
@@ -305,6 +290,76 @@ func (l *Loader) UnloadWallet() error {
 	l.wallet = nil
 	l.db = nil
 	return nil
+}
+
+// SetChainClient sets the chain server client.
+func (l *Loader) SetChainClient(chainClient *dcrrpcclient.Client) {
+	l.mu.Lock()
+	l.chainClient = chainClient
+	l.mu.Unlock()
+}
+
+// StartTicketPurchase launches the ticketbuyer to start purchasing tickets.
+func (l *Loader) StartTicketPurchase(passphrase []byte, ticketbuyerCfg *ticketbuyer.Config) error {
+	defer l.mu.Unlock()
+	l.mu.Lock()
+
+	// Already running?
+	if l.purchaseManager != nil {
+		return ErrTicketBuyerStarted
+	}
+
+	if l.wallet == nil {
+		return ErrWalletNotLoaded
+	}
+
+	if l.chainClient == nil {
+		return ErrNoChainClient
+	}
+
+	w := l.wallet
+	p, err := ticketbuyer.NewTicketPurchaser(ticketbuyerCfg, l.chainClient, w, l.chainParams)
+	if err != nil {
+		return err
+	}
+	if passphrase != nil {
+		err = w.Unlock(passphrase, nil)
+		if err != nil {
+			return err
+		}
+	}
+	n := w.NtfnServer.MainTipChangedNotifications()
+	pm := ticketbuyer.NewPurchaseManager(w, p, n.C)
+	l.ntfnClient = n
+	l.purchaseManager = pm
+	pm.Start()
+	return nil
+}
+
+// StopTicketPurchase stops the ticket purchaser, waiting until it has finished.
+// If no ticket purchaser is running, it returns ErrTicketBuyerStopped.
+func (l *Loader) StopTicketPurchase() error {
+	defer l.mu.Unlock()
+	l.mu.Lock()
+
+	if l.purchaseManager == nil {
+		return ErrTicketBuyerStopped
+	}
+
+	l.ntfnClient.Done()
+	l.purchaseManager.Stop()
+	l.purchaseManager.WaitForShutdown()
+	l.purchaseManager = nil
+	return nil
+}
+
+// PurchaseManager returns the ticket purchaser instance. If ticket purchasing
+// has been disabled, it returns nil.
+func (l *Loader) PurchaseManager() *ticketbuyer.PurchaseManager {
+	l.mu.Lock()
+	pm := l.purchaseManager
+	l.mu.Unlock()
+	return pm
 }
 
 func fileExists(filePath string) (bool, error) {

--- a/loader/log.go
+++ b/loader/log.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package loader
+
+import "github.com/btcsuite/btclog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// LogClosure is a closure that can be printed with %v to be used to
+// generate expensive-to-create data for a detailed log level and avoid doing
+// the work if the data isn't printed.
+type logClosure func() string
+
+// String invokes the log closure and returns the results string.
+func (c logClosure) String() string {
+	return c()
+}
+
+// newLogClosure returns a new closure over the passed function which allows
+// it to be used as a parameter in a logging function that is only invoked when
+// the logging level is such that the message will actually be logged.
+func newLogClosure(c func() string) logClosure {
+	return logClosure(c)
+}
+
+// pickNoun returns the singular or plural form of a noun depending
+// on the count n.
+func pickNoun(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/log.go
+++ b/log.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrwallet/chain"
+	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/rpc/legacyrpc"
 	"github.com/decred/dcrwallet/rpc/rpcserver"
 	"github.com/decred/dcrwallet/ticketbuyer"
@@ -29,6 +30,7 @@ import (
 var (
 	backendLog   = seelog.Disabled
 	log          = btclog.Disabled
+	loaderLog    = btclog.Disabled
 	walletLog    = btclog.Disabled
 	txmgrLog     = btclog.Disabled
 	tkbyLog      = btclog.Disabled
@@ -41,6 +43,7 @@ var (
 // subsystemLoggers maps each subsystem identifier to its associated logger.
 var subsystemLoggers = map[string]btclog.Logger{
 	"DCRW": log,
+	"LODR": loaderLog,
 	"WLLT": walletLog,
 	"TMGR": txmgrLog,
 	"TKBY": tkbyLog,
@@ -77,6 +80,9 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 	switch subsystemID {
 	case "DCRW":
 		log = logger
+	case "LODR":
+		loaderLog = logger
+		loader.UseLogger(logger)
 	case "WLLT":
 		walletLog = logger
 		wallet.UseLogger(logger)

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/btcsuite/websocket"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrwallet/chain"
+	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/wallet"
 )
 
@@ -60,7 +61,7 @@ func (c *websocketClient) send(b []byte) error {
 type Server struct {
 	httpServer    http.Server
 	wallet        *wallet.Wallet
-	walletLoader  *wallet.Loader
+	walletLoader  *loader.Loader
 	chainClient   *chain.RPCClient
 	handlerLookup func(string) (requestHandler, bool)
 	handlerMu     sync.Mutex
@@ -89,7 +90,7 @@ func jsonAuthFail(w http.ResponseWriter) {
 
 // NewServer creates a new server for serving legacy RPC client connections,
 // both HTTP POST and websocket.
-func NewServer(opts *Options, walletLoader *wallet.Loader, listeners []net.Listener) *Server {
+func NewServer(opts *Options, walletLoader *loader.Loader, listeners []net.Listener) *Server {
 	serveMux := http.NewServeMux()
 	const rpcAuthTimeoutSeconds = 10
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/decred/dcrutil"
+	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/rpc/legacyrpc"
 	"github.com/decred/dcrwallet/rpc/rpcserver"
 	"github.com/decred/dcrwallet/wallet"
@@ -105,7 +106,7 @@ func generateRPCKeyPair(writeKey bool) (tls.Certificate, error) {
 	return keyPair, nil
 }
 
-func startRPCServers(walletLoader *wallet.Loader) (*grpc.Server, *legacyrpc.Server, error) {
+func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *legacyrpc.Server, error) {
 	var (
 		server       *grpc.Server
 		legacyServer *legacyrpc.Server

--- a/ticketbuyer/purchase.go
+++ b/ticketbuyer/purchase.go
@@ -53,7 +53,10 @@ func (p *PurchaseManager) NotificationHandler() {
 out:
 	for {
 		select {
-		case v := <-p.ntfnChan:
+		case v, ok := <-p.ntfnChan:
+			if !ok {
+				break out
+			}
 			p.wg.Add(1)
 			go func(s1, s2 chan struct{}) {
 				defer p.wg.Done()

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil/hdkeychain"
 	"github.com/decred/dcrwallet/internal/prompt"
+	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/walletdb"
 	_ "github.com/decred/dcrwallet/walletdb/bdb"
@@ -47,7 +48,7 @@ func networkDir(dataDir string, chainParams *chaincfg.Params) string {
 // to do the initial sync.
 func createWallet(cfg *config) error {
 	dbDir := networkDir(cfg.AppDataDir, activeNet.Params)
-	stakeOptions := &wallet.StakeOptions{
+	stakeOptions := &loader.StakeOptions{
 		VoteBits:                cfg.VoteBits,
 		VoteBitsExtended:        cfg.VoteBitsExtended,
 		TicketPurchasingEnabled: cfg.EnableStakeMining && !cfg.EnableTicketBuyer,
@@ -59,7 +60,7 @@ func createWallet(cfg *config) error {
 		TicketMaxPrice:          cfg.tbCfg.MaxPriceAbsolute,
 		TicketFee:               cfg.TicketFee.ToCoin(),
 	}
-	loader := wallet.NewLoader(activeNet.Params, dbDir, stakeOptions,
+	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.AutomaticRepair, cfg.UnsafeMainNet, cfg.AddrIdxScanLen, cfg.AllowHighFees,
 		cfg.RelayFee.ToCoin())
 


### PR DESCRIPTION
As mentioned in #463 we need a way to start/stop the ticketbuyer purchaser over gRPC.

This PR allows the loader to be re-usable from `pkg loader`  so as to handle ticketbuyer services to be stopped/started similar to the current handling of wallet load/unload.