### PR TITLE
Fix incorrect error handling.

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -1427,7 +1427,7 @@ func (s *Store) InsertMinedTx(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.Re
 	// mined balance.
 	err = putMinedBalance(ns, minedBalance)
 	if err != nil {
-		return nil
+		return err
 	}
 
 	// If a transaction record for this tx hash and block already exist,


### PR DESCRIPTION
This fixes a bug in udb.Store.InsertMinedTx where an error writing the
new mined balance to the database would result in returning early
without indicating any error at all.