### PR TITLE
Raise default fees back to 0.01/kB.

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,7 +48,7 @@ const (
 
 	// ticket buyer options
 	defaultMaxFee                    dcrutil.Amount = 1e7
-	defaultMinFee                    dcrutil.Amount = 1e5
+	defaultMinFee                    dcrutil.Amount = 1e6
 	defaultMaxPriceScale                            = 0.0
 	defaultAvgVWAPPriceDelta                        = 2880
 	defaultMaxPerBlock                              = 5

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -927,7 +927,7 @@ func (w *Wallet) handleMissedTickets(dbtx walletdb.ReadWriteTx, blockHash *chain
 
 	if blockHeight >= w.chainParams.StakeValidationHeight+1 {
 		ntfns, err := w.StakeMgr.HandleMissedTicketsNtfn(stakemgrNs, addrmgrNs,
-			blockHash, blockHeight, tickets, w.AllowHighFees)
+			blockHash, blockHeight, tickets, w.RelayFee(), w.AllowHighFees)
 
 		if ntfns != nil {
 			// Send notifications for newly created revocations by the RPC.

--- a/wallet/txrules/rules.go
+++ b/wallet/txrules/rules.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultRelayFeePerKb is the default minimum relay fee policy for a mempool.
-const DefaultRelayFeePerKb dcrutil.Amount = 1e5
+const DefaultRelayFeePerKb dcrutil.Amount = 1e6
 
 // IsDustAmount determines whether a transaction output value and script length would
 // cause the output to be considered dust.  Transactions with dust outputs are


### PR DESCRIPTION
Users can still lower the fees on their own but until the majority of
the network has upgraded to the new mempool policy defaults, lowering
these fees can cause transactions to be rejected and votes to be
missed.

While here, remove the hardcoded constant used for revocations so
these are also created using the wallet's current relay fee.

Fixes #694.