### PR TITLE
Allow reading passphases from piped input.

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"unicode"
@@ -120,7 +121,17 @@ func PassPrompt(reader *bufio.Reader, prefix string, confirm bool) ([]byte, erro
 	prompt := fmt.Sprintf("%s: ", prefix)
 	for {
 		fmt.Print(prompt)
-		pass, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+		var pass []byte
+		var err error
+		fd := int(os.Stdin.Fd())
+		if terminal.IsTerminal(fd) {
+			pass, err = terminal.ReadPassword(fd)
+		} else {
+			pass, err = reader.ReadBytes('\n')
+			if err == io.EOF {
+				err = nil
+			}
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This change checks if stdin is a tty or not, and when it is not, it just reads
the input from stdin without removing terminal echo.  This allows passphrases to
be piped to the process.

For users running into difficult starting dcrwallet from startup scripts or
services due to the passphrase prompt when enabling the ticket buyer, it is now
possible to use the pipe as a workaround:

```
dcrwallet --enableticketbuyer < passfile
echo $pass | dcrwallet --enableticketbuyer
```

Fixes #690 