### PR TITLE
Drop default relay fee to 0.001 DCR/kB.

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ const (
 
 	// ticket buyer options
 	defaultMaxFee                    dcrutil.Amount = 1e7
-	defaultMinFee                    dcrutil.Amount = 1e6
+	defaultMinFee                    dcrutil.Amount = 1e5
 	defaultMaxPriceScale                            = 0.0
 	defaultAvgVWAPPriceDelta                        = 2880
 	defaultMaxPerBlock                              = 5

--- a/wallet/txrules/rules.go
+++ b/wallet/txrules/rules.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultRelayFeePerKb is the default minimum relay fee policy for a mempool.
-const DefaultRelayFeePerKb dcrutil.Amount = 1e6
+const DefaultRelayFeePerKb dcrutil.Amount = 1e5
 
 // IsDustAmount determines whether a transaction output value and script length would
 // cause the output to be considered dust.  Transactions with dust outputs are

--- a/wallet/udb/stake.go
+++ b/wallet/udb/stake.go
@@ -25,10 +25,6 @@ import (
 	"github.com/decred/dcrwallet/walletdb"
 )
 
-const (
-	revocationFeePerKB dcrutil.Amount = 1e6
-)
-
 func stakeStoreError(code apperrors.Code, str string, err error) error {
 	return apperrors.E{ErrorCode: code, Description: str, Err: err}
 }
@@ -786,8 +782,9 @@ func (s *StakeStore) getSSRtxs(ns walletdb.ReadBucket, sstxHash *chainhash.Hash)
 // GenerateRevocation generates a revocation (SSRtx), signs it, and
 // submits it by SendRawTransaction. It also stores a record of it
 // in the local database.
-func (s *StakeStore) generateRevocation(ns walletdb.ReadWriteBucket, waddrmgrNs walletdb.ReadBucket, blockHash *chainhash.Hash,
-	height int64, sstxHash *chainhash.Hash, feePerKb dcrutil.Amount, allowHighFees bool) (*StakeNotification, error) {
+func (s *StakeStore) generateRevocation(ns walletdb.ReadWriteBucket, waddrmgrNs walletdb.ReadBucket,
+	blockHash *chainhash.Hash, height int64, sstxHash *chainhash.Hash, feePerKb dcrutil.Amount,
+	allowHighFees bool) (*StakeNotification, error) {
 
 	// 1. Fetch the SStx, then calculate all the values we'll need later for
 	// the generation of the SSRtx tx outputs.
@@ -809,7 +806,7 @@ func (s *StakeStore) generateRevocation(ns walletdb.ReadWriteBucket, waddrmgrNs 
 	// Calculate the fee to use for this revocation based on the fee
 	// per KB that is standard for mainnet.
 	revocationSizeEst := estimateSSRtxTxSize(1, len(sstxPkhs))
-	revocationFee := txrules.FeeForSerializeSize(revocationFeePerKB,
+	revocationFee := txrules.FeeForSerializeSize(feePerKb,
 		revocationSizeEst)
 
 	// 2. Add the only input.


### PR DESCRIPTION
This change was already done for version 1.0.0 but reverted back in
1.0.1 because not enough dcrd nodes had upgraded to make transactions
relay quickly across the network and be mined into blocks.  This is no
longer the case (since the stake v4 lock-in) and fees can again be
dropped to match that of the dcrd default mempool and relay policy.

Closes #749.