### PR TITLE
Warn when attempting to add duplicate unmined txs.

### DIFF
--- a/apperrors/error.go
+++ b/apperrors/error.go
@@ -223,3 +223,14 @@ func Wraps(apperror, err error) bool {
 	e, ok := apperror.(E)
 	return ok && e.Err == err
 }
+
+// New returns a new application error with the code and description.
+func New(code Code, desc string) error {
+	return E{ErrorCode: code, Description: desc, Err: nil}
+}
+
+// Wrap returns a new application error that wraps err with an error code and
+// description.
+func Wrap(err error, code Code, desc string) error {
+	return E{ErrorCode: code, Description: desc, Err: err}
+}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -609,6 +609,11 @@ func (w *Wallet) processTransactionRecord(dbtx walletdb.ReadWriteTx, rec *udb.Tx
 	var err error
 	if serializedHeader == nil {
 		err = w.TxStore.InsertMemPoolTx(txmgrNs, rec)
+		if apperrors.IsError(err, apperrors.ErrDuplicate) {
+			log.Warnf("Refusing to add unmined transaction %v since same "+
+				"transaction already exists mined", &rec.Hash)
+			return nil
+		}
 	} else {
 		err = w.TxStore.InsertMinedTx(txmgrNs, addrmgrNs, rec, &blockMeta.Hash)
 	}

--- a/wallet/udb/txunmined.go
+++ b/wallet/udb/txunmined.go
@@ -8,12 +8,19 @@ package udb
 import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrwallet/apperrors"
 	"github.com/decred/dcrwallet/walletdb"
 )
 
 // InsertMemPoolTx inserts a memory pool transaction record.  It also marks
 // previous outputs referenced by its inputs as spent.
 func (s *Store) InsertMemPoolTx(ns walletdb.ReadWriteBucket, rec *TxRecord) error {
+	_, recVal := latestTxRecord(ns, &rec.Hash)
+	if recVal != nil {
+		const str = "transaction already exists mined"
+		return apperrors.New(apperrors.ErrDuplicate, str)
+	}
+
 	v := existsRawUnmined(ns, rec.Hash[:])
 	if v != nil {
 		// TODO: compare serialized txs to ensure this isn't a hash collision?

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -56,11 +56,6 @@ var (
 	SimulationPassphrase = []byte("password")
 )
 
-// ErrNotSynced describes an error where an operation cannot complete
-// due wallet being out of sync (and perhaps currently syncing with)
-// the remote chain server.
-var ErrNotSynced = errors.New("wallet is not synchronized with the chain server")
-
 // Namespace bucket keys.
 var (
 	waddrmgrNamespaceKey  = []byte("waddrmgr")


### PR DESCRIPTION
The database can enter an invalid state when an unmined transaction is
recorded even if it is already recorded mined.  Check for this and
refuse to continue, warning if it ever occurs.  If this does occur,
the notification system will need to be audited.