### PR TITLE
Upgrade created watching only DBs to latest version.

### DIFF
--- a/wallet/udb/initialize.go
+++ b/wallet/udb/initialize.go
@@ -107,15 +107,15 @@ func InitializeWatchOnly(db walletdb.DB, params *chaincfg.Params, hdPubKey strin
 		if err != nil {
 			return createBucketError(err, "metadata")
 		}
-		return unifiedDBMetadata{}.putVersion(metadataBucket, DBVersion)
+		return unifiedDBMetadata{}.putVersion(metadataBucket, initialVersion)
 	})
 	switch err.(type) {
 	case nil:
-		return nil
 	case apperrors.E:
 		return err
 	default:
 		const str = "db update failed"
 		return apperrors.E{ErrorCode: apperrors.ErrDatabase, Description: str, Err: err}
 	}
+	return Upgrade(db, pubPass)
 }


### PR DESCRIPTION
This fixes a panic that was caused by creating watching only databases
marked with the latest DB version when they really were in fact the
initial version of the udb database schema.

Watching only wallet databases that were created using the faulty code
(such as that found in the 1.0.0 and 1.0.1 releases) will not open
correctly due to the incorrectly-recorded database version and must be
recreated.

Fixes #725.