### PR TITLE
Preallocate the exact number of bytes if known.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -680,6 +680,7 @@ func (s *walletServer) ConstructTransaction(ctx context.Context, req *pb.Constru
 	}
 
 	var txBuf bytes.Buffer
+	txBuf.Grow(tx.Tx.SerializeSize())
 	err = tx.Tx.Serialize(&txBuf)
 	if err != nil {
 		return nil, translateError(err)

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -526,6 +526,7 @@ func (w *Wallet) txToOutputsInternal(dbtx walletdb.ReadWriteTx, outputs []*wire.
 	// TODO: this can be improved by not using the same codepath as notified
 	// relevant transactions, since this does a lot of extra work.
 	var buf bytes.Buffer
+	buf.Grow(tx.Tx.SerializeSize())
 	err = tx.Tx.Serialize(&buf)
 	if err != nil {
 		return nil, err

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -107,6 +107,7 @@ func makeTxSummary(dbtx walletdb.ReadTx, w *Wallet, details *udb.TxDetails) Tran
 	serializedTx := details.SerializedTx
 	if serializedTx == nil {
 		var buf bytes.Buffer
+		buf.Grow(details.MsgTx.SerializeSize())
 		err := details.MsgTx.Serialize(&buf)
 		if err != nil {
 			log.Errorf("Transaction serialization: %v", err)

--- a/wallet/udb/stakedb.go
+++ b/wallet/udb/stakedb.go
@@ -260,6 +260,7 @@ func serializeSStxRecord(record *sstxRecord, voteBits stake.VoteBits) ([]byte, e
 
 	// Serialize and write transaction.
 	var b bytes.Buffer
+	b.Grow(msgTx.SerializeSize())
 	err := msgTx.Serialize(&b)
 	if err != nil {
 		return buf, err

--- a/wallet/udb/tx_test.go
+++ b/wallet/udb/tx_test.go
@@ -88,6 +88,7 @@ func testStore() (*Store, func(), error) {
 
 func serializeTx(tx *dcrutil.Tx) []byte {
 	var buf bytes.Buffer
+	buf.Grow(tx.MsgTx().SerializeSize())
 	err := tx.MsgTx().Serialize(&buf)
 	if err != nil {
 		panic(err)

--- a/wallet/udb/txcommon_test.go
+++ b/wallet/udb/txcommon_test.go
@@ -95,6 +95,7 @@ func (g *blockGenerator) generate(voteBits uint16) *wire.BlockHeader {
 
 func makeHeaderData(h *wire.BlockHeader) BlockHeaderData {
 	var b bytes.Buffer
+	b.Grow(wire.MaxBlockHeaderPayload)
 	err := h.Serialize(&b)
 	if err != nil {
 		panic(err)

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -136,8 +136,10 @@ func NewTxRecord(serializedTx []byte, received time.Time) (*TxRecord, error) {
 // into the store.
 func NewTxRecordFromMsgTx(msgTx *wire.MsgTx, received time.Time) (*TxRecord,
 	error) {
-	buf := bytes.NewBuffer(make([]byte, 0, msgTx.SerializeSize()))
-	err := msgTx.Serialize(buf)
+
+	var buf bytes.Buffer
+	buf.Grow(msgTx.SerializeSize())
+	err := msgTx.Serialize(&buf)
 	if err != nil {
 		str := "failed to serialize transaction"
 		return nil, storeError(apperrors.ErrInput, str, err)

--- a/wallet/udb/txquery_test.go
+++ b/wallet/udb/txquery_test.go
@@ -191,10 +191,13 @@ func equalTxDetails(t *testing.T, got, exp *TxDetails) {
 
 func equalTxs(t *testing.T, got, exp *wire.MsgTx) {
 	var bufGot, bufExp bytes.Buffer
+
+	bufGot.Grow(got.SerializeSize())
 	err := got.Serialize(&bufGot)
 	if err != nil {
 		t.Fatal(err)
 	}
+	bufExp.Grow(exp.SerializeSize())
 	err = exp.Serialize(&bufExp)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
While here, convert existing NewBuffer(make()) users to Grow().