### PR TITLE
Remove most usage of chain.RPCClient from wallet package.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -273,7 +273,7 @@ func (s *walletServer) checkReady() bool {
 
 // requireChainClient checks whether the wallet has been associated with the
 // consensus server RPC client, returning a gRPC error when it is not.
-func (s *walletServer) requireChainClient() (*chain.RPCClient, error) {
+func (s *walletServer) requireChainClient() (*dcrrpcclient.Client, error) {
 	chainClient := s.wallet.ChainClient()
 	if chainClient == nil {
 		return nil, status.Errorf(codes.FailedPrecondition,
@@ -639,7 +639,7 @@ func (s *walletServer) StakeInfo(ctx context.Context, req *pb.StakeInfoRequest) 
 		return nil, err
 	}
 
-	si, err := s.wallet.StakeInfo(chainClient.Client)
+	si, err := s.wallet.StakeInfo(chainClient)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition,
 			"Failed to query stake info: %s", err.Error())
@@ -1743,7 +1743,7 @@ func (s *loaderServer) DiscoverAddresses(ctx context.Context, req *pb.DiscoverAd
 		}
 	}
 
-	err := wallet.DiscoverActiveAddresses(chainClient, req.DiscoverAccounts)
+	err := wallet.DiscoverActiveAddresses(chainClient.Client, req.DiscoverAccounts)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1792,7 +1792,7 @@ func (s *loaderServer) FetchHeaders(ctx context.Context, req *pb.FetchHeadersReq
 	}
 
 	fetchedHeaderCount, rescanFrom, rescanFromHeight,
-		mainChainTipBlockHash, mainChainTipBlockHeight, err := wallet.FetchHeaders(chainClient)
+		mainChainTipBlockHash, mainChainTipBlockHeight, err := wallet.FetchHeaders(chainClient.Client)
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -92,7 +92,7 @@ func (w *Wallet) handleChainNotifications(chainClient *chain.RPCClient) {
 	// some reason, however, the wallet will not be marked synced
 	// and many methods will error early since the wallet is known
 	// to be out of date.
-	err := w.syncWithChain(chainClient)
+	err := w.syncWithChain(chainClient.Client)
 	if err != nil && !w.ShuttingDown() {
 		log.Warnf("Unable to synchronize wallet to chain: %v", err)
 	}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -9,6 +9,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"github.com/decred/dcrrpcclient"
 	"time"
 
 	"github.com/decred/dcrd/blockchain"
@@ -22,7 +23,6 @@ import (
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrwallet/apperrors"
-	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/wallet/internal/txsizes"
 	"github.com/decred/dcrwallet/wallet/txauthor"
 	"github.com/decred/dcrwallet/wallet/txrules"
@@ -390,8 +390,8 @@ func (w *Wallet) txToOutputs(outputs []*wire.TxOut, account uint32, minconf int3
 // Decred: This func also sends the transaction, and if successful, inserts it
 // into the database, rather than delegating this work to the caller as
 // btcwallet does.
-func (w *Wallet) txToOutputsInternal(outputs []*wire.TxOut, account uint32, minconf int32, chainClient *chain.RPCClient,
-	randomizeChangeIdx bool, txFee dcrutil.Amount) (*txauthor.AuthoredTx, error) {
+func (w *Wallet) txToOutputsInternal(outputs []*wire.TxOut, account uint32, minconf int32,
+	chainClient *dcrrpcclient.Client, randomizeChangeIdx bool, txFee dcrutil.Amount) (*txauthor.AuthoredTx, error) {
 
 	var atx *txauthor.AuthoredTx
 	var changeSourceUpdates []func(walletdb.ReadWriteTx) error

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -9,7 +9,7 @@ import (
 	"encoding/hex"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrwallet/chain"
+	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrwallet/wallet/udb"
 	"github.com/decred/dcrwallet/walletdb"
 )
@@ -23,7 +23,7 @@ const maxBlocksPerRescan = 2000
 // startHash and height up through the recorded main chain tip block.  The
 // progress channel, if non-nil, is sent non-error progress notifications with
 // the heights the rescan has completed through, starting with the start height.
-func (w *Wallet) rescan(chainClient *chain.RPCClient, startHash *chainhash.Hash, height int32,
+func (w *Wallet) rescan(chainClient *dcrrpcclient.Client, startHash *chainhash.Hash, height int32,
 	p chan<- RescanProgress, cancel <-chan struct{}) error {
 
 	blockHashStorage := make([]chainhash.Hash, maxBlocksPerRescan)
@@ -112,7 +112,7 @@ func (w *Wallet) rescan(chainClient *chain.RPCClient, startHash *chainhash.Hash,
 // An error channel is returned for consumers of this API, but it is not
 // required to be read.  If the error can not be immediately written to the
 // returned channel, the error will be logged and the channel will be closed.
-func (w *Wallet) Rescan(chainClient *chain.RPCClient, startHash *chainhash.Hash) <-chan error {
+func (w *Wallet) Rescan(chainClient *dcrrpcclient.Client, startHash *chainhash.Hash) <-chan error {
 	errc := make(chan error)
 
 	go func() (err error) {
@@ -149,7 +149,7 @@ func (w *Wallet) Rescan(chainClient *chain.RPCClient, startHash *chainhash.Hash)
 
 // RescanFromHeight is an alternative to Rescan that takes a block height
 // instead of a hash.  See Rescan for more details.
-func (w *Wallet) RescanFromHeight(chainClient *chain.RPCClient, startHeight int32) <-chan error {
+func (w *Wallet) RescanFromHeight(chainClient *dcrrpcclient.Client, startHeight int32) <-chan error {
 	errc := make(chan error)
 
 	go func() (err error) {
@@ -193,7 +193,7 @@ type RescanProgress struct {
 // the main chain starting at startHeight.  Progress notifications and any
 // errors are sent to the channel p.  This function blocks until the rescan
 // completes or ends in an error.  p is closed before returning.
-func (w *Wallet) RescanProgressFromHeight(chainClient *chain.RPCClient, startHeight int32, p chan<- RescanProgress, cancel <-chan struct{}) {
+func (w *Wallet) RescanProgressFromHeight(chainClient *dcrrpcclient.Client, startHeight int32, p chan<- RescanProgress, cancel <-chan struct{}) {
 	defer close(p)
 
 	var startHash chainhash.Hash

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -10,13 +10,13 @@ import (
 	"sync"
 
 	"github.com/decred/bitset"
+	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrutil/hdkeychain"
-	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/wallet/udb"
 	"github.com/decred/dcrwallet/walletdb"
 )
 
-func (w *Wallet) findLastUsedAccount(client *chain.RPCClient, coinTypeXpriv *hdkeychain.ExtendedKey) (uint32, error) {
+func (w *Wallet) findLastUsedAccount(client *dcrrpcclient.Client, coinTypeXpriv *hdkeychain.ExtendedKey) (uint32, error) {
 	const scanLen = 100
 	var (
 		lastUsed uint32
@@ -74,7 +74,7 @@ Bsearch:
 	return lastUsed, nil
 }
 
-func (w *Wallet) accountUsed(client *chain.RPCClient, xpub *hdkeychain.ExtendedKey) (bool, error) {
+func (w *Wallet) accountUsed(client *dcrrpcclient.Client, xpub *hdkeychain.ExtendedKey) (bool, error) {
 	extKey, intKey, err := deriveBranches(xpub)
 	if err != nil {
 		return false, err
@@ -101,7 +101,7 @@ func (w *Wallet) accountUsed(client *chain.RPCClient, xpub *hdkeychain.ExtendedK
 	return false, nil
 }
 
-func (w *Wallet) branchUsed(client *chain.RPCClient, branchXpub *hdkeychain.ExtendedKey) (bool, error) {
+func (w *Wallet) branchUsed(client *dcrrpcclient.Client, branchXpub *hdkeychain.ExtendedKey) (bool, error) {
 	addrs, err := deriveChildAddresses(branchXpub, 0, uint32(w.gapLimit), w.chainParams)
 	if err != nil {
 		return false, err
@@ -121,7 +121,7 @@ func (w *Wallet) branchUsed(client *chain.RPCClient, branchXpub *hdkeychain.Exte
 // findLastUsedAddress returns the child index of the last used child address
 // derived from a branch key.  If no addresses are found, ^uint32(0) is
 // returned.
-func (w *Wallet) findLastUsedAddress(client *chain.RPCClient, xpub *hdkeychain.ExtendedKey) (uint32, error) {
+func (w *Wallet) findLastUsedAddress(client *dcrrpcclient.Client, xpub *hdkeychain.ExtendedKey) (uint32, error) {
 	var (
 		lastUsed        = ^uint32(0)
 		scanLen         = uint32(w.gapLimit)
@@ -165,7 +165,7 @@ Bsearch:
 // account extended pubkeys.
 //
 // A transaction filter (re)load and rescan should be performed after discovery.
-func (w *Wallet) DiscoverActiveAddresses(chainClient *chain.RPCClient, discoverAccts bool) error {
+func (w *Wallet) DiscoverActiveAddresses(chainClient *dcrrpcclient.Client, discoverAccts bool) error {
 	// Start by rescanning the accounts and determining what the
 	// current account index is. This scan should only ever be
 	// performed if we're restoring our wallet from seed.

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -13,9 +13,9 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
+	"github.com/decred/dcrrpcclient"
 	"github.com/decred/dcrutil"
 	"github.com/decred/dcrwallet/apperrors"
-	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/wallet/udb"
 	"github.com/decred/dcrwallet/walletdb"
 	"golang.org/x/sync/errgroup"
@@ -49,7 +49,7 @@ func (w *Wallet) GenerateVoteTx(blockHash *chainhash.Hash, height int32, ticketH
 
 // LiveTicketHashes returns the hashes of live tickets that the wallet has
 // purchased or has voting authority for.
-func (w *Wallet) LiveTicketHashes(chainClient *chain.RPCClient, includeImmature bool) ([]chainhash.Hash, error) {
+func (w *Wallet) LiveTicketHashes(chainClient *dcrrpcclient.Client, includeImmature bool) ([]chainhash.Hash, error) {
 	var ticketHashes []chainhash.Hash
 	var maybeLive []*chainhash.Hash
 
@@ -289,7 +289,7 @@ func (w *Wallet) AddTicket(ticket *wire.MsgTx) error {
 // RevokeTickets creates and sends revocation transactions for any unrevoked
 // missed and expired tickets.  The wallet must be unlocked to generate any
 // revocations.
-func (w *Wallet) RevokeTickets(chainClient *chain.RPCClient) error {
+func (w *Wallet) RevokeTickets(chainClient *dcrrpcclient.Client) error {
 	var ticketHashes []chainhash.Hash
 	var tipHash chainhash.Hash
 	var tipHeight int32


### PR DESCRIPTION
The remaining usages require the additional functionality of the
client wrapper for notifications and syncing.  These will be
eventually removed from the wallet package, allowing the chain package
to keep the wallet up to date.  Removing these usages are required to
avoid a circular dependency.