### PR TITLE
movefunds: resolve linter warning.

### DIFF
--- a/cmd/movefunds/main.go
+++ b/cmd/movefunds/main.go
@@ -207,7 +207,7 @@ func main() {
 	}
 	buf.WriteString("]' ")
 	buf.WriteString("| jq -r .hex")
-	err = ioutil.WriteFile("sign.sh", []byte(buf.String()), 0755)
+	err = ioutil.WriteFile("sign.sh", buf.Bytes(), 0755)
 	if err != nil {
 		fmt.Println("Failed to write signing script: ", err.Error())
 		return


### PR DESCRIPTION
addresses ./run_tests.sh warning: `cmd/movefunds/main.go:210:36:warning:
should use buf.Bytes() instead of []byte(buf.String()) (S1030)
(gosimple)`