### PR TITLE
Remove a silly error from accountsyncaddressindex.

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -321,13 +321,13 @@ func (w *Wallet) ExtendWatchedAddresses(account, branch, child uint32) error {
 
 	if client := w.ChainClient(); client != nil {
 		gapLimit := uint32(w.gapLimit)
-		lastWatched := lastUsed + gapLimit - 1
+		lastWatched := lastUsed + gapLimit
 		if child <= lastWatched {
 			// No need to derive anything more.
 			return nil
 		}
 		additionalAddrs := child - lastWatched
-		addrs, err := deriveChildAddresses(branchXpub, lastUsed+gapLimit,
+		addrs, err := deriveChildAddresses(branchXpub, lastUsed+1+gapLimit,
 			additionalAddrs, w.chainParams)
 		if err != nil {
 			return err


### PR DESCRIPTION
The accountsyncaddressindex RPC only extends watched addresses now and
doesn't change any actual index that the account is synced to.
Therefore there is no reason to bother returning an error when a child
index behind the last used address is passed.

This was caught because an account branch without any address use
(lastused=^uint32(0)) was hitting an error when any valid child index
was being passed.

While here, add an additional error to prevent trying to sync to child
indexes for hardened keys.