### PR TITLE
legacyrpc: update legacy rpc handler setup.

### DIFF
--- a/rpc/legacyrpc/errors.go
+++ b/rpc/legacyrpc/errors.go
@@ -71,6 +71,11 @@ var (
 		Message: "Request requires a wallet but wallet has not loaded yet",
 	}
 
+	ErrClientNotConnected = dcrjson.RPCError{
+		Code:    dcrjson.ErrRPCClientNotConnected,
+		Message: "RPC client has not connected yet",
+	}
+
 	ErrWalletUnlockNeeded = dcrjson.RPCError{
 		Code:    dcrjson.ErrRPCWalletUnlockNeeded,
 		Message: "Enter the wallet passphrase with walletpassphrase first",

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -17,9 +17,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/decred/dcrd/blockchain/stake"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/chaincfg/chainec"
@@ -200,7 +197,7 @@ func lazyApplyHandler(s *Server, request *dcrjson.Request) lazyHandler {
 		}
 	}
 
-	if ok && s.chainClient != nil {
+	if s.chainClient != nil {
 		return func() (interface{}, *dcrjson.RPCError) {
 			cmd, err := dcrjson.UnmarshalCmd(request)
 			if err != nil {
@@ -282,7 +279,7 @@ func accountAddressIndex(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account, err := w.AccountNumber(cmd.Account)
@@ -314,7 +311,7 @@ func accountSyncAddressIndex(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.AccountSyncAddressIndexCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account, err := w.AccountNumber(cmd.Account)
@@ -387,7 +384,7 @@ func addMultiSigAddress(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	secp256k1Addrs := make([]dcrutil.Address, len(cmd.Keys))
@@ -422,7 +419,7 @@ func addTicket(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.AddTicketCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	rawTx, err := hex.DecodeString(cmd.TicketHex)
@@ -446,7 +443,7 @@ func consolidate(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ConsolidateCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account := uint32(udb.DefaultAccountNum)
@@ -486,7 +483,7 @@ func createMultiSig(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.CreateMultisigCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	script, err := makeMultiSigScript(w, cmd.Keys, cmd.NRequired)
@@ -513,7 +510,7 @@ func dumpPrivKey(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.DumpPrivKeyCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
@@ -536,7 +533,7 @@ func generateVote(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GenerateVoteCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	blockHash, err := chainhash.NewHashFromStr(cmd.BlockHash)
@@ -589,7 +586,7 @@ func getAddressesByAccount(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetAddressesByAccountCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account, err := w.AccountNumber(cmd.Account)
@@ -635,7 +632,7 @@ func getBalance(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetBalanceCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	minConf := int32(*cmd.MinConf)
@@ -708,7 +705,7 @@ func getBalance(s *Server, icmd interface{}) (interface{}, error) {
 func getBestBlock(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	hash, height := w.MainChainTip()
@@ -724,7 +721,7 @@ func getBestBlock(s *Server, icmd interface{}) (interface{}, error) {
 func getBestBlockHash(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	hash, _ := w.MainChainTip()
@@ -736,7 +733,7 @@ func getBestBlockHash(s *Server, icmd interface{}) (interface{}, error) {
 func getBlockCount(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	_, height := w.MainChainTip()
@@ -749,7 +746,7 @@ func getBlockCount(s *Server, icmd interface{}) (interface{}, error) {
 func getInfo(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 	// Call down to dcrd for all of the information in this command known
 	// by them.
@@ -823,7 +820,7 @@ func getAccount(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
@@ -854,7 +851,7 @@ func getAccountAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetAccountAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account, err := w.AccountNumber(cmd.Account)
@@ -875,7 +872,7 @@ func getUnconfirmedBalance(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetUnconfirmedBalanceCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	acctName := "default"
@@ -900,7 +897,7 @@ func importPrivKey(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ImportPrivKeyCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Ensure that private keys are only imported to the correct account.
@@ -957,7 +954,7 @@ func importScript(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ImportScriptCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	rs, err := hex.DecodeString(cmd.Hex)
@@ -1005,7 +1002,7 @@ func createNewAccount(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.CreateNewAccountCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// The wildcard * is reserved by the rpc server with the special meaning
@@ -1031,7 +1028,7 @@ func renameAccount(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RenameAccountCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// The wildcard * is reserved by the rpc server with the special meaning
@@ -1054,7 +1051,7 @@ func getMultisigOutInfo(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetMultisigOutInfoCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	hash, err := chainhash.NewHashFromStr(cmd.Hash)
@@ -1116,7 +1113,7 @@ func getNewAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetNewAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	var callOpts []wallet.NextAddressCallOption
@@ -1162,7 +1159,7 @@ func getRawChangeAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetRawChangeAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	acctName := "default"
@@ -1189,7 +1186,7 @@ func getReceivedByAccount(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetReceivedByAccountCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account, err := w.AccountNumber(cmd.Account)
@@ -1217,7 +1214,7 @@ func getReceivedByAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetReceivedByAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
@@ -1238,7 +1235,7 @@ func getMasterPubkey(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetMasterPubkeyCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// If no account is passed, we provide the extended public key
@@ -1260,7 +1257,7 @@ func getMasterPubkey(s *Server, icmd interface{}) (interface{}, error) {
 func getStakeInfo(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Asynchronously query for the stake difficulty.
@@ -1309,7 +1306,7 @@ func getStakeInfo(s *Server, icmd interface{}) (interface{}, error) {
 func getTicketFee(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	return w.TicketFeeIncrement().ToCoin(), nil
@@ -1321,7 +1318,7 @@ func getTickets(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetTicketsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	ticketHashes, err := w.LiveTicketHashes(s.dcrrpcClient, cmd.IncludeImmature)
@@ -1344,7 +1341,7 @@ func getTransaction(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetTransactionCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	txSha, err := chainhash.NewHashFromStr(cmd.Txid)
@@ -1491,7 +1488,7 @@ func getTransaction(s *Server, icmd interface{}) (interface{}, error) {
 func getVoteChoices(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	version, agendas := wallet.CurrentAgendas(w.ChainParams())
@@ -1527,7 +1524,7 @@ func getVoteChoices(s *Server, icmd interface{}) (interface{}, error) {
 func getWalletFee(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	return w.RelayFee().ToCoin(), nil
@@ -1626,7 +1623,7 @@ func listAccounts(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListAccountsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	accountBalances := map[string]float64{}
@@ -1650,7 +1647,7 @@ func listAccounts(s *Server, icmd interface{}) (interface{}, error) {
 func listLockUnspent(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	return w.LockedOutpoints(), nil
@@ -1670,7 +1667,7 @@ func listReceivedByAccount(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListReceivedByAccountCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	results, err := w.TotalReceivedForAccounts(int32(*cmd.MinConf))
@@ -1704,7 +1701,7 @@ func listReceivedByAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListReceivedByAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Intermediate data for each address.
@@ -1797,7 +1794,7 @@ func listSinceBlock(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListSinceBlockCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	_, tipHeight := w.MainChainTip()
@@ -1844,7 +1841,7 @@ func listSinceBlock(s *Server, icmd interface{}) (interface{}, error) {
 func listScripts(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	redeemScripts, err := w.FetchAllRedeemScripts()
@@ -1873,7 +1870,7 @@ func listTransactions(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListTransactionsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// TODO: ListTransactions does not currently understand the difference
@@ -1902,7 +1899,7 @@ func listAddressTransactions(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListAddressTransactionsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	if cmd.Account != nil && *cmd.Account != "*" {
@@ -1934,7 +1931,7 @@ func listAllTransactions(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListAllTransactionsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	if cmd.Account != nil && *cmd.Account != "*" {
@@ -1952,7 +1949,7 @@ func listUnspent(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListUnspentCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	var addresses map[string]struct{}
@@ -1976,7 +1973,7 @@ func lockUnspent(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.LockUnspentCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	switch {
@@ -2007,7 +2004,7 @@ func purchaseTicket(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.PurchaseTicketCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	spendLimit, err := dcrutil.NewAmount(cmd.SpendLimit)
@@ -2159,7 +2156,7 @@ func redeemMultiSigOut(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RedeemMultiSigOutCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Convert the address to a useable format. If
@@ -2268,7 +2265,7 @@ func redeemMultiSigOuts(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RedeemMultiSigOutsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Get all the multisignature outpoints that are unspent for this
@@ -2322,7 +2319,7 @@ func rescanWallet(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RescanWalletCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	n := chain.BackendFromRPCClient(s.dcrrpcClient)
@@ -2335,7 +2332,7 @@ func rescanWallet(s *Server, icmd interface{}) (interface{}, error) {
 func revokeTickets(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 	err := w.RevokeTickets(s.dcrrpcClient)
 	return nil, err
@@ -2347,7 +2344,7 @@ func stakePoolUserInfo(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.StakePoolUserInfoCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	userAddr, err := dcrutil.DecodeAddress(cmd.User)
@@ -2400,7 +2397,7 @@ func ticketsForAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.TicketsForAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	addr, err := dcrutil.DecodeAddress(cmd.Address)
@@ -2434,7 +2431,7 @@ func sendFrom(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendFromCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Transaction comments are not yet supported.  Error instead of
@@ -2480,7 +2477,7 @@ func sendMany(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendManyCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Transaction comments are not yet supported.  Error instead of
@@ -2525,7 +2522,7 @@ func sendToAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendToAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Transaction comments are not yet supported.  Error instead of
@@ -2571,7 +2568,7 @@ func sendToMultiSig(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendToMultiSigCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	account := uint32(udb.DefaultAccountNum)
@@ -2642,7 +2639,7 @@ func setTicketFee(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetTicketFeeCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Check that amount is not negative.
@@ -2665,7 +2662,7 @@ func setTxFee(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetTxFeeCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Check that amount is not negative.
@@ -2689,7 +2686,7 @@ func setVoteChoice(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetVoteChoiceCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	_, err := w.SetAgendaChoices(wallet.AgendaChoice{
@@ -2705,7 +2702,7 @@ func signMessage(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignMessageCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
@@ -2727,7 +2724,7 @@ func signRawTransaction(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignRawTransactionCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	serializedTx, err := decodeHexStr(cmd.RawTx)
@@ -2945,7 +2942,7 @@ func signRawTransactions(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignRawTransactionsCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	// Sign each transaction sequentially and record the results.
@@ -3028,7 +3025,7 @@ func validateAddress(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ValidateAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	result := dcrjson.ValidateAddressWalletResult{}
@@ -3189,7 +3186,7 @@ func version(s *Server, icmd interface{}) (interface{}, error) {
 func walletInfo(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	n, err := w.NetworkBackend()
@@ -3233,7 +3230,7 @@ func walletInfo(s *Server, icmd interface{}) (interface{}, error) {
 func walletIsLocked(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	return w.Locked(), nil
@@ -3245,7 +3242,7 @@ func walletIsLocked(s *Server, icmd interface{}) (interface{}, error) {
 func walletLock(s *Server, icmd interface{}) (interface{}, error) {
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	w.Lock()
@@ -3259,7 +3256,7 @@ func walletPassphrase(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.WalletPassphraseCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	timeout := time.Second * time.Duration(cmd.Timeout)
@@ -3282,7 +3279,7 @@ func walletPassphraseChange(s *Server, icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.WalletPassphraseChangeCmd)
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
-		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+		return nil, ErrUnloadedWallet
 	}
 
 	err := w.ChangePrivatePassphrase([]byte(cmd.OldPassphrase),

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -55,7 +55,7 @@ func confirms(txHeight, curHeight int32) int32 {
 }
 
 // the registered rpc handlers
-var handlers = map[string]Handler{
+var handlers = map[string]handler{
 	// Reference implementation wallet methods (implemented)
 	"accountaddressindex":     {fn: accountAddressIndex},
 	"accountsyncaddressindex": {fn: accountSyncAddressIndex},
@@ -104,9 +104,6 @@ var handlers = map[string]Handler{
 	"sendmany":                {fn: sendMany},
 	"sendtoaddress":           {fn: sendToAddress},
 	"sendtomultisig":          {fn: sendToMultiSig},
-	"sendtosstx":              {fn: sendToSStx},
-	"sendtossgen":             {fn: sendToSSGen},
-	"sendtossrtx":             {fn: sendToSSRtx},
 	"setticketfee":            {fn: setTicketFee},
 	"settxfee":                {fn: setTxFee},
 	"setvotechoice":           {fn: setVoteChoice},
@@ -183,8 +180,8 @@ func lazyApplyHandler(s *Server, request *dcrjson.Request) lazyHandler {
 	handlerData, ok := handlers[request.Method]
 	if !ok {
 		return func() (interface{}, *dcrjson.RPCError) {
-			chainClient := s.GetChainServer()
-			if chainClient == nil {
+			chainClient, ok := s.requireChainClient()
+			if !ok {
 				return nil, &dcrjson.RPCError{
 					Code:    -1,
 					Message: "Chain RPC is inactive",
@@ -403,8 +400,8 @@ func addMultiSigAddress(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, err
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -754,8 +751,8 @@ func getInfo(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -914,8 +911,8 @@ func importPrivKey(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -984,8 +981,8 @@ func importScript(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -1300,8 +1297,8 @@ func getStakeInfo(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -1374,8 +1371,8 @@ func getTickets(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -1629,8 +1626,8 @@ func help(s *Server, icmd interface{}) (interface{}, error) {
 	// JSON-RPC clients.  Any errors creating the POST client may be ignored
 	// since the client is not necessary for the request.
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -1876,8 +1873,8 @@ func listSinceBlock(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -2409,8 +2406,8 @@ func rescanWallet(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -2435,8 +2432,8 @@ func revokeTickets(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -2737,8 +2734,8 @@ func sendToMultiSig(s *Server, icmd interface{}) (interface{}, error) {
 		RedeemScript: hex.EncodeToString(script),
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -2950,15 +2947,15 @@ func signRawTransaction(s *Server, icmd interface{}) (interface{}, error) {
 			continue
 		}
 
-		chainClient := s.GetChainServer()
-		// Asynchronously request the output script.
-		if chainClient == nil {
+		chainClient, ok := s.requireChainClient()
+		if !ok {
 			return nil, &dcrjson.RPCError{
 				Code:    -1,
 				Message: "Chain RPC is inactive",
 			}
 		}
 
+		// Asynchronously request the output script.
 		requested[txIn.PreviousOutPoint] = chainClient.GetTxOutAsync(
 			&txIn.PreviousOutPoint.Hash, txIn.PreviousOutPoint.Index,
 			true)
@@ -3069,8 +3066,8 @@ func signRawTransactions(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, ErrUnloadedWallet
 	}
 
-	chainClient := s.GetChainServer()
-	if chainClient == nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		return nil, &dcrjson.RPCError{
 			Code:    -1,
 			Message: "Chain RPC is inactive",
@@ -3293,8 +3290,8 @@ WrongAddrKind:
 // function for the versionWithChainRPC and versionNoChainRPC handlers.
 func version(s *Server, icmd interface{}) (interface{}, error) {
 	var resp map[string]dcrjson.VersionResult
-	chainClient := s.GetChainServer()
-	if chainClient != nil {
+	chainClient, ok := s.requireChainClient()
+	if !ok {
 		var err error
 		resp, err = chainClient.Version()
 		if err != nil {

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -30,6 +30,7 @@ import (
 	"github.com/decred/dcrwallet/apperrors"
 	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/loader"
+	"github.com/decred/dcrwallet/ticketbuyer"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/wallet/txrules"
 	"github.com/decred/dcrwallet/wallet/udb"
@@ -42,6 +43,20 @@ const (
 	jsonrpcSemverMinor  = 0
 	jsonrpcSemverPatch  = 0
 )
+
+// Handler represents a JSON-RPC handler
+type Handler struct {
+	handler func(interface{}) (interface{}, error)
+}
+
+// LegacyServer represents a generic JSON-RPC server
+type LegacyServer struct {
+	wallet      *wallet.Wallet
+	rpcClient   *dcrrpcclient.Client
+	loader      *loader.Loader
+	tCfg        *ticketbuyer.Config
+	rpcHandlers map[string]Handler
+}
 
 // confirms returns the number of confirmations for a transaction in a block at
 // height txHeight (or -1 for an unconfirmed tx) given the chain height

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -85,6 +85,50 @@ func (s *Server) registerHandlers() {
 		"getblockcount":           {fn: s.getBlockCount},
 		"getinfo":                 {fn: s.getInfo},
 		"getmasterpubkey":         {fn: s.getMasterPubkey},
+		"getmultisigoutinfo":      {fn: s.getMultisigOutInfo},
+		"getnewaddress":           {fn: s.getNewAddress},
+		"getrawchangeaddress":     {fn: s.getRawChangeAddress},
+		"getreceivedbyaccount":    {fn: s.getReceivedByAccount},
+		"getreceivedbyaddress":    {fn: s.getReceivedByAddress},
+		"getstakeinfo":            {fn: s.getStakeInfo},
+		"getticketfee":            {fn: s.getTicketFee},
+		"gettickets":              {fn: s.getTickets},
+		"gettransaction":          {fn: s.getTransaction},
+		"getvotechoices":          {fn: s.getVoteChoices},
+		"getwalletfee":            {fn: s.getWalletFee},
+		"importprivkey":           {fn: s.importPrivKey},
+		"importscript":            {fn: s.importScript},
+		"keypoolrefill":           {fn: s.keypoolRefill},
+		"listaccounts":            {fn: s.listAccounts},
+		"listlockunspent":         {fn: s.listLockUnspent},
+		"listreceivedbyaccount":   {fn: s.listReceivedByAccount},
+		"listreceivedbyaddress":   {fn: s.listReceivedByAddress},
+		"listsinceblock":          {fn: s.listSinceBlock},
+		"listscripts":             {fn: s.listScripts},
+		"listtransactions":        {fn: s.listTransactions},
+		"listunspent":             {fn: s.listUnspent},
+		"lockunspent":             {fn: s.lockUnspent},
+		"purchaseticket":          {fn: s.purchaseTicket},
+		"rescanwallet":            {fn: s.rescanWallet},
+		"revoketickets":           {fn: s.revokeTickets},
+		"sendfrom":                {fn: s.sendFrom},
+		"sendmany":                {fn: s.sendMany},
+		"sendtoaddress":           {fn: s.sendToAddress},
+		"sendtomultisig":          {fn: s.sendToMultiSig},
+		"sendtosstx":              {fn: s.sendToSStx},
+		"sendtossgen":             {fn: s.sendToSSGen},
+		"sendtossrtx":             {fn: s.sendToSSRtx},
+		"setticketfee":            {fn: s.setTicketFee},
+		"settxfee":                {fn: s.setTxFee},
+		"setvotechoice":           {fn: s.setVoteChoice},
+		"signmessage":             {fn: s.signMessage},
+		"signrawtransaction":      {fn: s.signRawTransaction},
+		"signrawtransactions":     {fn: s.signRawTransactions},
+		"redeemmultisigout":       {fn: s.redeemMultiSigOut},
+		"redeemmultisigouts":      {fn: s.redeemMultiSigOuts},
+		"stakepooluserinfo":       {fn: s.stakePoolUserInfo},
+		"ticketsforaddress":       {fn: s.ticketsForAddress},
+		"validateaddress":         {fn: s.validateAddress},
 
 		"help": {fn: s.help},
 
@@ -117,57 +161,6 @@ func (s *Server) registerHandlers() {
 //
 //
 //
-//
-//
-//
-//
-//
-//
-//
-//
-// 	"getmultisigoutinfo":      {handlerWithChain: getMultisigOutInfo},
-// 	"getnewaddress":           {handler: getNewAddress},
-// 	"getrawchangeaddress":     {handler: getRawChangeAddress},
-// 	"getreceivedbyaccount":    {handler: getReceivedByAccount},
-// 	"getreceivedbyaddress":    {handler: getReceivedByAddress},
-// 	"getstakeinfo":            {handlerWithChain: getStakeInfo},
-// 	"getticketfee":            {handler: getTicketFee},
-// 	"gettickets":              {handlerWithChain: getTickets},
-// 	"gettransaction":          {handler: getTransaction},
-// 	"getvotechoices":          {handler: getVoteChoices},
-// 	"getwalletfee":            {handler: getWalletFee},
-// 	"importprivkey":           {handlerWithChain: importPrivKey},
-// 	"importscript":            {handlerWithChain: importScript},
-// 	"keypoolrefill":           {handler: keypoolRefill},
-// 	"listaccounts":            {handler: listAccounts},
-// 	"listlockunspent":         {handler: listLockUnspent},
-// 	"listreceivedbyaccount":   {handler: listReceivedByAccount},
-// 	"listreceivedbyaddress":   {handler: listReceivedByAddress},
-// 	"listsinceblock":          {handlerWithChain: listSinceBlock},
-// 	"listscripts":             {handler: listScripts},
-// 	"listtransactions":        {handler: listTransactions},
-// 	"listunspent":             {handler: listUnspent},
-// 	"lockunspent":             {handler: lockUnspent},
-// 	"purchaseticket":          {handler: purchaseTicket},
-// 	"rescanwallet":            {handlerWithChain: rescanWallet},
-// 	"revoketickets":           {handlerWithChain: revokeTickets},
-// 	"sendfrom":                {handlerWithChain: sendFrom},
-// 	"sendmany":                {handler: sendMany},
-// 	"sendtoaddress":           {handler: sendToAddress},
-// 	"sendtomultisig":          {handlerWithChain: sendToMultiSig},
-// 	"sendtosstx":              {handlerWithChain: sendToSStx},
-// 	"sendtossgen":             {handler: sendToSSGen},
-// 	"sendtossrtx":             {handlerWithChain: sendToSSRtx},
-// 	"setticketfee":            {handler: setTicketFee},
-// 	"settxfee":                {handler: setTxFee},
-// 	"setvotechoice":           {handler: setVoteChoice},
-// 	"signmessage":             {handler: signMessage},
-// 	"signrawtransaction":      {handler: signRawTransactionNoChainRPC, handlerWithChain: signRawTransaction},
-// 	"signrawtransactions":     {handlerWithChain: signRawTransactions},
-// 	"redeemmultisigout":       {handlerWithChain: redeemMultiSigOut},
-// 	"redeemmultisigouts":      {handlerWithChain: redeemMultiSigOuts},
-// 	"stakepooluserinfo":       {handler: stakePoolUserInfo},
-// 	"ticketsforaddress":       {handler: ticketsForAddress},
 // 	"validateaddress":         {handler: validateAddress},
 // 	"verifymessage":           {handler: verifyMessage},
 // 	"version":                 {handler: versionNoChainRPC, handlerWithChain: versionWithChainRPC},
@@ -901,7 +894,6 @@ func (s *Server) getAccount(icmd interface{}) (interface{}, error) {
 func (s *Server) getAccountAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetAccountAddressCmd)
 	w, ok := s.walletLoader.LoadedWallet()
-
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
 	}
@@ -941,8 +933,12 @@ func getUnconfirmedBalance(icmd interface{}, w *wallet.Wallet) (interface{}, err
 
 // importPrivKey handles an importprivkey request by parsing
 // a WIF-encoded private key and adding it to an account.
-func importPrivKey(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) importPrivKey(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ImportPrivKeyCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Ensure that private keys are only imported to the correct account.
 	//
@@ -986,7 +982,7 @@ func importPrivKey(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient
 	}
 
 	if rescan {
-		n := chain.BackendFromRPCClient(chainClient)
+		n := chain.BackendFromRPCClient(s.dcrrpcClient)
 		go w.RescanFromHeight(context.Background(), n, scanFrom)
 	}
 
@@ -994,8 +990,13 @@ func importPrivKey(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient
 }
 
 // importScript imports a redeem script for a P2SH output.
-func importScript(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) importScript(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ImportScriptCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	rs, err := hex.DecodeString(cmd.Hex)
 	if err != nil {
 		return nil, err
@@ -1021,7 +1022,7 @@ func importScript(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.
 	}
 
 	if rescan {
-		n := chain.BackendFromRPCClient(chainClient)
+		n := chain.BackendFromRPCClient(s.dcrrpcClient)
 		go w.RescanFromHeight(context.Background(), n, int32(scanFrom))
 	}
 
@@ -1030,7 +1031,7 @@ func importScript(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.
 
 // keypoolRefill handles the keypoolrefill command. Since we handle the keypool
 // automatically this does nothing since refilling is never manually required.
-func keypoolRefill(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) keypoolRefill(icmd interface{}) (interface{}, error) {
 	return nil, nil
 }
 
@@ -1078,8 +1079,12 @@ func renameAccount(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // getMultisigOutInfo displays information about a given multisignature
 // output.
-func getMultisigOutInfo(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) getMultisigOutInfo(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetMultisigOutInfoCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	hash, err := chainhash.NewHashFromStr(cmd.Hash)
 	if err != nil {
@@ -1136,8 +1141,12 @@ func getMultisigOutInfo(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcc
 // error is returned.
 // TODO: Follow BIP 0044 and warn if number of unused addresses exceeds
 // the gap limit.
-func getNewAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getNewAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetNewAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	var callOpts []wallet.NextAddressCallOption
 	if cmd.GapPolicy != nil {
@@ -1178,8 +1187,12 @@ func getNewAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 //
 // Note: bitcoind allows specifying the account as an optional parameter,
 // but ignores the parameter.
-func getRawChangeAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getRawChangeAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetRawChangeAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	acctName := "default"
 	if cmd.Account != nil {
@@ -1201,8 +1214,12 @@ func getRawChangeAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error
 
 // getReceivedByAccount handles a getreceivedbyaccount request by returning
 // the total amount received by addresses of an account.
-func getReceivedByAccount(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getReceivedByAccount(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetReceivedByAccountCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	account, err := w.AccountNumber(cmd.Account)
 	if err != nil {
@@ -1225,8 +1242,12 @@ func getReceivedByAccount(icmd interface{}, w *wallet.Wallet) (interface{}, erro
 
 // getReceivedByAddress handles a getreceivedbyaddress request by returning
 // the total amount received by a single address.
-func getReceivedByAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getReceivedByAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetReceivedByAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
 	if err != nil {
@@ -1265,11 +1286,15 @@ func (s *Server) getMasterPubkey(icmd interface{}) (interface{}, error) {
 
 // getStakeInfo gets a large amounts of information about the stake environment
 // and a number of statistics about local staking in the wallet.
-func getStakeInfo(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
-	// Asynchronously query for the stake difficulty.
-	sdiffFuture := chainClient.GetStakeDifficultyAsync()
+func (s *Server) getStakeInfo(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
-	stakeInfo, err := w.StakeInfo(chainClient)
+	// Asynchronously query for the stake difficulty.
+	sdiffFuture := s.chainClient.GetStakeDifficultyAsync()
+	stakeInfo, err := w.StakeInfo(s.dcrrpcClient)
 	if err != nil {
 		return nil, err
 	}
@@ -1310,16 +1335,25 @@ func getStakeInfo(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.
 }
 
 // getTicketFee gets the currently set price per kb for tickets
-func getTicketFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getTicketFee(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	return w.TicketFeeIncrement().ToCoin(), nil
 }
 
 // getTickets handles a gettickets request by returning the hashes of the tickets
 // currently owned by wallet, encoded as strings.
-func getTickets(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) getTickets(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetTicketsCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
-	ticketHashes, err := w.LiveTicketHashes(chainClient, cmd.IncludeImmature)
+	ticketHashes, err := w.LiveTicketHashes(s.dcrrpcClient, cmd.IncludeImmature)
 	if err != nil {
 		return nil, err
 	}
@@ -1335,8 +1369,12 @@ func getTickets(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Cl
 
 // getTransaction handles a gettransaction request by returning details about
 // a single transaction saved by wallet.
-func getTransaction(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getTransaction(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.GetTransactionCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	txSha, err := chainhash.NewHashFromStr(cmd.Txid)
 	if err != nil {
@@ -1479,7 +1517,12 @@ func getTransaction(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // getVoteChoices handles a getvotechoices request by returning configured vote
 // preferences for each agenda of the latest supported stake version.
-func getVoteChoices(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getVoteChoices(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	version, agendas := wallet.CurrentAgendas(w.ChainParams())
 	resp := &dcrjson.GetVoteChoicesResult{
 		Version: version,
@@ -1510,7 +1553,12 @@ func getVoteChoices(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 }
 
 // getWalletFee returns the currently set tx fee for the requested wallet
-func getWalletFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) getWalletFee(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	return w.RelayFee().ToCoin(), nil
 }
 
@@ -1547,16 +1595,11 @@ func (s *Server) help(icmd interface{}) (interface{}, error) {
 	// JSON-RPC clients.  Any errors creating the POST client may be ignored
 	// since the client is not necessary for the request.
 
-	var chainClient *dcrrpcclient.Client
-	if s.chainClient != nil {
-		chainClient, _ = s.chainClient.POSTClient()
-	}
-
 	if cmd.Command == nil || *cmd.Command == "" {
 		// Prepend chain server usage if it is available.
 		usages := requestUsages
-		if chainClient != nil {
-			rawChainUsage, err := chainClient.RawRequest("help", nil)
+		if s.dcrrpcClient != nil {
+			rawChainUsage, err := s.dcrrpcClient.RawRequest("help", nil)
 			var chainUsage string
 			if err == nil {
 				_ = json.Unmarshal([]byte(rawChainUsage), &chainUsage)
@@ -1587,12 +1630,12 @@ func (s *Server) help(icmd interface{}) (interface{}, error) {
 
 	// Return the chain server's detailed help if possible.
 	var chainHelp string
-	if chainClient != nil {
+	if s.dcrrpcClient != nil {
 		param := make([]byte, len(*cmd.Command)+2)
 		param[0] = '"'
 		copy(param[1:], *cmd.Command)
 		param[len(param)-1] = '"'
-		rawChainHelp, err := chainClient.RawRequest("help", []json.RawMessage{param})
+		rawChainHelp, err := s.dcrrpcClient.RawRequest("help", []json.RawMessage{param})
 		if err == nil {
 			_ = json.Unmarshal([]byte(rawChainHelp), &chainHelp)
 		}
@@ -1608,8 +1651,12 @@ func (s *Server) help(icmd interface{}) (interface{}, error) {
 
 // listAccounts handles a listaccounts request by returning a map of account
 // names to their balances.
-func listAccounts(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listAccounts(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListAccountsCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	accountBalances := map[string]float64{}
 	results, err := w.CalculateAccountBalances(int32(*cmd.MinConf))
@@ -1629,7 +1676,12 @@ func listAccounts(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // listLockUnspent handles a listlockunspent request by returning an slice of
 // all locked outpoints.
-func listLockUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listLockUnspent(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	return w.LockedOutpoints(), nil
 }
 
@@ -1643,8 +1695,12 @@ func listLockUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 //             default: one;
 //  "includeempty": whether or not to include addresses that have no transactions -
 //                  default: false.
-func listReceivedByAccount(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listReceivedByAccount(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListReceivedByAccountCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	results, err := w.TotalReceivedForAccounts(int32(*cmd.MinConf))
 	if err != nil {
@@ -1673,8 +1729,12 @@ func listReceivedByAccount(icmd interface{}, w *wallet.Wallet) (interface{}, err
 //             default: one;
 //  "includeempty": whether or not to include addresses that have no transactions -
 //                  default: false.
-func listReceivedByAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listReceivedByAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListReceivedByAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Intermediate data for each address.
 	type AddrData struct {
@@ -1762,8 +1822,12 @@ func listReceivedByAddress(icmd interface{}, w *wallet.Wallet) (interface{}, err
 
 // listSinceBlock handles a listsinceblock request by returning an array of maps
 // with details of sent and received wallet transactions since the given block.
-func listSinceBlock(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) listSinceBlock(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListSinceBlockCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	_, tipHeight := w.MainChainTip()
 	targetConf := int64(*cmd.TargetConfirmations)
@@ -1771,7 +1835,7 @@ func listSinceBlock(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclien
 	// For the result we need the block hash for the last block counted
 	// in the blockchain due to confirmations. We send this off now so that
 	// it can arrive asynchronously while we figure out the rest.
-	gbh := chainClient.GetBlockHashAsync(int64(tipHeight) + 1 - targetConf)
+	gbh := s.chainClient.GetBlockHashAsync(int64(tipHeight) + 1 - targetConf)
 
 	var start int32
 	if cmd.BlockHash != nil {
@@ -1779,7 +1843,7 @@ func listSinceBlock(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclien
 		if err != nil {
 			return nil, DeserializationError{err}
 		}
-		block, err := chainClient.GetBlockVerbose(hash, false)
+		block, err := s.chainClient.GetBlockVerbose(hash, false)
 		if err != nil {
 			return nil, err
 		}
@@ -1806,7 +1870,12 @@ func listSinceBlock(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclien
 
 // listScripts handles a listscripts request by returning an
 // array of script details for all scripts in the wallet.
-func listScripts(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listScripts(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	redeemScripts, err := w.FetchAllRedeemScripts()
 	if err != nil {
 		return nil, err
@@ -1829,8 +1898,12 @@ func listScripts(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // listTransactions handles a listtransactions request by returning an
 // array of maps with details of sent and recevied wallet transactions.
-func listTransactions(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listTransactions(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListTransactionsCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// TODO: ListTransactions does not currently understand the difference
 	// between transactions pertaining to one account from another.  This
@@ -1896,8 +1969,12 @@ func listAllTransactions(icmd interface{}, w *wallet.Wallet) (interface{}, error
 }
 
 // listUnspent handles the listunspent command.
-func listUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) listUnspent(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ListUnspentCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	var addresses map[string]struct{}
 	if cmd.Addresses != nil {
@@ -1916,8 +1993,12 @@ func listUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 }
 
 // lockUnspent handles the lockunspent command.
-func lockUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) lockUnspent(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.LockUnspentCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	switch {
 	case cmd.Unlock && len(cmd.Transactions) == 0:
@@ -1942,9 +2023,14 @@ func lockUnspent(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 // purchaseTicket indicates to the wallet that a ticket should be purchased
 // using all currently available funds. If the ticket could not be purchased
 // because there are not enough eligible funds, an error will be returned.
-func purchaseTicket(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) purchaseTicket(icmd interface{}) (interface{}, error) {
 	// Enforce valid and positive spend limit.
 	cmd := icmd.(*dcrjson.PurchaseTicketCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	spendLimit, err := dcrutil.NewAmount(cmd.SpendLimit)
 	if err != nil {
 		return nil, err
@@ -2090,8 +2176,12 @@ func sendPairs(w *wallet.Wallet, amounts map[string]dcrutil.Amount,
 // construct a transaction with a single P2PKH paying to a specified address.
 // It signs any inputs that it can, then provides the raw transaction to
 // the user to export to others to sign.
-func redeemMultiSigOut(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) redeemMultiSigOut(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RedeemMultiSigOutCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Convert the address to a useable format. If
 	// we have no address, create a new address in
@@ -2182,7 +2272,7 @@ func redeemMultiSigOut(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpccl
 	}
 
 	// Sign it and give the results to the user.
-	signedTxResult, err := signRawTransaction(srtc, w, chainClient)
+	signedTxResult, err := s.signRawTransaction(srtc)
 	if signedTxResult == nil || err != nil {
 		return nil, err
 	}
@@ -2195,8 +2285,12 @@ func redeemMultiSigOut(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpccl
 // with that address, then generates a list of partially signed
 // transactions spending to either an address specified or internal
 // addresses in this wallet.
-func redeemMultiSigOuts(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) redeemMultiSigOuts(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RedeemMultiSigOutsCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Get all the multisignature outpoints that are unspent for this
 	// address.
@@ -2230,7 +2324,7 @@ func redeemMultiSigOuts(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcc
 			Tree:    mso.OutPoint.Tree,
 			Address: cmd.ToAddress,
 		}
-		redeemResult, err := redeemMultiSigOut(rmsoRequest, w, chainClient)
+		redeemResult, err := s.redeemMultiSigOut(rmsoRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -2245,24 +2339,37 @@ func redeemMultiSigOuts(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcc
 
 // rescanWallet initiates a rescan of the block chain for wallet data, blocking
 // until the rescan completes or exits with an error.
-func rescanWallet(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) rescanWallet(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.RescanWalletCmd)
-	n := chain.BackendFromRPCClient(chainClient)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
+	n := chain.BackendFromRPCClient(s.dcrrpcClient)
 	err := w.RescanFromHeight(context.TODO(), n, int32(*cmd.BeginHeight))
 	return nil, err
 }
 
 // revokeTickets initiates the wallet to issue revocations for any missing tickets that
 // not yet been revoked.
-func revokeTickets(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
-	err := w.RevokeTickets(chainClient)
+func (s *Server) revokeTickets(icmd interface{}) (interface{}, error) {
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+	err := w.RevokeTickets(s.dcrrpcClient)
 	return nil, err
 }
 
 // stakePoolUserInfo returns the ticket information for a given user from the
 // stake pool.
-func stakePoolUserInfo(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) stakePoolUserInfo(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.StakePoolUserInfoCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	userAddr, err := dcrutil.DecodeAddress(cmd.User)
 	if err != nil {
@@ -2310,8 +2417,12 @@ func stakePoolUserInfo(icmd interface{}, w *wallet.Wallet) (interface{}, error) 
 // ticketsForAddress retrieves all ticket hashes that have the passed voting
 // address. It will only return tickets that are in the mempool or blockchain,
 // and should not return pruned tickets.
-func ticketsForAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) ticketsForAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.TicketsForAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	addr, err := dcrutil.DecodeAddress(cmd.Address)
 	if err != nil {
@@ -2340,8 +2451,12 @@ func isNilOrEmpty(s *string) bool {
 // address.  Leftover inputs not sent to the payment address or a fee for
 // the miner are sent back to a new address in the wallet.  Upon success,
 // the TxID for the created transaction is returned.
-func sendFrom(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) sendFrom(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendFromCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Transaction comments are not yet supported.  Error instead of
 	// pretending to save them.
@@ -2382,8 +2497,12 @@ func sendFrom(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Clie
 // payment addresses.  Leftover inputs not sent to the payment address
 // or a fee for the miner are sent back to a new address in the wallet.
 // Upon success, the TxID for the created transaction is returned.
-func sendMany(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) sendMany(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendManyCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Transaction comments are not yet supported.  Error instead of
 	// pretending to save them.
@@ -2423,8 +2542,12 @@ func sendMany(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 // payment address.  Leftover inputs not sent to the payment address or a fee
 // for the miner are sent back to a new address in the wallet.  Upon success,
 // the TxID for the created transaction is returned.
-func sendToAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) sendToAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendToAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Transaction comments are not yet supported.  Error instead of
 	// pretending to save them.
@@ -2465,8 +2588,13 @@ func sendToAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 // The function returns a tx hash, P2SH address, and a multisig script if
 // successful.
 // TODO Use with non-default accounts as well
-func sendToMultiSig(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) sendToMultiSig(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SendToMultiSigCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	account := uint32(udb.DefaultAccountNum)
 	amount, err := dcrutil.NewAmount(cmd.Amount)
 	if err != nil {
@@ -2519,7 +2647,7 @@ func sendToMultiSig(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclien
 		RedeemScript: hex.EncodeToString(script),
 	}
 
-	err = chainClient.LoadTxFilter(false, []dcrutil.Address{addr}, nil)
+	err = s.chainClient.LoadTxFilter(false, []dcrutil.Address{addr}, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2531,8 +2659,12 @@ func sendToMultiSig(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclien
 }
 
 // setTicketFee sets the transaction fee per kilobyte added to tickets.
-func setTicketFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) setTicketFee(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetTicketFeeCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Check that amount is not negative.
 	if cmd.Fee < 0 {
@@ -2550,8 +2682,12 @@ func setTicketFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 }
 
 // setTxFee sets the transaction fee per kilobyte added to transactions.
-func setTxFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) setTxFee(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetTxFeeCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Check that amount is not negative.
 	if cmd.Amount < 0 {
@@ -2570,8 +2706,13 @@ func setTxFee(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // setVoteChoice handles a setvotechoice request by modifying the preferred
 // choice for a voting agenda.
-func setVoteChoice(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) setVoteChoice(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SetVoteChoiceCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
+
 	_, err := w.SetAgendaChoices(wallet.AgendaChoice{
 		AgendaID: cmd.AgendaID,
 		ChoiceID: cmd.ChoiceID,
@@ -2581,8 +2722,12 @@ func setVoteChoice(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 
 // signMessage signs the given message with the private key for the given
 // address
-func signMessage(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) signMessage(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignMessageCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())
 	if err != nil {
@@ -2595,16 +2740,16 @@ func signMessage(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
 	return base64.StdEncoding.EncodeToString(sig), nil
 }
 
-func signRawTransactionNoChainRPC(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
-	return signRawTransaction(icmd, w, nil)
-}
-
 // signRawTransaction handles the signrawtransaction command.
 //
 // chainClient may be nil, in which case it was called by the NoChainRPC
 // variant.  It must be checked before all usage.
-func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) signRawTransaction(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignRawTransactionCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	serializedTx, err := decodeHexStr(cmd.RawTx)
 	if err != nil {
@@ -2708,13 +2853,13 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcc
 		}
 
 		// Asynchronously request the output script.
-		if chainClient == nil {
+		if s.chainClient == nil {
 			return nil, &dcrjson.RPCError{
 				Code:    -1,
 				Message: "Chain RPC is inactive",
 			}
 		}
-		requested[txIn.PreviousOutPoint] = chainClient.GetTxOutAsync(
+		requested[txIn.PreviousOutPoint] = s.chainClient.GetTxOutAsync(
 			&txIn.PreviousOutPoint.Hash, txIn.PreviousOutPoint.Index,
 			true)
 	}
@@ -2817,8 +2962,12 @@ func signRawTransaction(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcc
 }
 
 // signRawTransactions handles the signrawtransactions command.
-func signRawTransactions(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpcclient.Client) (interface{}, error) {
+func (s *Server) signRawTransactions(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.SignRawTransactionsCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	// Sign each transaction sequentially and record the results.
 	// Error out if we meet some unexpected failure.
@@ -2829,7 +2978,7 @@ func signRawTransactions(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpc
 			RawTx: etx,
 			Flags: &flagAll,
 		}
-		result, err := signRawTransaction(srtc, w, chainClient)
+		result, err := s.signRawTransaction(srtc)
 		if err != nil {
 			return nil, err
 		}
@@ -2858,7 +3007,7 @@ func signRawTransactions(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpc
 				}
 				sent := false
 				hashStr := ""
-				hash, err := chainClient.SendRawTransaction(msgTx, w.AllowHighFees)
+				hash, err := s.chainClient.SendRawTransaction(msgTx, w.AllowHighFees)
 				// If sendrawtransaction errors out (blockchain rule
 				// issue, etc), continue onto the next transaction.
 				if err == nil {
@@ -2896,8 +3045,12 @@ func signRawTransactions(icmd interface{}, w *wallet.Wallet, chainClient *dcrrpc
 }
 
 // validateAddress handles the validateaddress command.
-func validateAddress(icmd interface{}, w *wallet.Wallet) (interface{}, error) {
+func (s *Server) validateAddress(icmd interface{}) (interface{}, error) {
 	cmd := icmd.(*dcrjson.ValidateAddressCmd)
+	w, ok := s.walletLoader.LoadedWallet()
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
+	}
 
 	result := dcrjson.ValidateAddressWalletResult{}
 	addr, err := decodeAddress(cmd.Address, w.ChainParams())

--- a/rpc/legacyrpc/rpchelp_test.go
+++ b/rpc/legacyrpc/rpchelp_test.go
@@ -25,7 +25,7 @@ import (
 
 func serverMethods() map[string]struct{} {
 	m := make(map[string]struct{})
-	for method, handlerData := range rpcHandlers {
+	for method, handlerData := range handlers {
 		if !handlerData.noHelp {
 			m[method] = struct{}{}
 		}

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/websocket"
 	"github.com/decred/dcrd/chaincfg"
 	"github.com/decred/dcrd/dcrjson"
+	dcrrpcclient "github.com/decred/dcrd/rpcclient"
 	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/loader"
 	"github.com/decred/dcrwallet/ticketbuyer"
@@ -63,6 +64,7 @@ type Server struct {
 	httpServer        http.Server
 	walletLoader      *loader.Loader
 	chainClient       *chain.RPCClient
+	dcrrpcClient      *dcrrpcclient.Client
 	ticketbuyerConfig *ticketbuyer.Config
 	handlerMu         sync.Mutex
 	listeners         []net.Listener
@@ -125,6 +127,7 @@ func NewServer(opts *Options, activeNet *chaincfg.Params, walletLoader *loader.L
 		activeNet:           activeNet,
 	}
 
+	walletLoader.LoadedWallet()
 	// map methods to functions here
 
 	serveMux.Handle("/", throttledFn(opts.MaxPOSTClients,
@@ -246,6 +249,7 @@ func (s *Server) Stop() {
 func (s *Server) SetChainServer(chainClient *chain.RPCClient) {
 	s.handlerMu.Lock()
 	s.chainClient = chainClient
+	s.dcrrpcClient, _ = chainClient.POSTClient()
 	s.handlerMu.Unlock()
 }
 

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -58,7 +58,6 @@ func (c *websocketClient) send(b []byte) error {
 
 // Server holds the items the RPC server may need to access (auth,
 // config, shutdown, etc.)
-
 type Server struct {
 	httpServer   http.Server
 	walletLoader *loader.Loader
@@ -83,10 +82,10 @@ type Server struct {
 
 	activeNet *chaincfg.Params
 
-	handlers map[string]Handler
+	handlers map[string]handler
 }
 
-type Handler struct {
+type handler struct {
 	fn     func(*Server, interface{}) (interface{}, error)
 	noHelp bool
 }
@@ -251,13 +250,17 @@ func (s *Server) SetChainServer(chainClient *chain.RPCClient) {
 	s.handlerMu.Unlock()
 }
 
-// GetChainServer get the chain server client component needed to run a fully
+// requireChainClient get the chain server client component needed to run a fully
 // functional decred wallet RPC server.
-func (s *Server) GetChainServer() *chain.RPCClient {
+func (s *Server) requireChainClient() (*chain.RPCClient, bool) {
 	s.handlerMu.Lock()
 	chainClient := s.chainClient
 	s.handlerMu.Unlock()
-	return chainClient
+	if chainClient != nil {
+		return chainClient, true
+	}
+
+	return nil, false
 }
 
 // handlerClosure creates a closure function for handling requests of the given

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -101,8 +101,6 @@ func jsonAuthFail(w http.ResponseWriter) {
 func NewServer(opts *Options, activeNet *chaincfg.Params, walletLoader *loader.Loader, ticketBuyerConfig *ticketbuyer.Config, listeners []net.Listener) *Server {
 	serveMux := http.NewServeMux()
 	const rpcAuthTimeoutSeconds = 10
-
-	walletLoader.LoadedWallet()
 	server := &Server{
 		httpServer: http.Server{
 			Handler: serveMux,
@@ -250,17 +248,13 @@ func (s *Server) SetChainServer(chainClient *chain.RPCClient) {
 	s.handlerMu.Unlock()
 }
 
-// requireChainClient get the chain server client component needed to run a fully
-// functional decred wallet RPC server.
+// requireChainClient gets the chain server client component needed to run a
+// fully functional decred wallet RPC server.
 func (s *Server) requireChainClient() (*chain.RPCClient, bool) {
 	s.handlerMu.Lock()
 	chainClient := s.chainClient
 	s.handlerMu.Unlock()
-	if chainClient != nil {
-		return chainClient, true
-	}
-
-	return nil, false
+	return chainClient, chainClient != nil
 }
 
 // handlerClosure creates a closure function for handling requests of the given

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -9,7 +9,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	xcontext "golang.org/x/net/context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -17,6 +16,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	xcontext "golang.org/x/net/context"
 
 	"github.com/decred/dcrd/certgen"
 	"github.com/decred/dcrwallet/loader"
@@ -184,7 +185,7 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *legacyrpc.Serv
 			MaxPOSTClients:      cfg.LegacyRPCMaxClients,
 			MaxWebsocketClients: cfg.LegacyRPCMaxWebsockets,
 		}
-		legacyServer = legacyrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
+		legacyServer = legacyrpc.NewServer(&opts, activeNet.Params, walletLoader, &cfg.tbCfg, listeners)
 		for _, lis := range listeners {
 			jsonrpcAddrNotifier.notify(lis.Addr().String())
 		}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	xcontext "golang.org/x/net/context"
 	"io/ioutil"
 	"net"
 	"os"
@@ -16,8 +17,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-
-	xcontext "golang.org/x/net/context"
 
 	"github.com/decred/dcrd/certgen"
 	"github.com/decred/dcrwallet/loader"


### PR DESCRIPTION
Handler dependencies are now fetched via the server.

Thanks to @jrick for the guidance.