### PR TITLE
Comment out EstimateStakeDiff request

### DIFF
--- a/ticketbuyer/buyer.go
+++ b/ticketbuyer/buyer.go
@@ -409,7 +409,6 @@ type PurchaseStats struct {
 	Height        int64
 	PriceMaxScale float64
 	PriceAverage  dcrutil.Amount
-	PriceNext     dcrutil.Amount
 	PriceCurrent  dcrutil.Amount
 	Purchased     int
 	LeftWindow    int
@@ -523,19 +522,19 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	ps.PriceCurrent = nextStakeDiff
 	t.ticketPrice = nextStakeDiff
 	ps.TicketPrice = nextStakeDiff
+	/*
+		sDiffEsts, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
+		if err != nil {
+			return ps, err
+		}
+		ps.PriceNext, err = dcrutil.NewAmount(sDiffEsts.Expected)
+		if err != nil {
+			return ps, err
+		}
 
-	sDiffEsts, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
-	if err != nil {
-		return ps, err
-	}
-	ps.PriceNext, err = dcrutil.NewAmount(sDiffEsts.Expected)
-	if err != nil {
-		return ps, err
-	}
-
-	log.Tracef("Estimated stake diff: (min: %v, expected: %v, max: %v)",
-		sDiffEsts.Min, sDiffEsts.Expected, sDiffEsts.Max)
-
+		log.Tracef("Estimated stake diff: (min: %v, expected: %v, max: %v)",
+			sDiffEsts.Min, sDiffEsts.Expected, sDiffEsts.Max)
+	*/
 	// Set the max price to the configuration parameter that is lower
 	// Absolute or relative max price
 	var maxPriceAmt dcrutil.Amount

--- a/ticketbuyer/buyer.go
+++ b/ticketbuyer/buyer.go
@@ -409,6 +409,7 @@ type PurchaseStats struct {
 	Height        int64
 	PriceMaxScale float64
 	PriceAverage  dcrutil.Amount
+	PriceNext     dcrutil.Amount
 	PriceCurrent  dcrutil.Amount
 	Purchased     int
 	LeftWindow    int
@@ -522,11 +523,9 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	ps.PriceCurrent = nextStakeDiff
 	t.ticketPrice = nextStakeDiff
 	ps.TicketPrice = nextStakeDiff
-	/*
-		sDiffEsts, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
-		if err != nil {
-			return ps, err
-		}
+	sDiffEsts, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
+	if err == nil {
+		return ps, err
 		ps.PriceNext, err = dcrutil.NewAmount(sDiffEsts.Expected)
 		if err != nil {
 			return ps, err
@@ -534,7 +533,8 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 
 		log.Tracef("Estimated stake diff: (min: %v, expected: %v, max: %v)",
 			sDiffEsts.Min, sDiffEsts.Expected, sDiffEsts.Max)
-	*/
+	}
+
 	// Set the max price to the configuration parameter that is lower
 	// Absolute or relative max price
 	var maxPriceAmt dcrutil.Amount

--- a/ticketbuyer/buyer.go
+++ b/ticketbuyer/buyer.go
@@ -523,9 +523,9 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	ps.PriceCurrent = nextStakeDiff
 	t.ticketPrice = nextStakeDiff
 	ps.TicketPrice = nextStakeDiff
+
 	sDiffEsts, err := t.dcrdChainSvr.EstimateStakeDiff(nil)
 	if err == nil {
-		return ps, err
 		ps.PriceNext, err = dcrutil.NewAmount(sDiffEsts.Expected)
 		if err != nil {
 			return ps, err


### PR DESCRIPTION
Due to known issue with interval size being greater than ticket maturity 
length (144 and 16, respectively on testnet), estimatestakediff request 
is not allowed.

https://github.com/decred/dcrd/blob/0d48ca0105e0d512f89629e39ef841a4194c448b/blockchain/difficulty.go#L1351-L1356

Instead of removing the request, we will simply only proceed with using it if no err is received.
