### PR TITLE
Set version in extended vote bits per network.

### DIFF
--- a/config.go
+++ b/config.go
@@ -752,13 +752,13 @@ func loadConfig() (*config, []string, error) {
 		}
 	}
 
-	// Validate extended vote bits
-	const minExtVBLen = 6
-	const maxExtVBLen = stake.SSGenVoteBitsExtendedMaxSize*2 - 2
+	// Validate extended vote bits.  Must be 8 characters (4 bytes) shorter than
+	// the actual max due to the appended version.
+	const maxExtVBLen = stake.SSGenVoteBitsExtendedMaxSize*2 - 8
 	vbeLen := len(cfg.VoteBitsExtended)
-	if vbeLen < minExtVBLen || vbeLen > maxExtVBLen {
+	if vbeLen > maxExtVBLen {
 		err = fmt.Errorf("bad extended votebits length: (got %v, "+
-			"min %v, max %v)", vbeLen, minExtVBLen, maxExtVBLen)
+			"max %v)", vbeLen, maxExtVBLen)
 		fmt.Fprintln(os.Stderr, err.Error())
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return loadConfigError(err)
@@ -778,11 +778,11 @@ func loadConfig() (*config, []string, error) {
 	// existing wallet code.
 	switch activeNet {
 	case &netparams.MainNetParams:
-		cfg.VoteBitsExtended = "03" + cfg.VoteBitsExtended
+		cfg.VoteBitsExtended = "03000000" + cfg.VoteBitsExtended
 	case &netparams.TestNetParams:
-		cfg.VoteBitsExtended = "04" + cfg.VoteBitsExtended
+		cfg.VoteBitsExtended = "04000000" + cfg.VoteBitsExtended
 	case &netparams.SimNetParams:
-		cfg.VoteBitsExtended = "04" + cfg.VoteBitsExtended
+		cfg.VoteBitsExtended = "04000000" + cfg.VoteBitsExtended
 	}
 
 	if cfg.RPCConnect == "" {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ const (
 	defaultEnableTicketBuyer   = false
 	defaultEnableVoting        = false
 	defaultVoteBits            = 0x0001
-	defaultVoteBitsExtended    = "03000000"
+	defaultVoteBitsExtended    = "000000" // does NOT include version.
 	defaultBalanceToMaintain   = 0
 	defaultReuseAddresses      = false
 	defaultRollbackTest        = false
@@ -109,7 +109,7 @@ type config struct {
 	EnableTicketBuyer   bool                `long:"enableticketbuyer" description:"Enable the automatic ticket buyer"`
 	EnableVoting        bool                `long:"enablevoting" description:"Enable creation of votes and revocations for owned tickets"`
 	VoteBits            uint16              `long:"votebits" hidden:"true" description:"Set your stake mining votebits to value" base:"16"`
-	VoteBitsExtended    string              `long:"votebitsextended" hidden:"true" description:"Set your stake mining extended votebits to the hexademical value indicated by the passed string"`
+	VoteBitsExtended    string              `long:"votebitsextended" hidden:"true" description:"Set your stake mining extended votebits to the hexademical value indicated by the passed string, must not include the version"`
 	ReuseAddresses      bool                `long:"reuseaddresses" description:"Reuse addresses for ticket purchase to cut down on address overuse"`
 	PruneTickets        bool                `long:"prunetickets" description:"Prune old tickets from the wallet and restore their inputs"`
 	PurchaseAccount     string              `long:"purchaseaccount" description:"Name of the account to buy tickets from"`
@@ -753,10 +753,12 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Validate extended vote bits
+	const minExtVBLen = 6
+	const maxExtVBLen = stake.SSGenVoteBitsExtendedMaxSize*2 - 2
 	vbeLen := len(cfg.VoteBitsExtended)
-	if vbeLen < 8 || vbeLen > stake.SSGenVoteBitsExtendedMaxSize*2 {
+	if vbeLen < minExtVBLen || vbeLen > maxExtVBLen {
 		err = fmt.Errorf("bad extended votebits length: (got %v, "+
-			"min 8, max %v)", vbeLen, stake.SSGenVoteBitsExtendedMaxSize*2)
+			"min %v, max %v)", vbeLen, minExtVBLen, maxExtVBLen)
 		fmt.Fprintln(os.Stderr, err.Error())
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return loadConfigError(err)
@@ -767,6 +769,20 @@ func loadConfig() (*config, []string, error) {
 		fmt.Fprintln(os.Stderr, err.Error())
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return loadConfigError(err)
+	}
+
+	// Set the vote bits version based on the active network.
+	//
+	// Config parsing is very likely the wrong place to do this, especially with
+	// magic version constants, but it is the least invasive change to the
+	// existing wallet code.
+	switch activeNet {
+	case &netparams.MainNetParams:
+		cfg.VoteBitsExtended = "03" + cfg.VoteBitsExtended
+	case &netparams.TestNetParams:
+		cfg.VoteBitsExtended = "04" + cfg.VoteBitsExtended
+	case &netparams.SimNetParams:
+		cfg.VoteBitsExtended = "04" + cfg.VoteBitsExtended
 	}
 
 	if cfg.RPCConnect == "" {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ const (
 	defaultEnableTicketBuyer   = false
 	defaultEnableVoting        = false
 	defaultVoteBits            = 0x0001
-	defaultVoteBitsExtended    = "000000" // does NOT include version.
+	defaultVoteBitsExtended    = "" // does NOT include version.
 	defaultBalanceToMaintain   = 0
 	defaultReuseAddresses      = false
 	defaultRollbackTest        = false

--- a/config.go
+++ b/config.go
@@ -753,7 +753,7 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Validate extended vote bits.  Must be 8 characters (4 bytes) shorter than
-	// the actual max due to the appended version.
+	// the actual max due to the prepended version.
 	const maxExtVBLen = stake.SSGenVoteBitsExtendedMaxSize*2 - 8
 	vbeLen := len(cfg.VoteBitsExtended)
 	if vbeLen > maxExtVBLen {
@@ -771,7 +771,7 @@ func loadConfig() (*config, []string, error) {
 		return loadConfigError(err)
 	}
 
-	// Set the vote bits version based on the active network.
+	// Prepend the vote bits version based on the active network.
 	//
 	// Config parsing is very likely the wrong place to do this, especially with
 	// magic version constants, but it is the least invasive change to the


### PR DESCRIPTION
This is a breaking change to anyone who is setting votebits from the
hidden --votebitsextended option.  The new option should not contain
any version info.