### PR TITLE
Improve error messages for failed address lookups.

### DIFF
--- a/wallet/udb/addressdb.go
+++ b/wallet/udb/addressdb.go
@@ -1157,7 +1157,7 @@ func forEachAccountAddress(ns walletdb.ReadBucket, account uint32, fn func(rowIn
 		addrRow, err := fetchAddressByHash(ns, k)
 		if err != nil {
 			if merr, ok := err.(apperrors.E); ok {
-				desc := fmt.Sprintf("failed to fetch address hash '%s': %v",
+				desc := fmt.Sprintf("failed to fetch address hash '%x': %v",
 					k, merr.Description)
 				merr.Description = desc
 				return merr
@@ -1188,7 +1188,7 @@ func forEachActiveAddress(ns walletdb.ReadBucket, fn func(rowInterface interface
 		// values.
 		addrRow, err := fetchAddressByHash(ns, k)
 		if merr, ok := err.(apperrors.E); ok {
-			desc := fmt.Sprintf("failed to fetch address hash '%s': %v",
+			desc := fmt.Sprintf("failed to fetch address hash '%x': %v",
 				k, merr.Description)
 			merr.Description = desc
 			return merr

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -772,7 +772,7 @@ func (m *Manager) loadAddress(ns walletdb.ReadBucket, address dcrutil.Address) (
 	if err != nil {
 		if merr, ok := err.(apperrors.E); ok {
 			desc := fmt.Sprintf("failed to fetch address '%s': %v",
-				address.ScriptAddress(), merr.Description)
+				address, merr.Description)
 			merr.Description = desc
 			return nil, merr
 		}


### PR DESCRIPTION
The previous error messages would format the lookup address or key in
an unreadable manner.