### PR TITLE
Log warnings for failed SLIP0044 coin type upgrades.

### DIFF
--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -377,7 +377,10 @@ func (w *Wallet) DiscoverActiveAddresses(n NetworkBackend, discoverAccts bool) e
 		activeCoinType, slip0044CoinType)
 	err = w.UpgradeToSLIP0044CoinType()
 	if err != nil {
-		return err
+		log.Errorf("Coin type upgrade failed: %v", err)
+		log.Warnf("Continuing with legacy BIP0044 coin type -- seed restores " +
+			"may not work with some other wallet software")
+		return nil
 	}
 	log.Infof("Upgraded coin type.")
 


### PR DESCRIPTION
This prevents a loop where synchronization stops and restarts, hitting
the exact same error again.

Fixes #994.