### PR TITLE
Log the correct number of watched addresses at startup.

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -790,7 +790,10 @@ func (w *Wallet) loadActiveAddrs(dbtx walletdb.ReadTx, chainClient *chain.RPCCli
 		intKey.ECPubKey()
 		go loadBranchAddrs(extKey, extn, errs)
 		go loadBranchAddrs(intKey, intn, errs)
-		bip0044AddrCount += uint64(extn) + uint64(intn)
+		// loadBranchAddrs loads addresses through extn/intn, and the actual
+		// number of watched addresses is one more for each branch due to zero
+		// indexing.
+		bip0044AddrCount += uint64(extn) + uint64(intn) + 2
 	}
 	go func() {
 		// Imported addresses are still sent as a single slice for now.  Could


### PR DESCRIPTION
This count was off by one for each account branch.  Issue was noticed
on a fresh wallet that reported watching only 38 addresses when there
should be 40 (20 for each branch in the default account).  This was
only a logging bug and no addresses were being missed.