### PR TITLE
Move application version code to its own package.

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/decred/dcrwallet/internal/cfgutil"
 	"github.com/decred/dcrwallet/netparams"
 	"github.com/decred/dcrwallet/ticketbuyer"
+	"github.com/decred/dcrwallet/version"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/wallet/txrules"
 	flags "github.com/jessevdk/go-flags"
@@ -397,7 +398,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		fmt.Printf("%s version %s (Go version %s)\n", appName, version(), runtime.Version())
+		fmt.Printf("%s version %s (Go version %s)\n", appName, version.String(), runtime.Version())
 		os.Exit(0)
 	}
 

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -24,6 +24,7 @@ import (
 	ldr "github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/rpc/legacyrpc"
 	"github.com/decred/dcrwallet/rpc/rpcserver"
+	"github.com/decred/dcrwallet/version"
 	"github.com/decred/dcrwallet/wallet"
 )
 
@@ -73,7 +74,7 @@ func run(ctx context.Context) error {
 	}()
 
 	// Show version at startup.
-	log.Infof("Version %s (Go version %s)", version(), runtime.Version())
+	log.Infof("Version %s (Go version %s)", version.String(), runtime.Version())
 
 	// Read IPC messages from the read end of a pipe created and passed by the
 	// parent process, if any.  When this pipe is closed, shutdown is

--- a/version/version.go
+++ b/version/version.go
@@ -3,7 +3,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package version
 
 import (
 	"bytes"
@@ -11,48 +11,48 @@ import (
 	"strings"
 )
 
-// semanticAlphabet
-const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
 
-// These constants define the application version and follow the semantic
-// versioning 2.0.0 spec (http://semver.org/).
+// Constants defining the application version number.
 const (
-	appMajor uint = 1
-	appMinor uint = 1
-	appPatch uint = 0
-
-	// appPreRelease MUST only contain characters from semanticAlphabet
-	// per the semantic versioning spec.
-	appPreRelease = ""
+	Major = 1
+	Minor = 1
+	Patch = 0
 )
 
-// appBuild is defined as a variable so it can be overridden during the build
-// process with '-ldflags "-X main.appBuild=foo' if needed.  It MUST only
-// contain characters from semanticAlphabet per the semantic versioning spec.
-var appBuild = "dev"
+// PreRelease contains the prerelease name of the application.  It is a variable
+// so it can be modified at link time (e.g.
+// `-ldflags "-X github.com/decred/dcrwallet/version.PreRelease=rc1"`).
+// It must only contain characters from the semantic version alphabet.
+var PreRelease = ""
 
-// version returns the application version as a properly formed string per the
+// BuildMetadata defines additional build metadata.  It is modified at link time
+// for official releases.  It must only contain characters from the semantic
+// version alphabet.
+var BuildMetadata = "dev"
+
+// String returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (http://semver.org/).
-func version() string {
+func String() string {
 	// Start with the major, minor, and path versions.
-	version := fmt.Sprintf("%d.%d.%d", appMajor, appMinor, appPatch)
+	version := fmt.Sprintf("%d.%d.%d", Major, Minor, Patch)
 
 	// Append pre-release version if there is one.  The hyphen called for
 	// by the semantic versioning spec is automatically appended and should
 	// not be contained in the pre-release string.  The pre-release version
 	// is not appended if it contains invalid characters.
-	preRelease := normalizeVerString(appPreRelease)
+	preRelease := normalizeVerString(PreRelease)
 	if preRelease != "" {
-		version = fmt.Sprintf("%s-%s", version, preRelease)
+		version = version + "-" + preRelease
 	}
 
 	// Append build metadata if there is any.  The plus called for
 	// by the semantic versioning spec is automatically appended and should
 	// not be contained in the build metadata string.  The build metadata
 	// string is not appended if it contains invalid characters.
-	build := normalizeVerString(appBuild)
-	if build != "" {
-		version = fmt.Sprintf("%s+%s", version, build)
+	buildMetadata := normalizeVerString(BuildMetadata)
+	if buildMetadata != "" {
+		version = version + "+" + buildMetadata
 	}
 
 	return version
@@ -63,10 +63,10 @@ func version() string {
 // version and build metadata strings.  In particular they MUST only contain
 // characters in semanticAlphabet.
 func normalizeVerString(str string) string {
-	result := bytes.Buffer{}
+	var buf bytes.Buffer
 	for _, r := range str {
-		if strings.ContainsRune(semanticAlphabet, r) {
-			_, err := result.WriteRune(r)
+		if strings.ContainsRune(semverAlphabet, r) {
+			_, err := buf.WriteRune(r)
 			// Writing to a bytes.Buffer panics on OOM, and all
 			// errors are unexpected.
 			if err != nil {
@@ -74,5 +74,5 @@ func normalizeVerString(str string) string {
 			}
 		}
 	}
-	return result.String()
+	return buf.String()
 }


### PR DESCRIPTION
This allows access to the application version info from other wallet
packages, which is of particular use for useragent strings when using
the wire protocol.