### PR TITLE
Bump the gRPC API version for SignMessage addition.

### DIFF
--- a/rpc/documentation/api.md
+++ b/rpc/documentation/api.md
@@ -1,6 +1,6 @@
 # RPC API Specification
 
-Version: 4.18.x
+Version: 4.19.x
 
 **Note:** This document assumes the reader is familiar with gRPC concepts.
 Refer to the [gRPC Concepts documentation](http://www.grpc.io/docs/guides/concepts.html)

--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -54,9 +54,9 @@ import (
 
 // Public API version constants
 const (
-	semverString = "4.18.0"
+	semverString = "4.19.0"
 	semverMajor  = 4
-	semverMinor  = 18
+	semverMinor  = 19
 	semverPatch  = 0
 )
 


### PR DESCRIPTION
This should have been included in the last commit but was overlooked.