### PR TITLE
Make cfgutil.ExplicitString a fmt.Stringer.

### DIFF
--- a/internal/cfgutil/explicitflags.go
+++ b/internal/cfgutil/explicitflags.go
@@ -34,3 +34,6 @@ func (e *ExplicitString) UnmarshalFlag(value string) error {
 	e.explicitlySet = true
 	return nil
 }
+
+// String implements the fmt.Stringer interface.
+func (e *ExplicitString) String() string { return e.Value }


### PR DESCRIPTION
This allows the option to be passed to the fmt package for conversion
to a string.