### PR TITLE
Revert "cfg: error if specified config file is missing."

### DIFF
--- a/config.go
+++ b/config.go
@@ -496,13 +496,6 @@ func loadConfig() (*config, []string, error) {
 		return loadConfigError(err)
 	}
 
-	// Error and shutdown if config file is specified on the command line
-	// but cannot be found.
-	if configFileError != nil && configFilePath != defaultConfigFile {
-		log.Errorf("%v", configFileError)
-		return loadConfigError(configFileError)
-	}
-
 	// Warn about missing config file after the final command line parse
 	// succeeds.  This prevents the warning on help messages and invalid
 	// options.


### PR DESCRIPTION
This reverts commit 1020bdd0bcc4ea416e2efc8af3a228ae0397744e.

Will put this back in when we can check if the config file was
explicitly set or not.