### PR TITLE
Don't set heights for manually added tickets.

### DIFF
--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -219,16 +219,15 @@ func (w *Wallet) TicketHashesForVotingAddress(votingAddr dcrutil.Address) ([]cha
 // updateStakePoolInvalidTicket properly updates a previously marked Invalid pool ticket,
 // it then creates a new entry in the validly tracked pool ticket db.
 func (w *Wallet) updateStakePoolInvalidTicket(stakemgrNs walletdb.ReadWriteBucket,
-	addr dcrutil.Address, ticket *chainhash.Hash, ticketHeight int64) error {
+	addr dcrutil.Address, ticket *chainhash.Hash) error {
 
 	err := w.StakeMgr.RemoveStakePoolUserInvalTickets(stakemgrNs, addr, ticket)
 	if err != nil {
 		return err
 	}
 	poolTicket := &udb.PoolTicket{
-		Ticket:       *ticket,
-		HeightTicket: uint32(ticketHeight),
-		Status:       udb.TSImmatureOrLive,
+		Ticket: *ticket,
+		Status: udb.TSImmatureOrLive,
 	}
 
 	return w.StakeMgr.UpdateStakePoolUserTickets(stakemgrNs, addr, poolTicket)
@@ -264,19 +263,9 @@ func (w *Wallet) AddTicket(ticket *wire.MsgTx) error {
 
 			ticketHash := ticket.TxHash()
 
-			chainClient, err := w.requireChainClient()
-			if err != nil {
-				return err
-			}
-			rawTx, err := chainClient.GetRawTransactionVerbose(&ticketHash)
-			if err != nil {
-				return err
-			}
-
 			// Update the pool ticket stake. This will include removing it from the
 			// invalid slice and adding a ImmatureOrLive ticket to the valid ones.
-			err = w.updateStakePoolInvalidTicket(stakemgrNs, addrs[0], &ticketHash,
-				rawTx.BlockHeight)
+			err = w.updateStakePoolInvalidTicket(stakemgrNs, addrs[0], &ticketHash)
 			if err != nil {
 				return err
 			}

--- a/wallet/udb/stake.go
+++ b/wallet/udb/stake.go
@@ -78,7 +78,7 @@ const (
 // ticket information when they have an account at the stake pool.
 type PoolTicket struct {
 	Ticket       chainhash.Hash
-	HeightTicket uint32
+	HeightTicket uint32 // Not used or guaranteed to be correct
 	Status       TicketStatus
 	HeightSpent  uint32
 	SpentBy      chainhash.Hash


### PR DESCRIPTION
The height field of a pool ticket saved by the stake manager was never
being used.  To remove a case of requiring the dcrd RPC client to
query for its height, this field is now left zeroed and a comment has
been added to the field indicating that it is not used and can not be
relied on.

If the height of the transaction is required to be known, it must be
looked up through the transaction manager.