### PR TITLE
Add wallet APIs for controlling the gap limit policy.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1047,7 +1047,7 @@ func getNewAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 		return nil, err
 	}
 
-	addr, err := w.NewExternalAddress(account)
+	addr, err := w.NewExternalAddress(account, wallet.WithGapPolicyWrap())
 	if err != nil {
 		return nil, err
 	}
@@ -1091,7 +1091,7 @@ func getRawChangeAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error
 		return nil, err
 	}
 
-	addr, err := w.NewInternalAddress(account)
+	addr, err := w.NewChangeAddress(account)
 	if err != nil {
 		return nil, err
 	}
@@ -2032,7 +2032,7 @@ func redeemMultiSigOut(icmd interface{}, w *wallet.Wallet, chainClient *chain.RP
 		}
 	} else {
 		account := uint32(udb.DefaultAccountNum)
-		addr, err = w.NewInternalAddress(account)
+		addr, err = w.NewInternalAddress(account, wallet.WithGapPolicyWrap())
 		if err != nil {
 			return nil, err
 		}

--- a/ticketbuyer/buyer.go
+++ b/ticketbuyer/buyer.go
@@ -828,7 +828,7 @@ func (t *TicketPurchaser) Purchase(height int64) (*PurchaseStats, error) {
 	// the wallet for the ticket address.
 	ticketAddress := t.TicketAddress()
 	if ticketAddress == nil {
-		ticketAddress, err = t.wallet.NewInternalAddress(account)
+		ticketAddress, err = t.wallet.NewInternalAddress(account, wallet.WithGapPolicyWrap())
 		if err != nil {
 			return ps, err
 		}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -708,7 +708,7 @@ func (w *Wallet) compressWalletInternal(dbtx walletdb.ReadWriteTx, maxNumIns int
 
 	// Check if output address is default, and generate a new adress if needed
 	if changeAddr == nil {
-		changeAddr, err = w.changeAddress(account)
+		changeAddr, err = w.NewChangeAddress(account)
 		if err != nil {
 			return nil, err
 		}
@@ -921,7 +921,7 @@ func (w *Wallet) purchaseTickets(req purchaseTicketRequest) ([]*chainhash.Hash, 
 			"given: %v, next height %v)", req.expiry, tipHeight+1)
 	}
 
-	addrFunc := w.NewInternalAddress
+	addrFunc := w.NewChangeAddress
 	if w.addressReuse {
 		xpub := w.addressBuffers[udb.DefaultAccountNum].albExternal.branchXpub
 		addr, err := deriveChildAddress(xpub, 0, w.chainParams)
@@ -1028,7 +1028,7 @@ func (w *Wallet) purchaseTickets(req purchaseTicketRequest) ([]*chainhash.Hash, 
 
 	// Fetch the single use split address to break tickets into, to
 	// immediately be consumed as tickets.
-	splitTxAddr, err := w.NewInternalAddress(req.account)
+	splitTxAddr, err := w.NewInternalAddress(req.account, WithGapPolicyWrap())
 	if err != nil {
 		return nil, err
 	}
@@ -1364,7 +1364,7 @@ func (w *Wallet) txToSStxInternal(dbtx walletdb.ReadWriteTx, pair map[string]dcr
 
 		if payouts[i].Addr == "" {
 			var err error
-			addr, err = w.NewInternalAddress(udb.DefaultAccountNum)
+			addr, err = w.NewChangeAddress(udb.DefaultAccountNum)
 			if err != nil {
 				return nil, err
 			}
@@ -1406,7 +1406,7 @@ func (w *Wallet) txToSStxInternal(dbtx walletdb.ReadWriteTx, pair map[string]dcr
 		// Add change to txouts.
 		if payouts[i].ChangeAddr == "" {
 			var err error
-			changeAddr, err = w.NewInternalAddress(udb.DefaultAccountNum)
+			changeAddr, err = w.NewChangeAddress(udb.DefaultAccountNum)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
There are three policies defined:

1. Error when the unused address gap limit is violated

2. Ignore the gap limit and generate the next child address
   regardless

3. Wrap around back to the first unused address after the last used
   address to avoid violating the gap limit

The third wrapping policy was the default and only policy up until
now.  The new default is to error, with the intention of allowing
users to specify the policy they desire.

Because nothing calls the new address methods yet with anything other
than the wrapping policy, this commit introduces no functional change
to the program's behavior, but lays the groudwork for the policy to be
exposed to users elsewhere (such as options in RPC requests or the
wallet config).