### PR TITLE
ticketbuyer: update default config settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,11 +48,11 @@ const (
 	defaultAllowHighFees       = false
 
 	// ticket buyer options
-	defaultMaxFee                    dcrutil.Amount = 1e7
+	defaultMaxFee                    dcrutil.Amount = 1e6
 	defaultMinFee                    dcrutil.Amount = 1e5
 	defaultMaxPriceScale                            = 0.0
 	defaultAvgVWAPPriceDelta                        = 2880
-	defaultMaxPerBlock                              = 5
+	defaultMaxPerBlock                              = 1
 	defaultBlocksToAvg                              = 11
 	defaultFeeTargetScaling                         = 1.0
 	defaultMaxInMempool                             = 40

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -160,7 +160,7 @@
 
 ; Maximum tickets per block, with negative numbers indicating buy one ticket
 ; every 1-in-n blocks
-; ticketbuyer.maxperblock=5
+; ticketbuyer.maxperblock=1
 
 ; Scaling factor for setting the ticket fee, multiplies by the average fee
 ; e.g. 1.0 = 100%
@@ -174,7 +174,7 @@
 ; ticketbuyer.avgpricevwapdelta=2880
 
 ; Maximum ticket fee per KB
-; ticketbuyer.maxfee=0.1
+; ticketbuyer.maxfee=0.01
 
 ; Minimum ticket fee per KB
 ; ticketbuyer.minfee=0.01


### PR DESCRIPTION
Due to expected changes to ticket purchasing performance, we can now lower the default maxfee to 0.01 DCR and also lower the maxperblock to 1.  
Closes #868 