### PR TITLE
txauthor: Update for MsgTx API changes.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8821a10afa7fa0a739161963d37154c7ed31841dc915a29978f2d27885acffbc
-updated: 2017-08-07T16:54:11.2859253-05:00
+updated: 2017-08-07T17:59:15.1279423-05:00
 imports:
 - name: github.com/agl/ed25519
   version: 278e1ec8e8a6e017cd07577924d6766039146ced
@@ -20,7 +20,7 @@ imports:
 - name: github.com/decred/blake256
   version: a840e32d7c31fe2e0218607334cb120a683951a4
 - name: github.com/decred/dcrd
-  version: 1c618ec5e119fa9ff4008e9fffd978b71ce68bbd
+  version: fce24223cd8d60c32a1ee107e3e1a2c7d837ecf1
   subpackages:
   - blockchain
   - blockchain/internal/dbnamespace
@@ -42,7 +42,7 @@ imports:
 - name: github.com/decred/dcrrpcclient
   version: abc326aeb97b299c7eb6b13b81353fc375e9b95d
 - name: github.com/decred/dcrutil
-  version: 58e046aab848365647c44b295f4fab078fbc3392
+  version: 166211f0196be1d3be344ae64149e7c4f5ca36b0
   subpackages:
   - base58
   - hdkeychain

--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -20,6 +20,16 @@ import (
 	"github.com/decred/dcrwallet/wallet/internal/txsizes"
 )
 
+const (
+	// generatedTxVersion is the version of the transaction being generated.
+	// It is defined as a constant here rather than using the wire.TxVersion
+	// constant since a change in the transaction version will potentially
+	// require changes to the generated transaction.  Thus, using the wire
+	// constant for the generated transaction version could allow creation
+	// of invalid transactions for the updated version.
+	generatedTxVersion = 1
+)
+
 // InputSource provides transaction inputs referencing spendable outputs to
 // construct a transaction outputting some target amount.  If the target amount
 // can not be satisified, this can be signaled by returning a total amount less
@@ -109,7 +119,8 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, relayFeePerKb dcrutil.Amount,
 		}
 
 		unsignedTransaction := &wire.MsgTx{
-			Version:  wire.DefaultMsgTxVersion(),
+			SerType:  wire.TxSerializeFull,
+			Version:  generatedTxVersion,
 			TxIn:     inputs,
 			TxOut:    outputs,
 			LockTime: 0,


### PR DESCRIPTION
~**NOTE: This contains overrides in `glide.yaml` and `glide.lock` for decred/dcrd#798 and decred/dcrutil#57 that need to be removed/updated before this is merged**.~

This updates the `txauthor` package to set the new serialization type field in the `wire.MsgTx` struct and introduces a local constant which defines the version to create the transaction with instead of using the
latest version in `wire`.  This is important since a change in the transaction version will potentially require changes to the generated transaction and thus using the wire constant for the generated transaction version could allow creation of invalid transactions for the updated version.