### PR TITLE
Fix an off by one in the address buffer.

### DIFF
--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -181,7 +181,9 @@ type accountInfo struct {
 }
 
 // AccountProperties contains properties associated with each account, such as
-// the account name, number, and the nubmer of derived and imported keys.
+// the account name, number, and the nubmer of derived and imported keys.  If no
+// address usage has been recorded on any of the external or internal branches,
+// the child index is ^uint32(0).
 type AccountProperties struct {
 	AccountNumber         uint32
 	AccountName           string

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -140,8 +140,10 @@ func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byt
 			return apperrors.E{ErrorCode: apperrors.ErrKeyChain, Description: str, Err: err}
 		}
 
-		// Determine the last used internal and external address indexes.
-		var lastUsedExtIndex, lastUsedIntIndex uint32
+		// Determine the last used internal and external address indexes.  The
+		// sentinel value ^uint32(0) means that there has been no usage at all.
+		lastUsedExtIndex := ^uint32(0)
+		lastUsedIntIndex := ^uint32(0)
 		for child := uint32(0); child < hdkeychain.HardenedKeyStart; child++ {
 			xpubChild, err := xpubExtBranch.Child(child)
 			if err == hdkeychain.ErrInvalidChild {

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -99,7 +99,7 @@ func verifyV2Upgrade(t *testing.T, db walletdb.DB) {
 			totalAddrs uint32
 			lastUsed   uint32
 		}{
-			{0, 0},
+			{^uint32(0), ^uint32(0)},
 			{20, 18},
 			{20, 19},
 			{20, 19},


### PR DESCRIPTION
This fixes two issues:

1. The old code would always hand out new addresses starting at the
   discovered last used child index.  This could result in accidental
   address reuse after restarting the wallet.

2. When the address gap limit was exhausted and the cursor wrapped
   around to the beginning, the next returned address would skip over
   the first returned address, because it was used.

To fix this, there needed to be a way to mark no addresses as used,
instead of recording child 0 as used.  This commit makes a change to
the database upgrade code and records the last used child index
^uint32(0) in this case.  This had to be a change to previous update
code as there is no way to otherwise distinguish between no use at all
or usage of just the 0th child after the upgrade has completed.

Fixes #651.