### PR TITLE
Remove dcrd RPC client from stake manager object.

### DIFF
--- a/wallet/udb/stake.go
+++ b/wallet/udb/stake.go
@@ -17,7 +17,6 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrwallet/apperrors"
-	walletchain "github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/walletdb"
 )
 
@@ -95,9 +94,8 @@ type StakePoolUser struct {
 // StakeStore represents a safely accessible database of
 // stake transactions.
 type StakeStore struct {
-	Params   *chaincfg.Params
-	Manager  *Manager
-	chainSvr *walletchain.RPCClient
+	Params  *chaincfg.Params
+	Manager *Manager
 
 	ownedSStxs map[chainhash.Hash]struct{}
 	mtx        sync.RWMutex // only protects ownedSStxs
@@ -556,18 +554,11 @@ func (s *StakeStore) loadOwnedSStxs(ns walletdb.ReadBucket) error {
 	return nil
 }
 
-// SetChainSvr is used to set the chainSvr to a given pointer. Should
-// be called after chainSvr is initialized in wallet.
-func (s *StakeStore) SetChainSvr(chainSvr *walletchain.RPCClient) {
-	s.chainSvr = chainSvr
-}
-
 // newStakeStore initializes a new stake store with the given parameters.
 func newStakeStore(params *chaincfg.Params, manager *Manager) *StakeStore {
 	return &StakeStore{
 		Params:     params,
 		Manager:    manager,
-		chainSvr:   nil,
 		ownedSStxs: make(map[chainhash.Hash]struct{}),
 	}
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -546,8 +546,6 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 	w.chainClient = chainClient
 	w.chainClientLock.Unlock()
 
-	w.StakeMgr.SetChainSvr(chainClient)
-
 	// TODO: It would be preferable to either run these goroutines
 	// separately from the wallet (use wallet mutator functions to
 	// make changes from the RPC client) and not have to stop and


### PR DESCRIPTION
It has no place being here and is no longer being used after several
stake manager refactors.