### PR TITLE
Fix PoolAddress and TicketAddress options with new AddressFlag.

### DIFF
--- a/config.go
+++ b/config.go
@@ -907,10 +907,10 @@ func loadConfig() (*config, []string, error) {
 		MaxPriceAbsolute:          int64(cfg.TBOpts.MaxPriceAbsolute.Amount),
 		MaxPriceRelative:          cfg.TBOpts.MaxPriceRelative,
 		MaxInMempool:              cfg.TBOpts.MaxInMempool,
-		PoolAddress:               cfg.PoolAddress,
+		PoolAddress:               cfg.PoolAddress.Address,
 		PoolFees:                  cfg.PoolFees,
 		NoSpreadTicketPurchases:   cfg.TBOpts.NoSpreadTicketPurchases,
-		TicketAddress:             cfg.TicketAddress,
+		TicketAddress:             cfg.TicketAddress.Address,
 		TxFee:                     int64(cfg.RelayFee.Amount),
 	}
 

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -97,8 +97,8 @@ func walletMain() error {
 	stakeOptions := &ldr.StakeOptions{
 		VotingEnabled:       cfg.EnableVoting,
 		AddressReuse:        cfg.ReuseAddresses,
-		TicketAddress:       cfg.TicketAddress,
-		PoolAddress:         cfg.PoolAddress,
+		TicketAddress:       cfg.TicketAddress.Address,
+		PoolAddress:         cfg.PoolAddress.Address,
 		PoolFees:            cfg.PoolFees,
 		StakePoolColdExtKey: cfg.StakePoolColdExtKey,
 		TicketFee:           cfg.TicketFee.ToCoin(),


### PR DESCRIPTION
Use embedded `Address` instead of the `*AddressFlag` when assigning to `Address` type fields of `ticketbuyer.Config` and `ldr.StakeOptions`.  This previously compiled because `*AddressFlag` satisfies the `dcrutil.Address` interface.  However, this broke later tests against `nil` because it was itself not nil (whether nil `interface{}`, nil `*AddressPubKeyHash`, etc.), but rather a non-nil pointer to a `cfgutil.AddressFlag`.

This fixes the bug introduced in https://github.com/decred/dcrwallet/commit/fe7e5da10bdc6522dde8ece83abf59a2bbdec1c0