### PR TITLE
Skip tickets without voting authority.

### DIFF
--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -276,6 +276,17 @@ func (w *Wallet) RevokeTickets(chainClient *chain.RPCClient) error {
 			if err != nil {
 				return err
 			}
+
+			// Don't create revocations when this wallet doesn't have voting
+			// authority.
+			owned, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
+			if err != nil {
+				return err
+			}
+			if !owned {
+				continue
+			}
+
 			revocation, err := createUnsignedRevocation(ticketHash,
 				ticketPurchase, feePerKb)
 			if err != nil {

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -1036,10 +1036,10 @@ func (m *Manager) ConvertToWatchingOnly(ns walletdb.ReadWriteBucket) error {
 
 }
 
-// ExistsAddress returns whether or not the passed address is known to the
-// address manager.
-func (m *Manager) ExistsAddress(ns walletdb.ReadBucket, addressID []byte) bool {
-	return existsAddress(ns, addressID)
+// ExistsHash160 returns whether or not the 20 byte P2PKH or P2SH HASH160 is
+// known to the address manager.
+func (m *Manager) ExistsHash160(ns walletdb.ReadBucket, hash160 []byte) bool {
+	return existsAddress(ns, hash160)
 }
 
 // ImportPrivateKey imports a WIF private key into the address manager.  The


### PR DESCRIPTION
This change skips over all ticket purchase transactions for
getstakeinfo where the wallet does not own the voting rights for the
ticket.  It also avoids creating votes and revocations for selected
and expired/missed tickets.

Fixes #903.