### PR TITLE
Add method to retrieve an account branch xpub.

### DIFF
--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -701,6 +701,26 @@ func (m *Manager) AccountProperties(ns walletdb.ReadBucket, account uint32) (*Ac
 	return props, nil
 }
 
+// AccountBranchExtendedPubKey returns the extended public key of an account's
+// branch, which then can be used to derive addreses belonging to the account.
+func (m *Manager) AccountBranchExtendedPubKey(dbtx walletdb.ReadTx, account, branch uint32) (*hdkeychain.ExtendedKey, error) {
+	ns := dbtx.ReadBucket(waddrmgrBucketKey)
+	if account == ImportedAddrAccount {
+		const str = "the imported account does not contain an extended key"
+		return nil, apperrors.E{ErrorCode: apperrors.ErrInvalidAccount, Description: str, Err: nil}
+	}
+	acctInfo, err := m.loadAccountInfo(ns, account)
+	if err != nil {
+		return nil, err
+	}
+	xpub, err := acctInfo.acctKeyPub.Child(branch)
+	if err != nil {
+		const str = "failed to derive child xpub"
+		return nil, apperrors.E{ErrorCode: apperrors.ErrKeyChain, Description: str, Err: err}
+	}
+	return xpub, nil
+}
+
 // deriveKeyFromPath returns either a public or private derived extended key
 // based on the private flag for the given an account, branch, and index.
 //

--- a/wallet/udb/initialize.go
+++ b/wallet/udb/initialize.go
@@ -23,15 +23,15 @@ func createBucketError(err error, bucketName string) error {
 // does not require any upgrades to use.
 func Initialize(db walletdb.DB, params *chaincfg.Params, seed, pubPass, privPass []byte, unsafeMainNet bool) error {
 	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs, err := tx.CreateTopLevelBucket([]byte(waddrmgrBucketKey))
+		addrmgrNs, err := tx.CreateTopLevelBucket(waddrmgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "address manager")
 		}
-		txmgrNs, err := tx.CreateTopLevelBucket([]byte(wtxmgrBucketKey))
+		txmgrNs, err := tx.CreateTopLevelBucket(wtxmgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "transaction store")
 		}
-		stakemgrNs, err := tx.CreateTopLevelBucket([]byte(wstakemgrBucketKey))
+		stakemgrNs, err := tx.CreateTopLevelBucket(wstakemgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "stake store")
 		}
@@ -74,15 +74,15 @@ func Initialize(db walletdb.DB, params *chaincfg.Params, seed, pubPass, privPass
 // with the latest version and does not require any upgrades to use.
 func InitializeWatchOnly(db walletdb.DB, params *chaincfg.Params, hdPubKey string, pubPass []byte) error {
 	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs, err := tx.CreateTopLevelBucket([]byte(waddrmgrBucketKey))
+		addrmgrNs, err := tx.CreateTopLevelBucket(waddrmgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "address manager")
 		}
-		txmgrNs, err := tx.CreateTopLevelBucket([]byte(wtxmgrBucketKey))
+		txmgrNs, err := tx.CreateTopLevelBucket(wtxmgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "transaction store")
 		}
-		stakemgrNs, err := tx.CreateTopLevelBucket([]byte(wstakemgrBucketKey))
+		stakemgrNs, err := tx.CreateTopLevelBucket(wstakemgrBucketKey)
 		if err != nil {
 			return createBucketError(err, "stake store")
 		}

