### PR TITLE
Add TX pipe and RPC listener events.

### DIFF
--- a/config.go
+++ b/config.go
@@ -114,7 +114,6 @@ type config struct {
 	AllowHighFees       bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
 	RelayFee            *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`
 	TicketFee           *cfgutil.AmountFlag  `long:"ticketfee" description:"Sets the wallet's ticket fee per kb"`
-	PipeRx              *uint                `long:"piperx" description:"File descriptor of read end pipe to enable parent -> child process communication"`
 
 	// RPC client options
 	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to"`
@@ -147,6 +146,11 @@ type config struct {
 	LegacyRPCMaxWebsockets int64                   `long:"rpcmaxwebsockets" description:"Max number of legacy JSON-RPC websocket connections"`
 	Username               string                  `short:"u" long:"username" description:"Username for legacy JSON-RPC and dcrd authentication (if dcrdusername is unset)"`
 	Password               string                  `short:"P" long:"password" default-mask:"-" description:"Password for legacy JSON-RPC and dcrd authentication (if dcrdpassword is unset)"`
+
+	// IPC options
+	PipeTx            *uint `long:"pipetx" description:"File descriptor or handle of write end pipe to enable child -> parent process communication"`
+	PipeRx            *uint `long:"piperx" description:"File descriptor or handle of read end pipe to enable parent -> child process communication"`
+	RPCListenerEvents bool  `long:"rpclistenerevents" description:"Notify JSON-RPC and gRPC listener addresses over the TX pipe"`
 
 	TBOpts ticketBuyerOptions `group:"Ticket Buyer Options" namespace:"ticketbuyer"`
 	tbCfg  ticketbuyer.Config

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -82,6 +82,11 @@ func run(ctx context.Context) error {
 	if cfg.PipeRx != nil {
 		go serviceControlPipeRx(uintptr(*cfg.PipeRx))
 	}
+	if cfg.PipeTx != nil {
+		go serviceControlPipeTx(uintptr(*cfg.PipeTx))
+	} else {
+		go drainOutgoingPipeMessages()
+	}
 
 	// Run the pprof profiler if enabled.
 	if len(cfg.Profile) > 0 {

--- a/ipc.go
+++ b/ipc.go
@@ -7,10 +7,26 @@ package main
 
 import (
 	"bufio"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 )
+
+// Messages sent over a pipe are encoded using a simple binary message format:
+//
+//   - Protocol version (1 byte, currently 1)
+//   - Message type length (1 byte)
+//   - Message type string (encoded as UTF8, no longer than 255 bytes)
+//   - Message payload length (4 bytes, little endian)
+//   - Message payload bytes (no longer than 2^32 - 1 bytes)
+type pipeMessage interface {
+	Type() string
+	PayloadSize() uint32
+	WritePayload(w io.Writer) error
+}
+
+var outgoingPipeMessages = make(chan pipeMessage)
 
 // serviceControlPipeRx reads from the file descriptor fd of a read end pipe.
 // This is intended to be used as a simple control mechanism for parent
@@ -40,4 +56,120 @@ func serviceControlPipeRx(fd uintptr) {
 	}
 
 	shutdownRequestChannel <- struct{}{}
+}
+
+// serviceControlPipeTx sends pipe messages to the file descriptor fd of a write
+// end pipe.  This is intended to be a simple response and notification system
+// for a child dcrd process to communicate with a parent process without the
+// need to go through the RPC server.
+//
+// See the comment on the pipeMessage interface for the binary encoding of a
+// pipe message.
+func serviceControlPipeTx(fd uintptr) {
+	defer drainOutgoingPipeMessages()
+
+	pipe := os.NewFile(fd, fmt.Sprintf("|%v", fd))
+	w := bufio.NewWriter(pipe)
+	headerBuffer := make([]byte, 0, 1+1+255+4) // capped to max header size
+	var err error
+	for m := range outgoingPipeMessages {
+		const protocolVersion byte = 1
+
+		mtype := m.Type()
+		psize := m.PayloadSize()
+
+		headerBuffer = append(headerBuffer, protocolVersion)
+		headerBuffer = append(headerBuffer, byte(len(mtype)))
+		headerBuffer = append(headerBuffer, mtype...)
+		buf := make([]byte, 4)
+		binary.LittleEndian.PutUint32(buf, psize)
+		headerBuffer = append(headerBuffer, buf...)
+
+		_, err = w.Write(headerBuffer)
+		if err != nil {
+			break
+		}
+
+		err = m.WritePayload(w)
+		if err != nil {
+			break
+		}
+
+		err = w.Flush()
+		if err != nil {
+			break
+		}
+
+		headerBuffer = headerBuffer[:0]
+	}
+
+	log.Errorf("Failed to write to pipe: %v", err)
+}
+
+func drainOutgoingPipeMessages() {
+	for range outgoingPipeMessages {
+	}
+}
+
+// The jsonrpcListenerEvent is used to notify the listener addresses used for
+// the legacy JSON-RPC server.  The message type is "jsonrpclistener".  This
+// event is most notably useful when parent processes start the wallet with
+// listener addresses bound on port 0 to cause the operating system to select an
+// unused port.
+//
+// The payload is the UTF8 bytes of the listener address, and the payload size
+// is the byte length of the string.
+type jsonrpcListenerEvent string
+
+var _ pipeMessage = jsonrpcListenerEvent("")
+
+func (jsonrpcListenerEvent) Type() string          { return "jsonrpclistener" }
+func (e jsonrpcListenerEvent) PayloadSize() uint32 { return uint32(len(e)) }
+func (e jsonrpcListenerEvent) WritePayload(w io.Writer) error {
+	_, err := w.Write([]byte(e))
+	return err
+}
+
+type jsonrpcListenerEventServer chan<- pipeMessage
+
+func newJSONRPCListenerEventServer(outChan chan<- pipeMessage) jsonrpcListenerEventServer {
+	return jsonrpcListenerEventServer(outChan)
+}
+
+func (s jsonrpcListenerEventServer) notify(laddr string) {
+	if s == nil {
+		return
+	}
+	s <- jsonrpcListenerEvent(laddr)
+}
+
+// The grpcListenerEvent is used to notify the listener addresses used for the
+// gRPC server.  The message type is "grpclistener".  This event is most notably
+// useful when parent processes start the wallet with listener addresses bound
+// on port 0 to cause the operating system to select an unused port.
+//
+// The payload is the UTF8 bytes of the listener address, and the payload size
+// is the byte length of the string.
+type grpcListenerEvent string
+
+var _ pipeMessage = grpcListenerEvent("")
+
+func (grpcListenerEvent) Type() string          { return "grpclistener" }
+func (e grpcListenerEvent) PayloadSize() uint32 { return uint32(len(e)) }
+func (e grpcListenerEvent) WritePayload(w io.Writer) error {
+	_, err := w.Write([]byte(e))
+	return err
+}
+
+type grpcListenerEventServer chan<- pipeMessage
+
+func newGRPCListenerEventServer(outChan chan<- pipeMessage) grpcListenerEventServer {
+	return grpcListenerEventServer(outChan)
+}
+
+func (s grpcListenerEventServer) notify(laddr string) {
+	if s == nil {
+		return
+	}
+	s <- grpcListenerEvent(laddr)
 }


### PR DESCRIPTION
This changes adds support for the TX IPC pipe (to complement the RX
pipe) and events to notify the listener addresses used by the JSON-RPC
and gRPC servers.  This is useful for parent processes which start the
wallet with a listener address bound to port 0, causing the operating
system to pick an unused port.  A new config option
--rpclistenerevents must be used to enable these messages.

The pipe messages use the same protocol format as dcrd.

Closes #964.