### PR TITLE
Prevent panic in JSON-RPC server.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -210,10 +210,10 @@ type lazyHandler func() (interface{}, *dcrjson.RPCError)
 // returning a closure that will execute it with the (required) wallet and
 // (optional) consensus RPC server.  If no handlers are found and the
 // chainClient is not nil, the returned handler performs RPC passthrough.
-func lazyApplyHandler(request *dcrjson.Request, w *wallet.Wallet, chainClient *chain.RPCClient, unsafeMainNet bool) lazyHandler {
+func lazyApplyHandler(request *dcrjson.Request, activeNet *chaincfg.Params, w *wallet.Wallet, chainClient *chain.RPCClient, unsafeMainNet bool) lazyHandler {
 	handlerData, ok := rpcHandlers[request.Method]
 	if ok && handlerData.requireUnsafeOnMainNet &&
-		w.ChainParams() == &chaincfg.MainNetParams && !unsafeMainNet {
+		activeNet == &chaincfg.MainNetParams && !unsafeMainNet {
 		return func() (interface{}, *dcrjson.RPCError) {
 			return nil, &ErrMainNetSafety
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -173,7 +173,7 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *legacyrpc.Serv
 			MaxWebsocketClients: cfg.LegacyRPCMaxWebsockets,
 			UnsafeMainNet:       cfg.UnsafeMainNet,
 		}
-		legacyServer = legacyrpc.NewServer(&opts, walletLoader, listeners)
+		legacyServer = legacyrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
 	}
 
 	// Error when neither the GRPC nor legacy RPC servers can be started.


### PR DESCRIPTION
This fixes panics caused by dereferencing a nil wallet to determine if
an RPC that requires the --unsafemainnet flag when mainnet is the
active network.  The fix is to pass in the active network parameters
to the RPC server and use those rather than trying to access them
through the nil wallet.

Fixes #650.