### PR TITLE
Use earliest of block and receive time for tx timestamp.

### DIFF
--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -180,13 +180,20 @@ func makeTxSummary(dbtx walletdb.ReadTx, w *Wallet, details *udb.TxDetails) Tran
 			break
 		}
 	}
+
+	// Use earliest of receive time or block time if the transaction is mined.
+	receiveTime := details.Received
+	if details.Height() >= 0 && details.Block.Time.Before(receiveTime) {
+		receiveTime = details.Block.Time
+	}
+
 	return TransactionSummary{
 		Hash:        &details.Hash,
 		Transaction: serializedTx,
 		MyInputs:    inputs,
 		MyOutputs:   outputs,
 		Fee:         fee,
-		Timestamp:   details.Received.Unix(),
+		Timestamp:   receiveTime.Unix(),
 		Type:        transactionType,
 	}
 }


### PR DESCRIPTION
This corrects an issue where seed-restored wallets report the time of
restore as the transaction time and fixes timestamps for transactions
received when the wallet was not running or connected to the network.

Fixes #905.