### PR TITLE
Add illumos support.

### DIFF
--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/btcsuite/golangcrypto/ssh/terminal"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson"
 	"github.com/decred/dcrd/txscript"
@@ -23,6 +22,7 @@ import (
 	"github.com/decred/dcrwallet/wallet/txauthor"
 	"github.com/decred/dcrwallet/wallet/txrules"
 	"github.com/jessevdk/go-flags"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e131a09cdee55488fc872343167c3f23e5de31714be022b47cbc6842c33a44f6
-updated: 2017-02-16T15:38:21.171164034Z
+hash: 5da93fdff30aec2a373fd7b4525267f9dadf5329933c2cace07ae5809f12f579
+updated: 2017-02-16T15:58:24.686782258Z
 imports:
 - name: github.com/boltdb/bolt
   version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
@@ -66,6 +66,10 @@ imports:
   - proto
 - name: github.com/jessevdk/go-flags
   version: 48cf8722c3375517aba351d1f7577c40663a4407
+- name: golang.org/x/crypto
+  version: 453249f01cfeb54c3d549ddb75ff152ca243f9d8
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: b4690f45fa1cafc47b1c280c2e75116efe40cc13
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -48,3 +48,6 @@ import:
   version: ^v1.1.0
 - package: github.com/boltdb/bolt
   version: ^1.3.0
+- package: golang.org/x/crypto
+  subpackages:
+  - ssh/terminal

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/btcsuite/golangcrypto/ssh/terminal"
 	"github.com/decred/dcrutil/hdkeychain"
 	"github.com/decred/dcrwallet/walletseed"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 // ProvideSeed is used to prompt for the wallet seed which maybe required during


### PR DESCRIPTION
This change adds support for illumos (and probably Solaris) operating
systems by switching from the outdated btcsuite fork of
golang.org/x/crypto/ssh/terminal to the upstream repo.

Closes #556.