### PR TITLE
Allow duplicate listeners when binding to port 0.

### DIFF
--- a/config.go
+++ b/config.go
@@ -823,7 +823,8 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		return loadConfigError(err)
 	}
 
-	// Both RPC servers may not listen on the same interface/port.
+	// Both RPC servers may not listen on the same interface/port, with the
+	// exception of listeners using port 0.
 	if len(cfg.LegacyRPCListeners) > 0 && len(cfg.GRPCListeners) > 0 {
 		seenAddresses := make(map[string]struct{}, len(cfg.LegacyRPCListeners))
 		for _, addr := range cfg.LegacyRPCListeners {
@@ -831,7 +832,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		}
 		for _, addr := range cfg.GRPCListeners {
 			_, seen := seenAddresses[addr]
-			if seen {
+			if seen && !strings.HasSuffix(addr, ":0") {
 				err := fmt.Errorf("Address `%s` may not be "+
 					"used as a listener address for both "+
 					"RPC servers", addr)


### PR DESCRIPTION
Port 0 indicates that the operating system is free to pick an unused
port, so these listener addresses don't actually clash.