### PR TITLE
Handle address wraping policy after restarts.

### DIFF
--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -324,6 +324,11 @@ func (w *Wallet) DiscoverActiveAddresses(chainClient *chain.RPCClient, discoverA
 					buf.cursor = lastReturned - lastUsed
 					w.addressBuffersMu.Unlock()
 
+					// Unfortunately if the cursor is equal to or greater than
+					// the gap limit, the next child index isn't completely
+					// known.  Depending on the gap limit policy being used, the
+					// next address could be the index after the last returned
+					// child or the child may wrap around to a lower value.
 					log.Infof("Synchronized account %d branch %d to next child index %v",
 						acct, branch, lastReturned+1)
 					return nil

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -1414,7 +1414,9 @@ func (m *Manager) MarkUsedChildIndex(tx walletdb.ReadWriteTx, account, branch, c
 }
 
 // MarkReturnedChildIndex marks a BIP0044 account branch child as returned to a
-// caller.  This method will never write an index lower than the existing index.
+// caller.  This method will write returned child indexes that are lower than
+// the currently-recorded last returned indexes, but these indexes will never be
+// lower than the last used index.
 func (m *Manager) MarkReturnedChildIndex(tx walletdb.ReadWriteTx, account, branch, child uint32) error {
 	ns := tx.ReadWriteBucket(waddrmgrBucketKey)
 
@@ -1432,13 +1434,6 @@ func (m *Manager) MarkReturnedChildIndex(tx walletdb.ReadWriteTx, account, branc
 	default:
 		const str = "unsupported account branch"
 		return apperrors.E{ErrorCode: apperrors.ErrBranch, Description: str, Err: nil}
-	}
-
-	if lastRetExtIndex+1 < row.lastReturnedExternalIndex+1 ||
-		lastRetIntIndex+1 < row.lastReturnedInternalIndex+1 {
-		// Later child indexes have already been marked returned, nothing to
-		// update.
-		return nil
 	}
 
 	// The last returned indexes should never be less than the last used.  The


### PR DESCRIPTION
When called with the wrapping gap policy, RPCs like getnewaddress and
WalletService.NextAddress would wrap around to a previously returned
address in order to avoid violating the BIP0044 gap limit.  However,
this was not correctly handled on restarts due to the last returned
child indexes not being reset down to the lower values.  This changes
the database code so that lower returned child indexes are written and
persisted across restarts.