### PR TITLE
Remove automatic rescans for discovered scripts.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -673,7 +673,6 @@ func (w *Wallet) processTransaction(dbtx walletdb.ReadWriteTx, serializedTx []by
 						if err != nil {
 							return err
 						}
-						w.Rescan(chainClient, w.chainParams.GenesisHash)
 					}
 				}
 			}


### PR DESCRIPTION
If previous p2sh outputs must be discovered, a second rescan should be
manually performed.

Fixes #707.