### PR TITLE
Don't waste the first address of new accounts.

### DIFF
--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -1677,7 +1677,7 @@ func (m *Manager) NewAccount(ns walletdb.ReadWriteBucket, name string) (uint32, 
 	// We have the encrypted account extended keys, so save them to the
 	// database
 	row := bip0044AccountInfo(acctPubEnc, acctPrivEnc, 0, 0,
-		^uint32(0), ^uint32(0), 0, 0, name, DBVersion)
+		^uint32(0), ^uint32(0), ^uint32(0), ^uint32(0), name, DBVersion)
 	err = putAccountInfo(ns, account, row)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Previously, the child index 0 for both the internal and external
branches of new accounts was marked as returned, so the first returned
address of the account would be those at child index 1.

Fixes #880.