### PR TITLE
config: Add enablevoting to sample config file

### DIFF
--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -18,6 +18,11 @@
 ; automatically (e.g. as a system service).
 ; pass=
 
+; Enable the wallet to vote on tickets. If this is a voting-only wallet, set
+; this option to 1 and optionally also set the wallet passphrase with the "pass"
+; flag.
+; enablevoting=0
+
 ; The directory to open and save wallet, transaction, and unspent transaction
 ; output files.  Two directories, `mainnet` and `testnet` are used in this
 ; directory for mainnet and testnet wallets, respectively.


### PR DESCRIPTION
This flag is listed in several places in the docs but was missing in the sample config.