### PR TITLE
Add stakePoolEnabled check

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -982,6 +982,7 @@ func (w *Wallet) handleWinningTickets(dbtx walletdb.ReadWriteTx, blockHash *chai
 			blockHeight,
 			tickets,
 			w.VoteBits,
+			w.stakePoolEnabled,
 			w.AllowHighFees,
 		)
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -297,6 +297,7 @@ func (w *Wallet) SetTicketPurchasingEnabled(flag bool) error {
 				w.CurrentVotingInfo.BlockHeight,
 				w.CurrentVotingInfo.Tickets,
 				w.VoteBits,
+				w.stakePoolEnabled,
 				w.AllowHighFees,
 			)
 			return err


### PR DESCRIPTION
When not in stake pool mode, use the config setting of voteBits instead of anything saved in the sstx record.

We will also still need to fix a way for stakepool users to seamlessly update their vote bits when versions are bumped.