### PR TITLE
grpc: Update grpc version

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -59,9 +59,9 @@ import (
 
 // Public API version constants
 const (
-	semverString = "4.25.0"
+	semverString = "4.26.0"
 	semverMajor  = 4
-	semverMinor  = 25
+	semverMinor  = 26
 	semverPatch  = 0
 )
 


### PR DESCRIPTION
The versions in server.go and api.md are different. This updates server.go to respect what is api.md.