### PR TITLE
Remove duplicate udb method with identical functionality.

### DIFF
--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -782,7 +782,7 @@ func (c *ConfirmationNotificationsClient) Watch(txHashes []*chainhash.Hash, stop
 				if err != nil {
 					return err
 				}
-				blockHash, err := w.TxStore.GetBlockHash(txmgrNs, height)
+				blockHash, err := w.TxStore.GetMainChainBlockHashForHeight(txmgrNs, height)
 				if err != nil {
 					return err
 				}
@@ -863,7 +863,7 @@ func (c *ConfirmationNotificationsClient) process(tipHeight int32) {
 				if err != nil {
 					return err
 				}
-				blockHash, err := w.TxStore.GetBlockHash(txmgrNs, height)
+				blockHash, err := w.TxStore.GetMainChainBlockHashForHeight(txmgrNs, height)
 				if err != nil {
 					return err
 				}

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -249,17 +249,6 @@ func (s *Store) ExtendMainChain(ns walletdb.ReadWriteBucket, header *BlockHeader
 	return putRawBlockRecord(ns, blockKey, blockVal)
 }
 
-// GetBlockHash fetches the block hash for the block at the given height,
-// and returns an error if it's missing.
-func (s *Store) GetBlockHash(ns walletdb.ReadBucket, height int32) (chainhash.Hash, error) {
-	br, err := fetchBlockRecord(ns, height)
-	if err != nil {
-		return chainhash.Hash{}, err
-	}
-
-	return br.Block.Hash, nil
-}
-
 // log2 calculates an integer approximation of log2(x).  This is used to
 // approximate the cap to use when allocating memory for the block locators.
 func log2(x int) int {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2361,7 +2361,8 @@ func (w *Wallet) BlockInfo(blockID *BlockIdentifier) (*BlockInfo, error) {
 		_, tipHeight := w.TxStore.MainChainTip(txmgrNs)
 		blockHash := blockID.hash
 		if blockHash == nil {
-			hash, err := w.TxStore.GetBlockHash(txmgrNs, blockID.height)
+			hash, err := w.TxStore.GetMainChainBlockHashForHeight(txmgrNs,
+				blockID.height)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
The GetBlockHash and GetMainChainBlockHashForHeight methods had the
same functionality: returning the block hash of the block at some
height in the wallet's main chain.  Prefer to use the latter as it is
slightly more efficient by not decoding the entire block record.