### PR TITLE
Switch default coin types to those defined in SLIP0044.

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -238,17 +238,17 @@ func PublicPass(reader *bufio.Reader, privPass []byte,
 // yes, a the user is prompted for it.  All prompts are repeated until the user
 // enters a valid response. The bool returned indicates if the wallet was
 // restored from a given seed or not.
-func Seed(reader *bufio.Reader) ([]byte, error) {
+func Seed(reader *bufio.Reader) (seed []byte, imported bool, err error) {
 	// Ascertain the wallet generation seed.
 	useUserSeed, err := promptListBool(reader, "Do you have an "+
 		"existing wallet seed you want to use?", "no")
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if !useUserSeed {
 		seed, err := hdkeychain.GenerateSeed(hdkeychain.RecommendedSeedLen)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		seedStrSplit := walletseed.EncodeMnemonicSlice(seed)
@@ -275,7 +275,7 @@ func Seed(reader *bufio.Reader) ([]byte, error) {
 				`and secure location, enter "OK" to continue: `)
 			confirmSeed, err := reader.ReadString('\n')
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 			confirmSeed = strings.TrimSpace(confirmSeed)
 			confirmSeed = strings.Trim(confirmSeed, `"`)
@@ -284,7 +284,7 @@ func Seed(reader *bufio.Reader) ([]byte, error) {
 			}
 		}
 
-		return seed, nil
+		return seed, false, nil
 	}
 
 	for {
@@ -334,7 +334,7 @@ func Seed(reader *bufio.Reader) ([]byte, error) {
 
 		fmt.Printf("\nSeed input successful. \nHex: %x\n", seed)
 
-		return seed, nil
+		return seed, true, nil
 	}
 }
 
@@ -352,7 +352,7 @@ func Seed(reader *bufio.Reader) ([]byte, error) {
 // previously specified in a configuration file.  The user will be given the
 // option of using this passphrase if public data encryption is enabled,
 // otherwise a user-specified passphrase will be prompted for.
-func Setup(r *bufio.Reader, insecurePubPass, configPubPass []byte) (privPass, pubPass, seed []byte, err error) {
+func Setup(r *bufio.Reader, insecurePubPass, configPubPass []byte) (privPass, pubPass, seed []byte, imported bool, err error) {
 	// Decred: no legacy keystore restore is needed (first decred wallet
 	// version did not use the legacy keystore from earlier versions of
 	// btcwallet).
@@ -376,7 +376,7 @@ func Setup(r *bufio.Reader, insecurePubPass, configPubPass []byte) (privPass, pu
 	// Ascertain the wallet generation seed.  This will either be an
 	// automatically generated value the user has already confirmed or a
 	// value the user has entered which has already been validated.
-	seed, err = Seed(r)
+	seed, imported, err = Seed(r)
 
 	return
 }

--- a/prompt/prompt.go
+++ b/prompt/prompt.go
@@ -15,6 +15,6 @@ import (
 // randomly generated seed of the recommended length will be generated and
 // returned after the user has confirmed the seed has been backed up to a secure
 // location.
-func Setup(r *bufio.Reader) (privPass, pubPass, seed []byte, err error) {
+func Setup(r *bufio.Reader) (privPass, pubPass, seed []byte, imported bool, err error) {
 	return prompt.Setup(r, []byte(wallet.InsecurePubPassphrase), nil)
 }

--- a/wallet/cointype.go
+++ b/wallet/cointype.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"github.com/decred/dcrd/hdkeychain"
+	"github.com/decred/dcrwallet/wallet/udb"
+	"github.com/decred/dcrwallet/walletdb"
+)
+
+// UpgradeToSLIP0044CoinType upgrades the wallet from the legacy BIP0044 coin
+// type to one of the coin types assigned to Decred in SLIP0044.  This should be
+// called after a new wallet is created with a random (not imported) seed.
+//
+// This function does not register addresses from the new account 0 with the
+// wallet's network backend.  This is intentional as it allows offline
+// activities, such as wallet creation, to perform this upgrade.
+func (w *Wallet) UpgradeToSLIP0044CoinType() error {
+	var extBranchXpub, intBranchXpub *hdkeychain.ExtendedKey
+
+	err := walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
+		err := w.Manager.UpgradeToSLIP0044CoinType(dbtx)
+		if err != nil {
+			return err
+		}
+
+		extBranchXpub, err = w.Manager.AccountBranchExtendedPubKey(dbtx, 0,
+			udb.ExternalBranch)
+		if err != nil {
+			return err
+		}
+		intBranchXpub, err = w.Manager.AccountBranchExtendedPubKey(dbtx, 0,
+			udb.InternalBranch)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+
+	w.addressBuffersMu.Lock()
+	w.addressBuffers[0] = &bip0044AccountData{
+		albExternal: addressBuffer{branchXpub: extBranchXpub, lastUsed: ^uint32(0)},
+		albInternal: addressBuffer{branchXpub: intBranchXpub, lastUsed: ^uint32(0)},
+	}
+	w.addressBuffersMu.Unlock()
+
+	return nil
+}

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -16,6 +16,7 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainec"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
+	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrwallet/apperrors"
 	"github.com/decred/dcrwallet/internal/zero"
 	"github.com/decred/dcrwallet/snacl"
@@ -659,6 +660,177 @@ func (m *Manager) CoinTypePrivKey(dbtx walletdb.ReadTx) (*hdkeychain.ExtendedKey
 		return nil, managerError(apperrors.ErrKeyChain, str, err)
 	}
 	return coinTypeKeyPriv, nil
+}
+
+// CoinType returns the BIP0044 coin type currently in use.  Early versions of
+// the wallet used coin types that conflicted with other coins, preventing use
+// of the same seed in multicurrency wallets.  New (not restored) wallets are
+// now created using the coin types assigned to Decred in SLIP0044:
+//
+//  https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+//
+// The address manager should be upgraded to the SLIP0044 coin type if it is
+// currently using the legacy coin type and there are no used accounts or
+// addresses.  This procedure must be performed for seed restored wallets which
+// save both coin types and, for backwards compatibility reasons, default to the
+// legacy coin type.  Both coin types for a network may be queried using the
+// CoinTypes func and upgrades are performed using the UpgradeToSLIP0044CoinType
+// method.
+//
+// Watching-only wallets that are created using an account xpub do not save the
+// coin type keys and this method will return an error with code
+// ErrValueNoExists on these wallets.
+func (m *Manager) CoinType(dbtx walletdb.ReadTx) (uint32, error) {
+	ns := dbtx.ReadBucket(waddrmgrBucketKey)
+	mainBucket := ns.NestedReadBucket(mainBucketName)
+
+	legacyCoinType, slip0044CoinType := CoinTypes(m.chainParams)
+
+	if mainBucket.Get(coinTypeLegacyPubKeyName) != nil {
+		return legacyCoinType, nil
+	}
+	if mainBucket.Get(coinTypeSLIP0044PubKeyName) != nil {
+		return slip0044CoinType, nil
+	}
+
+	return 0, apperrors.New(apperrors.ErrValueNoExists, "coin type keys are not saved")
+}
+
+// UpgradeToSLIP0044CoinType upgrades a wallet from using the legacy coin type
+// to the coin type registered to Decred as per SLIP0044.  On mainnet, this
+// upgrades the coin type from 20 to 42.  On testnet and simnet, the coin type
+// is upgraded to 1.  This upgrade is only possible if the SLIP0044 coin type
+// private key is saved and there is no address use for keys derived by the
+// legacy coin type.
+func (m *Manager) UpgradeToSLIP0044CoinType(dbtx walletdb.ReadWriteTx) error {
+	coinType, err := m.CoinType(dbtx)
+	if err != nil {
+		return err
+	}
+	legacyCoinType, _ := CoinTypes(m.chainParams)
+	if coinType != legacyCoinType {
+		const desc = "upgrade to SLIP0044 coin type must be performed on legacy coin type wallet"
+		return apperrors.New(apperrors.ErrUnsupported, desc)
+	}
+
+	ns := dbtx.ReadWriteBucket(waddrmgrBucketKey)
+	mainBucket := ns.NestedReadWriteBucket(mainBucketName)
+
+	coinTypeSLIP0044PubKeyEnc := mainBucket.Get(coinTypeSLIP0044PubKeyName)
+	coinTypeSLIP0044PrivKeyEnc := mainBucket.Get(coinTypeSLIP0044PrivKeyName)
+	if coinTypeSLIP0044PubKeyEnc == nil || coinTypeSLIP0044PrivKeyEnc == nil {
+		const desc = "upgrade to SLIP0044 coin type requires SLIP0044 coin type keys saved"
+		return apperrors.New(apperrors.ErrUnsupported, desc)
+	}
+
+	// Refuse to upgrade the coin type if any accounts or addresses have been
+	// used or derived.
+	lastAcct, err := m.LastAccount(ns)
+	if err != nil {
+		return err
+	}
+	acctProps, err := m.AccountProperties(ns, lastAcct)
+	if err != nil {
+		return err
+	}
+	if lastAcct != 0 || acctProps.LastReturnedExternalIndex != ^uint32(0) ||
+		acctProps.LastReturnedInternalIndex != ^uint32(0) {
+		const desc = "wallets with account or address usage may not be " +
+			"upgraded to SLIP0044 coin type"
+		return apperrors.New(apperrors.ErrUnsupported, desc)
+	}
+
+	// Delete the legacy coin type keys.  With these missing, the SLIP0044 coin
+	// type keys (which have already been checked to exist) will be used
+	// instead.
+	err = mainBucket.Delete(coinTypeLegacyPubKeyName)
+	if err != nil {
+		const desc = "failed to delete legacy coin type pubkey"
+		return apperrors.Wrap(err, apperrors.ErrDatabase, desc)
+	}
+	err = mainBucket.Delete(coinTypeLegacyPrivKeyName)
+	if err != nil {
+		const desc = "failed to delete legacy coin type privkey"
+		return apperrors.Wrap(err, apperrors.ErrDatabase, desc)
+	}
+
+	// Rewrite the account 0 row using the SLIP0044 coin type key derivations.
+	serializedRow := mainBucket.Get(slip0044Account0RowName)
+	if serializedRow == nil {
+		const desc = "missing SLIP0044 coin type account row"
+		return apperrors.New(apperrors.ErrData, desc)
+	}
+	accountID := uint32ToBytes(0)
+	row, err := deserializeAccountRow(accountID, serializedRow)
+	if err != nil {
+		return err
+	}
+	if row.acctType != actBIP0044 {
+		desc := fmt.Sprintf("unsupported account row type %d", row.acctType)
+		return apperrors.New(apperrors.ErrData, desc)
+	}
+	bip0044Row, err := deserializeBIP0044AccountRow(accountID, row, initialVersion)
+	if err != nil {
+		return err
+	}
+	// Keep previous name of account 0
+	bip0044Row.name = acctProps.AccountName
+	bip0044Row.rawData = serializeBIP0044AccountRow(bip0044Row, DBVersion)
+	err = putAccountRow(ns, 0, &bip0044Row.dbAccountRow)
+	if err != nil {
+		return err
+	}
+	err = mainBucket.Delete(slip0044Account0RowName)
+	if err != nil {
+		const desc = "failed to delete SLIP0044 coin type account row"
+		return apperrors.Wrap(err, apperrors.ErrDatabase, desc)
+	}
+
+	// Acquire the manager mutex for the remainder of the call so that caches
+	// can be updated.
+	defer m.mtx.Unlock()
+	m.mtx.Lock()
+
+	// Check if the account info cache exists and must be updated for the
+	// SLIP044 coin type derivations.
+	acctInfo, ok := m.acctInfo[0]
+	if !ok {
+		return nil
+	}
+
+	// Decrypt the SLIP0044 coin type account xpub so the in memory account
+	// information can be updated.
+	acctExtPubKeyStr, err := m.cryptoKeyPub.Decrypt(bip0044Row.pubKeyEncrypted)
+	if err != nil {
+		const desc = "failed to decrypt SLIP0044 coin type account xpub"
+		return apperrors.Wrap(err, apperrors.ErrCrypto, desc)
+	}
+	acctExtPubKey, err := hdkeychain.NewKeyFromString(string(acctExtPubKeyStr))
+	if err != nil {
+		const desc = "failed to deserialize SLIP0044 coin type account xpub"
+		return apperrors.Wrap(err, apperrors.ErrKeyChain, desc)
+	}
+
+	// When unlocked, decrypt the SLIP0044 coin type account xpriv as well.
+	var acctExtPrivKey *hdkeychain.ExtendedKey
+	if !m.locked {
+		acctExtPrivKeyStr, err := m.cryptoKeyPriv.Decrypt(bip0044Row.privKeyEncrypted)
+		if err != nil {
+			const desc = "failed to decrypt SLIP0044 coin type account xpriv"
+			return apperrors.Wrap(err, apperrors.ErrCrypto, desc)
+		}
+		acctExtPrivKey, err = hdkeychain.NewKeyFromString(string(acctExtPrivKeyStr))
+		if err != nil {
+			const desc = "failed to deserialize SLIP0044 coin type account xpriv"
+			return apperrors.Wrap(err, apperrors.ErrKeyChain, desc)
+		}
+	}
+
+	acctInfo.acctKeyEncrypted = bip0044Row.privKeyEncrypted
+	acctInfo.acctKeyPriv = acctExtPrivKey
+	acctInfo.acctKeyPub = acctExtPubKey
+
+	return nil
 }
 
 // deriveKeyFromPath returns either a public or private derived extended key
@@ -2220,6 +2392,22 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte,
 	return mgr, nil
 }
 
+// CoinTypes returns the legacy and SLIP0044 coin types for the chain
+// parameters.  At the moment, the parameters have not been upgraded for the new
+// coin types.
+func CoinTypes(params *chaincfg.Params) (legacyCoinType, slip0044CoinType uint32) {
+	// This will need to be rewritten after the chaincfg parameters are updated
+	// for the SLIP0044 coin types.  A test function, TestCoinTypes, exists to
+	// check that the output of this function remains correct after the
+	// parameters are eventually changed.
+	switch params.Net {
+	case wire.MainNet:
+		return params.HDCoinType, 42
+	default:
+		return params.HDCoinType, 1
+	}
+}
+
 // createAddressManager creates a new address manager in the given namespace.
 // The seed must conform to the standards described in hdkeychain.NewMaster and
 // will be used to create the master root node from which all hierarchical
@@ -2266,16 +2454,35 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
 
-		// Derive the cointype key according to BIP0044.
-		coinTypeKeyPriv, err := deriveCoinTypeKey(root, chainParams.HDCoinType)
+		// Derive the cointype keys according to BIP0044.
+		legacyCoinType, slip0044CoinType := CoinTypes(chainParams)
+		coinTypeLegacyKeyPriv, err := deriveCoinTypeKey(root, legacyCoinType)
 		if err != nil {
-			str := "failed to derive cointype extended key"
+			str := "failed to derive legacy cointype extended key"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		defer coinTypeKeyPriv.Zero()
+		defer coinTypeLegacyKeyPriv.Zero()
+		coinTypeSLIP0044KeyPriv, err := deriveCoinTypeKey(root, slip0044CoinType)
+		if err != nil {
+			str := "failed to derive SLIP0044 cointype extended key"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		defer coinTypeSLIP0044KeyPriv.Zero()
 
 		// Derive the account key for the first account according to BIP0044.
-		acctKeyPriv, err := deriveAccountKey(coinTypeKeyPriv, 0)
+		acctKeyLegacyPriv, err := deriveAccountKey(coinTypeLegacyKeyPriv, 0)
+		if err != nil {
+			// The seed is unusable if the any of the children in the
+			// required hierarchy can't be derived due to invalid child.
+			if err == hdkeychain.ErrInvalidChild {
+				str := "the provided seed is unusable"
+				return managerError(apperrors.ErrKeyChain, str,
+					hdkeychain.ErrUnusableSeed)
+			}
+
+			return err
+		}
+		acctKeySLIP0044Priv, err := deriveAccountKey(coinTypeSLIP0044KeyPriv, 0)
 		if err != nil {
 			// The seed is unusable if the any of the children in the
 			// required hierarchy can't be derived due to invalid child.
@@ -2290,7 +2497,18 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 
 		// Ensure the branch keys can be derived for the provided seed according
 		// to BIP0044.
-		if err := checkBranchKeys(acctKeyPriv); err != nil {
+		if err := checkBranchKeys(acctKeyLegacyPriv); err != nil {
+			// The seed is unusable if the any of the children in the
+			// required hierarchy can't be derived due to invalid child.
+			if err == hdkeychain.ErrInvalidChild {
+				str := "the provided seed is unusable"
+				return managerError(apperrors.ErrKeyChain, str,
+					hdkeychain.ErrUnusableSeed)
+			}
+
+			return err
+		}
+		if err := checkBranchKeys(acctKeySLIP0044Priv); err != nil {
 			// The seed is unusable if the any of the children in the
 			// required hierarchy can't be derived due to invalid child.
 			if err == hdkeychain.ErrInvalidChild {
@@ -2303,9 +2521,14 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 		}
 
 		// The address manager needs the public extended key for the account.
-		acctKeyPub, err := acctKeyPriv.Neuter()
+		acctKeyLegacyPub, err := acctKeyLegacyPriv.Neuter()
 		if err != nil {
-			str := "failed to convert private key for account 0"
+			str := "failed to convert private key for legacy account 0"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		acctKeySLIP0044Pub, err := acctKeySLIP0044Priv.Neuter()
+		if err != nil {
+			str := "failed to convert private key for SLIP0044 account 0"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
 
@@ -2372,50 +2595,97 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 			return managerError(apperrors.ErrCrypto, str, err)
 		}
 
-		// Encrypt the cointype keys with the associated crypto keys.
-		coinTypeKeyPub, err := coinTypeKeyPriv.Neuter()
+		// Encrypt the legacy cointype keys with the associated crypto keys.
+		coinTypeLegacyKeyPub, err := coinTypeLegacyKeyPriv.Neuter()
 		if err != nil {
-			str := "failed to convert cointype private key"
+			str := "failed to convert legacy cointype private key"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		ctpes, err := coinTypeKeyPub.String()
+		ctpes, err := coinTypeLegacyKeyPub.String()
 		if err != nil {
-			str := "failed to convert cointype public key string"
+			str := "failed to convert legacy cointype public key string"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		coinTypePubEnc, err := cryptoKeyPub.Encrypt([]byte(ctpes))
+		coinTypeLegacyPubEnc, err := cryptoKeyPub.Encrypt([]byte(ctpes))
 		if err != nil {
-			str := "failed to encrypt cointype public key"
+			str := "failed to encrypt legacy cointype public key"
 			return managerError(apperrors.ErrCrypto, str, err)
 		}
-		ctpes, err = coinTypeKeyPriv.String()
+		ctpes, err = coinTypeLegacyKeyPriv.String()
 		if err != nil {
-			str := "failed to convert cointype private key string"
+			str := "failed to convert legacy cointype private key string"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		coinTypePrivEnc, err := cryptoKeyPriv.Encrypt([]byte(ctpes))
+		coinTypeLegacyPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(ctpes))
 		if err != nil {
-			str := "failed to encrypt cointype private key"
+			str := "failed to encrypt legacy cointype private key"
+			return managerError(apperrors.ErrCrypto, str, err)
+		}
+
+		// Encrypt the SLIP0044 cointype keys with the associated crypto keys.
+		coinTypeSLIP0044KeyPub, err := coinTypeSLIP0044KeyPriv.Neuter()
+		if err != nil {
+			str := "failed to convert SLIP0044 cointype private key"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		ctpes, err = coinTypeSLIP0044KeyPub.String()
+		if err != nil {
+			str := "failed to convert SLIP0044 cointype public key string"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		coinTypeSLIP0044PubEnc, err := cryptoKeyPub.Encrypt([]byte(ctpes))
+		if err != nil {
+			str := "failed to encrypt SLIP0044 cointype public key"
+			return managerError(apperrors.ErrCrypto, str, err)
+		}
+		ctpes, err = coinTypeSLIP0044KeyPriv.String()
+		if err != nil {
+			str := "failed to convert SLIP0044 cointype private key string"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		coinTypeSLIP0044PrivEnc, err := cryptoKeyPriv.Encrypt([]byte(ctpes))
+		if err != nil {
+			str := "failed to encrypt SLIP0044 cointype private key"
 			return managerError(apperrors.ErrCrypto, str, err)
 		}
 
 		// Encrypt the default account keys with the associated crypto keys.
-		apes, err := acctKeyPub.String()
+		apes, err := acctKeyLegacyPub.String()
 		if err != nil {
 			str := "failed to convert public key string for account 0"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		acctPubEnc, err := cryptoKeyPub.Encrypt([]byte(apes))
+		acctPubLegacyEnc, err := cryptoKeyPub.Encrypt([]byte(apes))
 		if err != nil {
 			str := "failed to encrypt public key for account 0"
 			return managerError(apperrors.ErrCrypto, str, err)
 		}
-		apes, err = acctKeyPriv.String()
+		apes, err = acctKeyLegacyPriv.String()
 		if err != nil {
 			str := "failed to convert private key string for account 0"
 			return managerError(apperrors.ErrKeyChain, str, err)
 		}
-		acctPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(apes))
+		acctPrivLegacyEnc, err := cryptoKeyPriv.Encrypt([]byte(apes))
+		if err != nil {
+			str := "failed to encrypt private key for account 0"
+			return managerError(apperrors.ErrCrypto, str, err)
+		}
+		apes, err = acctKeySLIP0044Pub.String()
+		if err != nil {
+			str := "failed to convert public key string for account 0"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		acctPubSLIP0044Enc, err := cryptoKeyPub.Encrypt([]byte(apes))
+		if err != nil {
+			str := "failed to encrypt public key for account 0"
+			return managerError(apperrors.ErrCrypto, str, err)
+		}
+		apes, err = acctKeySLIP0044Priv.String()
+		if err != nil {
+			str := "failed to convert private key string for account 0"
+			return managerError(apperrors.ErrKeyChain, str, err)
+		}
+		acctPrivSLIP0044Enc, err := cryptoKeyPriv.Encrypt([]byte(apes))
 		if err != nil {
 			str := "failed to encrypt private key for account 0"
 			return managerError(apperrors.ErrCrypto, str, err)
@@ -2436,14 +2706,20 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 			return err
 		}
 
-		// Save the encrypted cointype keys to the database.
-		err = putCoinTypeKeys(ns, coinTypePubEnc, coinTypePrivEnc)
+		// Save the encrypted legacy cointype keys to the database.
+		err = putCoinTypeLegacyKeys(ns, coinTypeLegacyPubEnc, coinTypeLegacyPrivEnc)
 		if err != nil {
 			return err
 		}
 
-		// Save the fact this is a watching-only address manager to
-		// the database.
+		// Save the encrypted SLIP0044 cointype keys.
+		err = putCoinTypeSLIP0044Keys(ns, coinTypeSLIP0044PubEnc, coinTypeSLIP0044PrivEnc)
+		if err != nil {
+			return err
+		}
+
+		// Save the fact this is not a watching-only address manager to the
+		// database.
 		err = putWatchingOnly(ns, false)
 		if err != nil {
 			return err
@@ -2469,10 +2745,27 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 			return err
 		}
 
-		// Save the information for the default account to the database.
-		defaultRow := bip0044AccountInfo(acctPubEnc, acctPrivEnc, 0, 0, 0, 0, 0, 0,
-			defaultAccountName, initialVersion)
-		return putAccountInfo(ns, DefaultAccountNum, defaultRow)
+		// Save the information for the default account to the database.  This
+		// account is derived from the legacy coin type.
+		defaultRow := bip0044AccountInfo(acctPubLegacyEnc, acctPrivLegacyEnc,
+			0, 0, 0, 0, 0, 0, defaultAccountName, initialVersion)
+		err = putAccountInfo(ns, DefaultAccountNum, defaultRow)
+		if err != nil {
+			return err
+		}
+
+		// Save the account row for the 0th account derived from the coin type
+		// 42 key.
+		slip0044Account0Row := bip0044AccountInfo(acctPubSLIP0044Enc, acctPrivSLIP0044Enc,
+			0, 0, 0, 0, 0, 0, defaultAccountName, initialVersion)
+		mainBucket := ns.NestedReadWriteBucket(mainBucketName)
+		err = mainBucket.Put(slip0044Account0RowName, serializeAccountRow(&slip0044Account0Row.dbAccountRow))
+		if err != nil {
+			const desc = "failed to write SLIP0044 account row to main bucket"
+			return apperrors.Wrap(err, apperrors.ErrDatabase, desc)
+		}
+
+		return nil
 	}()
 	if err != nil {
 		return maybeConvertDbError(err)
@@ -2646,8 +2939,7 @@ func createWatchOnly(ns walletdb.ReadWriteBucket, hdPubKey string,
 		return err
 	}
 
-	// Save the fact this is not a watching-only address manager to
-	// the database.
+	// Save the fact this is a watching-only address manager to the database.
 	err = putWatchingOnly(ns, true)
 	if err != nil {
 		return err

--- a/wallet/udb/cointype_test.go
+++ b/wallet/udb/cointype_test.go
@@ -1,0 +1,214 @@
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package udb
+
+import (
+	"testing"
+
+	"github.com/decred/dcrd/chaincfg"
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/hdkeychain"
+	"github.com/decred/dcrwallet/apperrors"
+	"github.com/decred/dcrwallet/walletdb"
+)
+
+func TestCoinTypes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		params                           *chaincfg.Params
+		legacyCoinType, slip0044CoinType uint32
+	}{
+		{&chaincfg.MainNetParams, 20, 42},
+		{&chaincfg.TestNet2Params, 11, 1},
+		{&chaincfg.SimNetParams, 115, 1},
+	}
+	for _, test := range tests {
+		legacyCoinType, slip0044CoinType := CoinTypes(test.params)
+		if legacyCoinType != test.legacyCoinType {
+			t.Errorf("%s: got legacy coin type %d, expected %d", test.params.Name,
+				legacyCoinType, test.legacyCoinType)
+		}
+		if slip0044CoinType != test.slip0044CoinType {
+			t.Errorf("%s: got SLIP0044 coin type %d, expected %d", test.params.Name,
+				slip0044CoinType, test.slip0044CoinType)
+		}
+	}
+}
+
+func deriveChildAddress(accountExtKey *hdkeychain.ExtendedKey, branch, child uint32, params *chaincfg.Params) (dcrutil.Address, error) {
+	branchKey, err := accountExtKey.Child(branch)
+	if err != nil {
+		return nil, err
+	}
+	addressKey, err := branchKey.Child(child)
+	if err != nil {
+		return nil, err
+	}
+	return addressKey.Address(params)
+}
+
+func equalExtKeys(k0, k1 *hdkeychain.ExtendedKey) bool {
+	s0, e0 := k0.String()
+	s1, e1 := k1.String()
+	return e0 == nil && e1 == nil && s0 == s1
+}
+
+func TestCoinTypeUpgrade(t *testing.T) {
+	t.Parallel()
+
+	db, teardown := tempDB(t)
+	defer teardown()
+
+	params := &chaincfg.TestNet2Params
+
+	err := Initialize(db, params, seed, pubPass, privPassphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m, _, _, err := Open(db, params, pubPass)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	legacyCoinType, slip0044CoinType := CoinTypes(params)
+
+	masterExtKey, err := hdkeychain.NewMaster(seed, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyCoinTypeExtKey, err := deriveCoinTypeKey(masterExtKey, legacyCoinType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044CoinTypeExtKey, err := deriveCoinTypeKey(masterExtKey, slip0044CoinType)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account0ExtKey, err := deriveAccountKey(slip0044CoinTypeExtKey, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account0ExtKey, err = slip0044Account0ExtKey.Neuter()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account1ExtKey, err := deriveAccountKey(slip0044CoinTypeExtKey, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account1ExtKey, err = slip0044Account1ExtKey.Neuter()
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account0Address0, err := deriveChildAddress(slip0044Account0ExtKey, 0, 0, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slip0044Account1Address0, err := deriveChildAddress(slip0044Account1ExtKey, 0, 0, params)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = walletdb.Update(db, func(dbtx walletdb.ReadWriteTx) error {
+		ns := dbtx.ReadWriteBucket(waddrmgrBucketKey)
+		err := m.Unlock(ns, privPassphrase)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Check reported initial coin type and compare the key itself against
+		// the expected value.
+		coinType, err := m.CoinType(dbtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if coinType != legacyCoinType {
+			t.Fatalf("initialized database has wrong coin type %d", coinType)
+		}
+		coinTypeExtKey, err := m.CoinTypePrivKey(dbtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !equalExtKeys(coinTypeExtKey, legacyCoinTypeExtKey) {
+			t.Fatalf("initialized database has wrong coin type key")
+		}
+
+		// Perform the upgrade
+		err = m.UpgradeToSLIP0044CoinType(dbtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Check upgraded coin type and keys.
+		coinType, err = m.CoinType(dbtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if coinType != slip0044CoinType {
+			t.Fatalf("upgraded database has wrong coin type %d", coinType)
+		}
+		coinTypeExtKey, err = m.CoinTypePrivKey(dbtx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !equalExtKeys(coinTypeExtKey, slip0044CoinTypeExtKey) {
+			t.Fatalf("upgraded database has wrong coin type key")
+		}
+
+		// Check the account 0 xpub matches the one derived from the SLIP0044
+		// coin type.
+		accountExtKey, err := m.AccountExtendedPubKey(dbtx, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !equalExtKeys(accountExtKey, slip0044Account0ExtKey) {
+			t.Fatalf("upgraded database has wrong account xpub")
+		}
+
+		// Check that the SLIP0044-derived account 0's first address can be
+		// created and is indexed.
+		err = m.SyncAccountToAddrIndex(ns, 0, 1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !m.ExistsHash160(ns, slip0044Account0Address0.Hash160()[:]) {
+			t.Fatalf("upgraded database does not record SLIP0044-derived account 0 branch 0 address 0")
+		}
+
+		// Create the next account, and perform all of the same checks on it as
+		// the first account.
+		_, err = m.NewAccount(ns, "account-1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		accountExtKey, err = m.AccountExtendedPubKey(dbtx, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !equalExtKeys(accountExtKey, slip0044Account1ExtKey) {
+			t.Fatal("upgraded database derived wrong account xpub")
+		}
+		err = m.SyncAccountToAddrIndex(ns, 1, 1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !m.ExistsHash160(ns, slip0044Account1Address0.Hash160()[:]) {
+			t.Fatalf("upgraded database does not record SLIP0044-derived account 1 branch 0 address 0")
+		}
+
+		// Check that the upgrade can not be performed a second time.
+		err = m.UpgradeToSLIP0044CoinType(dbtx)
+		if !apperrors.IsError(err, apperrors.ErrUnsupported) {
+			t.Fatalf("upgrade database did not refuse second upgrade with ErrUnsupported")
+		}
+
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/wallet/udb/common_test.go
+++ b/wallet/udb/common_test.go
@@ -4,24 +4,11 @@
 // license that can be found in the LICENSE file.
 
 // Test must be updated for API changes.
-//+build disabled
 
 package udb
 
 import (
 	"encoding/hex"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"testing"
-
-	"github.com/boltdb/bolt"
-	"github.com/decred/dcrd/chaincfg"
-	"github.com/decred/dcrd/chaincfg/chainhash"
-	"github.com/decred/dcrd/wire"
-	"github.com/decred/dcrwallet/apperrors"
-	"github.com/decred/dcrwallet/walletdb"
-	_ "github.com/decred/dcrwallet/walletdb/bdb"
 )
 
 var (
@@ -45,138 +32,7 @@ var (
 		R: 8,
 		P: 1,
 	}
-
-	// expectedAddrs is the list of all expected addresses generated from the
-	// seed.
-	expectedAddrs = []expectedAddr{
-		{
-			address:     "TsU4c9NBMajGb5eYv8Nf6mW9yaQoQCYcUpR",
-			addressHash: hexToBytes("21604e6679b943734c61297c94bc6e347d19722a"),
-			internal:    false,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("02065884ce63ee2f66e82f8aa7b8a584bd0cb658a16860ea1c685dc6499b06dad1"),
-			privKey:     hexToBytes("31258faa30c4f36b600682cf586db377e327a7f2fdcef39a91e18f5e6e9b8839"),
-			privKeyWIF:  "PtWTuWf7uRYgteK8tDtfwNWdhADh9auKtrE8nNUyGdLAprZLYMPCc",
-		},
-		{
-			address:     "TsThths61ijMNmyK5r5uJirYh9x2Dz5mkcb",
-			addressHash: hexToBytes("1d756518d95c3736a4316e7ee2b2f88da2d2d4ad"),
-			internal:    false,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("03799f30387b2a8c65591368cf7d9d9d5e4245f369a90895c4e2b22e811a18796a"),
-			privKey:     hexToBytes("9023cb7b8e9ae0a2cd411a07adeeff7780e9f1906e3de811f25a6a0ea3c404e5"),
-			privKeyWIF:  "PtWUdM8TCGSju37965fkkq1GrEuhfiNzu8zcEc8uN65H4ni9JzXTX",
-		},
-		{
-			address:     "TsnjoqZTUMC4n86KrJqTxsSxfcVZLknRhpt",
-			addressHash: hexToBytes("ee3c8dbf4bd6f66f7350f4653dd103f7e78cc72f"),
-			internal:    false,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("03dd95cca091f9d06e0cfdfccac75f15057a11e350d416efffda9ec17e61e2a925"),
-			privKey:     hexToBytes("9c88b9f930f90f958743671a0dd8e9f74a812928d3a2d1d29e30efb63f5b99b4"),
-			privKeyWIF:  "PtWUioixEtzc1ErPYykYbJtZSyuWkiXfeppNCuzuK4HFm959M8EQX",
-		},
-		{
-			address:     "TsbKRJEDT4ojPoYqVM6Y9xvfAsTbC4tHYx7",
-			addressHash: hexToBytes("70f65f12e52786853d53cdf126c03b61b7421948"),
-			internal:    false,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("03c642fc8e9133682787b70f0a11958617353c6d9a850ebd346b1e5769a5273dee"),
-			privKey:     hexToBytes("a29362a8d9c45754468bcc106e56fc085e61d13cca95aa68e618e96e7fce4b7d"),
-			privKeyWIF:  "PtWUmU3qCju8NeXguuAqnHpVHrQpJMQBWTywkwJeXKkXgg8hSqgXG",
-		},
-		{
-			address:     "TsgpA7siAKgSWa5cdm6PPJ8WjZHuZBzTWw7",
-			addressHash: hexToBytes("ad3e648f4a3ffe73816fc2ead468b955514a10c9"),
-			internal:    false,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("03bd60247ae5cda41aa6c0da7f36b9c296ae591fccf7bcb6c5207c8968a5ff08a9"),
-			privKey:     hexToBytes("4f2ad247fba882d746199af6b32e3f12d1790d6a8ae512720d4dee2db6f7375b"),
-			privKeyWIF:  "PtWU8jVXVuntE1Jazn4e3NUofYR1cveo9LZhHpN9frA2hvwnzNn36",
-		},
-		{
-			address:     "TsTQPUbv4Amvbf2W7YpJtz56Fz3kynP6JUB",
-			addressHash: hexToBytes("1a25ecba04a7552fc875420738badfe47e6dbf0e"),
-			internal:    true,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("038c2816d53e69e4bda46c208070a0dc08a53324b8ab06012b22dd01333650d29b"),
-			privKey:     hexToBytes("1fbe840701f9f8b76c3caea7c6830388f3e6004bde25a2f3aafa9803e5c46a94"),
-			privKeyWIF:  "PtWTmr8izsePN9u3AUcoDpXz6sSLKUa9H8B6fDF2wX8cyQEXYoKWP",
-		},
-		{
-			address:     "TsauUQn4HJDszuRVHNo6vjsVZphBVDQwwdG",
-			addressHash: hexToBytes("6c6efca0cde6bb8c83468a0f454ab3c63758cd63"),
-			internal:    true,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("0393c925e9e3e551c67f3c2a24dd0a9d760a6006d194906b8a4f25b7a02cf89fb3"),
-			privKey:     hexToBytes("4713f7a949ee00099882e3a78e3962498e794ba8d9fd28587b9bd11a7ea0e9d5"),
-			privKeyWIF:  "PtWU5As1RGTx2dCMzN6SVNB8zxi5NeBxLbw6GiKL4ugX11e8qcUG7",
-		},
-		{
-			address:     "TscWhrFeB8NCZG947cDgRQcoisrMMUgfwXu",
-			addressHash: hexToBytes("7e10e3c8d0ee50dbd565b775ce2ed419a16c188e"),
-			internal:    true,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("03f07840b3a739ffff86c1b9cec4698f6715f2ae3e02bc7c5d769e8a8e367568fe"),
-			privKey:     hexToBytes("47f61ab82da5a4e2bdbd15188f69f20ee72fd58b9a64e135e92c05611e83bfe5"),
-			privKeyWIF:  "PtWU5ZRiTnRc7fT6nWTDMKjrNjdjHDjZpEeza3ioxhmntzvV6RABc",
-		},
-		{
-			address:     "TsUW8wqqr6dFPcEfxZ6vPdaB3JWKVHCdPFD",
-			addressHash: hexToBytes("26346abd270f8155b71581e33e6f4e57cd315709"),
-			internal:    true,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("02ed0450cae4b26aa675181c16e90a6192ff5edd25d8a2e91c8503c6d4ded64cef"),
-			privKey:     hexToBytes("be77e3d659da10679b6d45ce9aaf2773fb9622b06cf5676f70dfd6fd08ea9415"),
-			privKeyWIF:  "PtWUykXcL1g4iscr2iLKW5aFbUtDZxZvQmM4NU6rTz4eJKiKSgcG6",
-		},
-		{
-			address:     "TsfHNz4HQ8BzD4Xp3k6VnLJfSsS3NMr7DJS",
-			addressHash: hexToBytes("9c741c8e8faa0fc76e0907127e0145c26ea3b31b"),
-			internal:    true,
-			compressed:  true,
-			imported:    false,
-			pubKey:      hexToBytes("0374af6831563bb7470323ca41289e4b5b1b7c754317bf58a9280ac04a5fd702e9"),
-			privKey:     hexToBytes("fc970de1af191f844fa5b31d0c9ac8490406051c34c031c25865cab104d5e04b"),
-			privKeyWIF:  "PtWVT7LxY4rGwj2826fxgdukkQFT6z6rAAmuhtbqcQVyA9b6qtkyp",
-		},
-	}
-
-	// expectedExternalAddrs is the list of expected external addresses
-	// generated from the seed
-	expectedExternalAddrs = expectedAddrs[:5]
-
-	// expectedInternalAddrs is the list of expected internal addresses
-	// generated from the seed
-	expectedInternalAddrs = expectedAddrs[5:]
 )
-
-// checkManagerError ensures the passed error is a ManagerError with an error
-// code that matches the passed  error code.
-func checkManagerError(t *testing.T, testName string, gotErr error, wantErrCode apperrors.Code) bool {
-	merr, ok := gotErr.(apperrors.E)
-	if !ok {
-		t.Errorf("%s: unexpected error type - got %T, want %T",
-			testName, gotErr, waddrmgr.ManagerError{})
-		return false
-	}
-	if merr.ErrorCode != wantErrCode {
-		t.Errorf("%s: unexpected error code - got %s (%s), want %s",
-			testName, merr.ErrorCode, merr.Description, wantErrCode)
-		return false
-	}
-
-	return true
-}
 
 // hexToBytes is a wrapper around hex.DecodeString that panics if there is an
 // error.  It MUST only be used with hard coded values in the tests.
@@ -186,40 +42,4 @@ func hexToBytes(origHex string) []byte {
 		panic(err)
 	}
 	return buf
-}
-
-// setupManager creates a new address manager and returns a teardown function
-// that should be invoked to ensure it is closed and removed upon completion.
-func setupManager(t *testing.T) (tearDownFunc func(), mgr *Manager) {
-	t.Parallel()
-
-	// Create a new manager in a temp directory.
-	dirName, err := ioutil.TempDir("", "mgrtest")
-	if err != nil {
-		t.Fatalf("Failed to create db temp dir: %v", err)
-	}
-	dbPath := filepath.Join(dirName, "mgrtest.db")
-	db, namespace, err := createDbNamespace(dbPath)
-	if err != nil {
-		_ = os.RemoveAll(dirName)
-		t.Fatalf("createDbNamespace: unexpected error: %v", err)
-	}
-	err = waddrmgr.Create(namespace, seed, pubPassphrase,
-		privPassphrase, &chaincfg.MainNetParams, fastScrypt, false)
-	if err == nil {
-		mgr, err = waddrmgr.Open(namespace, pubPassphrase,
-			&chaincfg.TestNetParams, nil)
-	}
-
-	if err != nil {
-		db.Close()
-		_ = os.RemoveAll(dirName)
-		t.Fatalf("Failed to create Manager: %v", err)
-	}
-	tearDownFunc = func() {
-		mgr.Close()
-		db.Close()
-		_ = os.RemoveAll(dirName)
-	}
-	return tearDownFunc, mgr
 }

--- a/wallet/udb/txcommon_test.go
+++ b/wallet/udb/txcommon_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/boltdb/bolt"
@@ -70,6 +71,23 @@ func setupBoltDB() (db *bolt.DB, teardown func(), err error) {
 		os.Remove(f.Name())
 	}
 	db, err = bolt.Open(f.Name(), 0600, nil)
+	return
+}
+
+func tempDB(t *testing.T) (db walletdb.DB, teardown func()) {
+	f, err := ioutil.TempFile("", "udb")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	db, err = walletdb.Create("bdb", f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	teardown = func() {
+		db.Close()
+		os.Remove(f.Name())
+	}
 	return
 }
 

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -30,6 +30,7 @@ var dbUpgradeTests = [...]struct {
 	{verifyV4Upgrade, "v3.db.gz"},
 	{verifyV5Upgrade, "v4.db.gz"},
 	{verifyV6Upgrade, "v5.db.gz"},
+	// No upgrade test for V7, it is a backwards-compatible upgrade
 }
 
 var pubPass = []byte("public")


### PR DESCRIPTION
This change modifies the wallet to prefer the use of the coin types
assigned to Decred in SLIP0044 over the coin types used thus far.  New
wallets that are created with a random seed are created using the
SLIP0044 coin type, and if no address usage from the legacy coin type
is found during address discovery, the wallet is automatically
upgraded to use the SLIP0044 coin type instead.

This change introduces a database upgrade and older versions of the
wallet will not work on upgraded wallet DBs.

Closes #945.