### PR TITLE
Allow JSON-RPC handlers access to the wallet loader.

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -49,14 +49,13 @@ type Loader struct {
 
 // StakeOptions contains the various options necessary for stake mining.
 type StakeOptions struct {
-	TicketPurchasingEnabled bool
-	VotingEnabled           bool
-	TicketFee               float64
-	AddressReuse            bool
-	VotingAddress           dcrutil.Address
-	PoolAddress             dcrutil.Address
-	PoolFees                float64
-	StakePoolColdExtKey     string
+	VotingEnabled       bool
+	TicketFee           float64
+	AddressReuse        bool
+	VotingAddress       dcrutil.Address
+	PoolAddress         dcrutil.Address
+	PoolFees            float64
+	StakePoolColdExtKey string
 }
 
 // NewLoader constructs a Loader.
@@ -298,7 +297,6 @@ func (l *Loader) StartTicketPurchase(passphrase []byte, ticketbuyerCfg *ticketbu
 	l.ntfnClient = n
 	l.purchaseManager = pm
 	pm.Start()
-	l.wallet.SetTicketPurchasingEnabled(true)
 	return nil
 }
 
@@ -313,7 +311,6 @@ func (l *Loader) stopTicketPurchase() error {
 	l.purchaseManager.Stop()
 	l.purchaseManager.WaitForShutdown()
 	l.purchaseManager = nil
-	l.wallet.SetTicketPurchasingEnabled(false)
 	return nil
 }
 

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -289,7 +289,7 @@ func (s *Server) handlerClosure(ctx context.Context, request *dcrjson.Request) l
 		}
 	}
 
-	return lazyApplyHandler(request, wallet, rpcClient)
+	return lazyApplyHandler(request, wallet, rpcClient, s.walletLoader)
 }
 
 // ErrNoAuth represents an error where authentication could not succeed

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -82,16 +82,15 @@ type Wallet struct {
 	StakeMgr *udb.StakeStore
 
 	// Handlers for stake system.
-	stakeSettingsLock       sync.Mutex
-	voteBits                stake.VoteBits
-	ticketPurchasingEnabled bool
-	votingEnabled           bool
-	balanceToMaintain       dcrutil.Amount
-	poolAddress             dcrutil.Address
-	poolFees                float64
-	stakePoolEnabled        bool
-	stakePoolColdAddrs      map[string]struct{}
-	subsidyCache            *blockchain.SubsidyCache
+	stakeSettingsLock  sync.Mutex
+	voteBits           stake.VoteBits
+	votingEnabled      bool
+	balanceToMaintain  dcrutil.Amount
+	poolAddress        dcrutil.Address
+	poolFees           float64
+	stakePoolEnabled   bool
+	stakePoolColdAddrs map[string]struct{}
+	subsidyCache       *blockchain.SubsidyCache
 
 	// Start up flags/settings
 	initiallyUnlocked bool
@@ -276,14 +275,6 @@ func (w *Wallet) SetBalanceToMaintain(balance dcrutil.Amount) {
 	w.stakeSettingsLock.Unlock()
 }
 
-// TicketPurchasingEnabled returns whether the wallet is configured to purchase tickets.
-func (w *Wallet) TicketPurchasingEnabled() bool {
-	w.stakeSettingsLock.Lock()
-	enabled := w.ticketPurchasingEnabled
-	w.stakeSettingsLock.Unlock()
-	return enabled
-}
-
 // VotingEnabled returns whether the wallet is configured to vote tickets.
 func (w *Wallet) VotingEnabled() bool {
 	w.stakeSettingsLock.Lock()
@@ -466,14 +457,6 @@ func (w *Wallet) SetAgendaChoices(choices ...AgendaChoice) (voteBits uint16, err
 	return voteBits, nil
 }
 
-// SetTicketPurchasingEnabled is used to enable or disable ticket purchasing in the
-// wallet.
-func (w *Wallet) SetTicketPurchasingEnabled(flag bool) {
-	w.stakeSettingsLock.Lock()
-	w.ticketPurchasingEnabled = flag
-	w.stakeSettingsLock.Unlock()
-}
-
 // TicketAddress gets the ticket address for the wallet to give the ticket
 // voting rights to.
 func (w *Wallet) TicketAddress() dcrutil.Address {
@@ -569,18 +552,9 @@ func (w *Wallet) SynchronizeRPC(chainClient *chain.RPCClient) {
 			"and missed tickets. Error: ", err.Error())
 	}
 
-	ticketPurchasingEnabled := w.TicketPurchasingEnabled()
-	if ticketPurchasingEnabled {
-		vb := w.VoteBits()
-		log.Infof("Wallet ticket purchasing enabled: vote bits = %#04x, "+
-			"extended vote bits = %x", vb.Bits, vb.ExtendedBits)
-	}
 	if w.votingEnabled {
 		log.Infof("Wallet voting enabled")
-	}
-	if ticketPurchasingEnabled || w.votingEnabled {
-		log.Infof("Please ensure your wallet remains unlocked so it may " +
-			"create stake transactions")
+		log.Infof("Please ensure your wallet remains unlocked so it may vote")
 	}
 }
 


### PR DESCRIPTION
This is now being passed into the walletinfo handler to provide
information on whether the ticket buyer is running.  This is
preferable to querying this from the wallet itself since the wallet no
longer purchases tickets and the ticket buyer can be started/stopped
at will (over gRPC) so plumbing the config option to the handler
through the wallet struct is not the correct way to report this.

Remove the old TicketPurchasingEnabled methods from the wallet as they
are simply no longer needed.