### PR TITLE
rpc: StartConsesusRpc - set loader chain client

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1555,6 +1555,8 @@ private passphrase must be passed as a parameter when performing this action.
 
 - `FailedPrecondition`: Wallet has not been loaded.
 
+- `FailedPrecondition`: Chain client is not available.
+
 - `FailedPrecondition`: Ticket buyer is already started.
 
 **Stability:** Unstable

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -1620,6 +1620,7 @@ func (s *loaderServer) StartConsensusRpc(ctx context.Context, req *pb.StartConse
 	}
 
 	s.rpcClient = rpcClient
+	s.loader.SetChainClient(rpcClient.Client)
 
 	return &pb.StartConsensusRpcResponse{}, nil
 }


### PR DESCRIPTION
When started with `--noinitialload`, the loader chain client is not being set, causing RPC calls from Paymetheus to fail.

Fixed by setting the loader chain client in `StartConsensusRpc`.