### PR TITLE
Fix extended vote bit setting for stakepool wallets

### DIFF
--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -675,6 +675,9 @@ func (s *StakeStore) generateVote(ns walletdb.ReadWriteBucket, waddrmgrNs wallet
 
 	if stakePoolEnabled && sstxRecord.voteBitsSet {
 		voteBits.Bits = sstxRecord.voteBits
+		// This is not correct and therefore commented out.  For now, this will set
+		// extended voteBits to whatever the default is to the wallet.
+		// voteBits.ExtendedBits = sstxRecord.voteBitsExt
 	}
 
 	// Store the sstx pubkeyhashes and amounts as found in the transaction

--- a/wstakemgr/stake.go
+++ b/wstakemgr/stake.go
@@ -675,7 +675,6 @@ func (s *StakeStore) generateVote(ns walletdb.ReadWriteBucket, waddrmgrNs wallet
 
 	if stakePoolEnabled && sstxRecord.voteBitsSet {
 		voteBits.Bits = sstxRecord.voteBits
-		voteBits.ExtendedBits = sstxRecord.voteBitsExt
 	}
 
 	// Store the sstx pubkeyhashes and amounts as found in the transaction


### PR DESCRIPTION
Previously it was incorrect pulling extended vote bits from the database which
caused mangling of extended vote bits, which in turn, caused invalid vote versions.