### PR TITLE
Add Go 1.8 support, remove 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6.x
   - 1.7.x
+  - 1.8.x
 sudo: false
 before_install:
   - GLIDE_TAG=v0.12.3

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ https://github.com/decred/decred-release/releases
 
 Building or updating from source requires the following build dependencies:
 
-- **Go 1.6 or 1.7**
+- **Go 1.7 or 1.8**
 
   Installation instructions can be found here: http://golang.org/doc/install.
   It is recommended to add `$GOPATH/bin` to your `PATH` at this point.

--- a/wtxmgr/tx_test.go
+++ b/wtxmgr/tx_test.go
@@ -166,7 +166,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstRecvTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -194,7 +194,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstRecvTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -223,7 +223,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstRecvTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeREgular,
@@ -250,7 +250,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstRecvTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -267,7 +267,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstRecvTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstRecvTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -296,7 +296,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstDoubleSpendTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstDoubleSpendTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
@@ -356,7 +356,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
@@ -383,12 +383,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
 				}: {},
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -411,12 +411,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
 				}: {},
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -433,12 +433,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unc: 0,
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
 				}: {},
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,
@@ -455,12 +455,12 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 			bal: 0,
 			unc: dcrutil.Amount(TstSpendingTx.MsgTx().TxOut[0].Value + TstSpendingTx.MsgTx().TxOut[1].Value),
 			unspents: map[wire.OutPoint]struct{}{
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 0,
 					Tree:  dcrutil.TxTreeRegular,
 				}: {},
-				wire.OutPoint{
+				{
 					Hash:  *TstSpendingTx.Sha(),
 					Index: 1,
 					Tree:  dcrutil.TxTreeRegular,


### PR DESCRIPTION
Go 1.8 is out and by policy we only support the latest two Go releases.