### PR TITLE
Fixes #806  Prompt accepts "ok"

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -279,7 +279,7 @@ func Seed(reader *bufio.Reader) ([]byte, error) {
 			}
 			confirmSeed = strings.TrimSpace(confirmSeed)
 			confirmSeed = strings.Trim(confirmSeed, `"`)
-			if confirmSeed == "OK" {
+			if strings.EqualFold("OK", confirmSeed) {
 				break
 			}
 		}


### PR DESCRIPTION
# Fixes #806

`Once you have stored the seed in a safe and secure location, enter "OK" to continue: ok`

Now accepts `ok | OK` instead of only `OK`