### PR TITLE
Enable the gRPC server by default.

### DIFF
--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -93,7 +93,7 @@ func init() {
 	if opts.RPCConnect == "" {
 		fatalf("RPC hostname[:port] is required")
 	}
-	rpcConnect, err := cfgutil.NormalizeAddress(opts.RPCConnect, activeNet.RPCServerPort)
+	rpcConnect, err := cfgutil.NormalizeAddress(opts.RPCConnect, activeNet.JSONRPCServerPort)
 	if err != nil {
 		fatalf("Invalid RPC network address `%v`: %v", opts.RPCConnect, err)
 	}

--- a/netparams/params.go
+++ b/netparams/params.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -11,30 +11,34 @@ import "github.com/decred/dcrd/chaincfg"
 // network and test networks.
 type Params struct {
 	*chaincfg.Params
-	RPCClientPort string
-	RPCServerPort string
+	JSONRPCClientPort string
+	JSONRPCServerPort string
+	GRPCServerPort    string
 }
 
 // MainNetParams contains parameters specific running dcrwallet and
 // dcrd on the main network (wire.MainNet).
 var MainNetParams = Params{
-	Params:        &chaincfg.MainNetParams,
-	RPCClientPort: "9109",
-	RPCServerPort: "9110",
+	Params:            &chaincfg.MainNetParams,
+	JSONRPCClientPort: "9109",
+	JSONRPCServerPort: "9110",
+	GRPCServerPort:    "9111",
 }
 
 // TestNet2Params contains parameters specific running dcrwallet and
 // dcrd on the test network (version 2) (wire.TestNet2).
 var TestNet2Params = Params{
-	Params:        &chaincfg.TestNet2Params,
-	RPCClientPort: "19109",
-	RPCServerPort: "19110",
+	Params:            &chaincfg.TestNet2Params,
+	JSONRPCClientPort: "19109",
+	JSONRPCServerPort: "19110",
+	GRPCServerPort:    "19111",
 }
 
 // SimNetParams contains parameters specific to the simulation test network
 // (wire.SimNet).
 var SimNetParams = Params{
-	Params:        &chaincfg.SimNetParams,
-	RPCClientPort: "19556",
-	RPCServerPort: "19557",
+	Params:            &chaincfg.SimNetParams,
+	JSONRPCClientPort: "19556",
+	JSONRPCServerPort: "19557",
+	GRPCServerPort:    "19558",
 }

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1346,7 +1346,7 @@ func (s *loaderServer) StartConsensusRpc(ctx context.Context, req *pb.StartConse
 	}
 
 	networkAddress, err := cfgutil.NormalizeAddress(req.NetworkAddress,
-		s.activeNet.RPCClientPort)
+		s.activeNet.JSONRPCClientPort)
 	if err != nil {
 		return nil, grpc.Errorf(codes.InvalidArgument,
 			"Network address is ill-formed: %v", err)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -133,8 +133,8 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *legacyrpc.Serv
 			return tls.Listen(net, laddr, tlsConfig)
 		}
 
-		if len(cfg.ExperimentalRPCListeners) != 0 {
-			listeners := makeListeners(cfg.ExperimentalRPCListeners, net.Listen)
+		if len(cfg.GRPCListeners) != 0 {
+			listeners := makeListeners(cfg.GRPCListeners, net.Listen)
 			if len(listeners) == 0 {
 				err := errors.New("failed to create listeners for RPC server")
 				return nil, nil, err
@@ -153,11 +153,9 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *legacyrpc.Serv
 			for _, lis := range listeners {
 				lis := lis
 				go func() {
-					log.Infof("Experimental RPC server listening on %s",
-						lis.Addr())
+					log.Infof("gRPC server listening on %s", lis.Addr())
 					err := server.Serve(lis)
-					log.Tracef("Finished serving expimental RPC: %v",
-						err)
+					log.Tracef("Finished serving gRPC: %v", err)
 				}()
 			}
 		}

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -60,12 +60,20 @@
 ; already exists.
 ; onetimetlskey=0
 
-; Specify the interfaces for the RPC server listen on.  One rpclisten address
-; per line.  Multiple rpclisten options may be set in the same configuration,
+; Specify the interfaces for the RPC server listen on, one listen address
+; per line.  Multiple options may be set in the same configuration,
 ; and each will be used to listen for connections.  NOTE: The default port is
 ; modified by some options such as 'testnet', so it is recommended to not
 ; specify a port and allow a proper default to be chosen unless you have a
 ; specific reason to do otherwise.
+;
+; These option semantics apply to both the rpclisten and grpclisten options.
+; rpclisten sets the listeners for the legacy JSON-RPC server while grpclisten
+; modifies the listeners for the gRPC server.
+;
+; By default, the legacy JSON-RPC server listens on localhost addresses on port
+; 9110, and the gRPC server listens on localhost addresses on port 9111.
+;
 ; rpclisten=                ; all interfaces on default port
 ; rpclisten=0.0.0.0         ; all ipv4 interfaces on default port
 ; rpclisten=::              ; all ipv6 interfaces on default port
@@ -78,6 +86,10 @@
 ; rpclisten=:18337          ; all interfaces on non-standard port 18337
 ; rpclisten=0.0.0.0:18337   ; all ipv4 interfaces on non-standard port 18337
 ; rpclisten=[::]:18337      ; all ipv6 interfaces on non-standard port 18337
+
+; Disable the legacy (JSON-RPC) server or gRPC servers
+; nolegacyrpc=0
+; nogrpc=0
 
 ; Legacy (Bitcoin Core-compatible) RPC listener addresses.  Addresses without a
 ; port specified use the same default port as the new server.  Listeners cannot


### PR DESCRIPTION
The gRPC server defaults binding to localhost addresses on port 9111
(mainnet), 19111 (testnet), and 19558 (simnet).

The experimentalrpclisten option has been renamed to grpclisten.

To disable the server, a nogrpc option has been added.  For
consistency with the legacy JSON-RPC server, a nolegacyrpc option has
also been added.

Closes #742.
Closes #743.