--- a/wallet/udb/migration.go
+++ b/wallet/udb/migration.go
@@ -12,10 +12,10 @@ import (
 
 // Old package namespace bucket keys.  These are still used as of the very first
 // unified database layout.
-const (
-	waddrmgrBucketKey  = "waddrmgr"
-	wtxmgrBucketKey    = "wtxmgr"
-	wstakemgrBucketKey = "wstakemgr"
+var (
+	waddrmgrBucketKey  = []byte("waddrmgr")
+	wtxmgrBucketKey    = []byte("wtxmgr")
+	wstakemgrBucketKey = []byte("wstakemgr")
 )
 
 // NeedsMigration checks whether the database needs to be converted to the
@@ -35,9 +35,9 @@ func NeedsMigration(db walletdb.DB) (bool, error) {
 // performed.
 func Migrate(db walletdb.DB, params *chaincfg.Params) error {
 	return walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		addrmgrNs := tx.ReadWriteBucket([]byte(waddrmgrBucketKey))
-		txmgrNs := tx.ReadWriteBucket([]byte(wtxmgrBucketKey))
-		stakemgrNs := tx.ReadWriteBucket([]byte(wstakemgrBucketKey))
+		addrmgrNs := tx.ReadWriteBucket(waddrmgrBucketKey)
+		txmgrNs := tx.ReadWriteBucket(wtxmgrBucketKey)
+		stakemgrNs := tx.ReadWriteBucket(wstakemgrBucketKey)
 
 		stakeStoreVersionName := []byte("stakestorever")
 

--- a/wallet/udb/open.go
+++ b/wallet/udb/open.go
@@ -41,8 +41,8 @@ func Open(db walletdb.DB, params *chaincfg.Params, pubPass []byte) (addrMgr *Man
 			return apperrors.E{ErrorCode: apperrors.ErrUnknownVersion, Description: str}
 		}
 
-		addrmgrNs := tx.ReadBucket([]byte(waddrmgrBucketKey))
-		stakemgrNs := tx.ReadBucket([]byte(wstakemgrBucketKey))
+		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
+		stakemgrNs := tx.ReadBucket(wstakemgrBucketKey)
 
 		addrMgr, err = loadManager(addrmgrNs, pubPass, params)
 		if err != nil {

--- a/wallet/udb/stakevalidation_test.go
+++ b/wallet/udb/stakevalidation_test.go
@@ -47,8 +47,8 @@ func TestStakeInvalidationOfTip(t *testing.T) {
 	const balanceFlag = BFBalanceSpendable
 
 	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket([]byte(wtxmgrBucketKey))
-		addrmgrNs := tx.ReadBucket([]byte(waddrmgrBucketKey))
+		ns := tx.ReadWriteBucket(wtxmgrBucketKey)
+		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 
 		err := s.InsertMemPoolTx(ns, block1TxRec)
 		if err != nil {
@@ -195,8 +195,8 @@ func TestStakeInvalidationTxInsert(t *testing.T) {
 	}
 
 	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
-		ns := tx.ReadWriteBucket([]byte(wtxmgrBucketKey))
-		addrmgrNs := tx.ReadBucket([]byte(waddrmgrBucketKey))
+		ns := tx.ReadWriteBucket(wtxmgrBucketKey)
+		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 
 		headerData := makeHeaderDataSlice(block1Header, block2Header, block3Header)
 		err = s.InsertMainChainHeaders(ns, addrmgrNs, headerData)

--- a/wallet/udb/txcommon_test.go
+++ b/wallet/udb/txcommon_test.go
@@ -42,11 +42,11 @@ func setup() (db walletdb.DB, s *Store, teardown func(), err error) {
 		return
 	}
 	defer tx.Commit()
-	ns, err := tx.CreateTopLevelBucket([]byte(wtxmgrBucketKey))
+	ns, err := tx.CreateTopLevelBucket(wtxmgrBucketKey)
 	if err != nil {
 		return
 	}
-	_, err = tx.CreateTopLevelBucket([]byte(waddrmgrBucketKey))
+	_, err = tx.CreateTopLevelBucket(waddrmgrBucketKey)
 	if err != nil {
 		return
 	}

--- a/wallet/udb/txdb_test.go
+++ b/wallet/udb/txdb_test.go
@@ -32,7 +32,7 @@ func TestCursorDeletions(t *testing.T) {
 			valueUnminedCredit(2e8, true, 0, false, scriptTypeP2PKH, 0, 0, 0),
 		}
 
-		ns := dbtx.ReadWriteBucket([]byte(wtxmgrBucketKey))
+		ns := dbtx.ReadWriteBucket(wtxmgrBucketKey)
 		for i := range ks {
 			err = putRawUnminedCredit(ns, ks[i], vs[i])
 			if err != nil {
@@ -89,7 +89,7 @@ func TestBoltDBCursorDeletion(t *testing.T) {
 	}
 
 	err = db.Update(func(dbtx *bolt.Tx) error {
-		b, err := dbtx.CreateBucket([]byte(wtxmgrBucketKey))
+		b, err := dbtx.CreateBucket(wtxmgrBucketKey)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This new method takes a read-only database transaction, rather than
the bucket.  This differs from the rest of the API which currently
takes namespace buckets themselves, but this is the direction that I
want to take the API.

To remove some generated garbage created by creating the bucket key
bytes, do the conversion once and save the keys as package variables.
Use these consistently across the entire package.

Closes #602 