### PR TITLE
Use correct confirmation check for ticket expiry.

### DIFF
--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -56,13 +56,14 @@ func (w *Wallet) LiveTicketHashes(chainClient *chain.RPCClient, includeImmature 
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 
 		_, tipHeight := w.TxStore.MainChainTip(txmgrNs)
+		expiryConfs := int32(w.chainParams.TicketExpiry) +
+			int32(w.chainParams.TicketMaturity) + 1
 
 		it := w.TxStore.IterateTickets(dbtx)
 		for it.Next() {
 			// Tickets that are mined at a height beyond the expiry height can
 			// not be live.
-			if confirmed(int32(w.chainParams.TicketExpiry), it.Block.Height,
-				tipHeight) {
+			if confirmed(expiryConfs, it.Block.Height, tipHeight) {
 				continue
 			}
 


### PR DESCRIPTION
Tickets expire after they have 40960 + 256 + 1 confirmations (on
mainnet).  Unfortunately, the confirmation check used by the wallet
was not taking into consideration the extra confirmations required
before the ticket becomes live.  Fix this so it matches consensus
rules.

The consensus rules calculate and compare the height that the ticket
expires at rather than checking the total number of confirmations (the
depth of the transaction in the blockchain), but wallet uses
confirmation checks everywhere so this was kept consistent with the
rest of the wallet code.