### PR TITLE
[wip] Mobile bindings (#1022)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,43 @@ env:
   - GOVERSION = 1.8
   - GOVERSION = 1.9
 
+matrix:
+  include:
+    # build a library for iOS
+    - os: osx # gomobile: target=ios requires the host machine to be running OS X.
+      go: 1.9
+      install:
+        # setup the cocoapods master repo
+        - gem uninstall cocoapods -a -x
+        - gem install cocoapods
+        - pod setup --verbose
+      script:
+        - gomobile bind -target ios -v github.com/decred/dcrd/mobile
+      before_deploy:
+        # render cocoapods spec based on a template (project root directory)
+        -
+        # ensure that we have a valid cocoapod spec
+        - pod spec lint template.podspec 
+      deploy:
+        - pod trunk push DCRD.podspec --allow-warnings --verbose
+    
+    # build a library for Android
+    - os:
+      language: android
+      before_script:
+        # verify that the sdk and ndk are available
+        - 
+      script:
+        # install android compiler toolchain & generate android artifact
+        - gomobile init -ndk $ANDROID_NDK 
+        - gomobile -target android -javapkg org.decred -v github.com/decred/dcrd/mobile
+      before_deploy:
+        # import key
+        - gpg --import $PGP_KEY
+      deploy:
+        # signs artifact and installs the artifact in the remote repository.
+        - mvn gpg:sign-and-deploy-file -settings=mobile/build/mvn.settings -Durl="https://oss.sonatype.org/service/local/staging/deploy/maven2" -DrepositoryId=sonatype -pomFile=mobile/build/pom.xml -Dfile=dcrd.aar
+
 install: true
 
 script:

--- a/mobile/build/pom.xml
+++ b/mobile/build/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                               http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.decred</groupId>
+  <artifactId>dcrd</artifactId>
+  <version>@TODO(rgeraldes)</version>
+  <packaging>aar</packaging>
+  <name>Dcrd client - Android</name>
+  <url>https://github.com/decred/dcrd</url>
+  <licenses>
+    <license>
+      <name></name>
+      <url></url>
+    </license>
+  </licenses>
+  <organization>
+    <name>Decred</name>
+    <url>https://decred.org/</url>
+  </organization>
+  <contributors>
+    <contributor>
+      <name>Ricardo Geraldes</name>
+      <email>rgeraldes24@gmail.com</email>
+    </contributor>
+  </contributors>
+  <scm>
+    <url>https://github.com/decred/dcrd</url>
+  </scm>
+</project>

--- a/mobile/build/settings.xml
+++ b/mobile/build/settings.xml
@@ -1,0 +1,22 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                          https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>sonatype</id>
+            <username>${env.SONATYPE_USERNAME}</username>
+            <password>${env.SONATYPE_PASSWORD}</password>
+        </server>
+    </servers>
+    <profiles>
+        <id>sonatype</id>
+        <activation>
+            <activeByDefault>true</activeByDefault>
+        </activation>
+        <properties>
+            <gpg.executable>gpg</gpg.executable>
+            <gpg.passphrase></gpg.passphrase>
+      </properties>
+    </profiles>
+</settings>

--- a/mobile/build/template.podspec
+++ b/mobile/build/template.podspec
@@ -1,0 +1,11 @@
+Pod::Spec.new do |s|
+  s.name         = "Dcrd"
+  s.version      = "0.0.1" # Version should be rendered based on dcrd version
+  s.summary      = "Dcrd Client - iOS"
+  s.homepage     = "https://decred.org/"
+  # s.license      = "MIT (example)" 
+  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
+  s.author             = { "Ricardo Geraldes" => "rgeraldes24@gmail.com" }
+  s.platform     = :ios, "9.0" # deployment target
+  s.source       = { :git => "https://github.com/decred/dcrd.git", :tag => "#{s.version}" }
+end


### PR DESCRIPTION
WIP - PR Fixes #938 
Moved from: https://github.com/decred/dcrd/pull/944

**Pre-Requisites:**

_IOS - cocoapods_

- sign up for an account with your email address (reference: https://guides.cocoapods.org/making/getting-setup-with-trunk.html)

- get the authentication Token from the password field of ~/.netrc

- define a secure variable (pod relies on COCOAPODS_TRUNK_TOKEN) - that will store the token - in the repository settings(dcrd). (reference: https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings)

Other:
- complete the cocoapods spec license fields (file: template.podspec)

_Android - maven central_

- create a Sonatype account (reference: http://central.sonatype.org/pages/ossrh-guide.html#SonatypeOSSMavenRepositoryUsageGuide-2.Signup)
- request permissions to upload artifacts on Maven Central:
 (Ethereum example: https://issues.sonatype.org/browse/OSSRH-25355)
- Define the following secure variables in the travis repository settings(dcrd):
        - SONATYPE_USERNAME
        - SONATYPE_PASSWORD
With your username and password being the same ones you used to create the Jira issue. To confirm your credentials are right, you can try using them to login at http://oss.sonatype.org.
- generate a PGP key (reference: http://blog.sonatype.com/2010/01/how-to-generate-pgp-signatures-with-maven/) - The PGP key is needed to be able to sign the artifacts before the upload to Maven Central.
- define a secure variable ($PGP_KEY) in the travis repository settings(dcrd), just like the auth token step done for iOS. Display value in build log set to off > secure value.

Other:
- complete the pom file license information (file:mobile/build/pom.xml)

**Integration with Decrediton Mobile**

_iOS - automatic dependency (Cocoapods)_ 

1. adding pods to an existing xcode project (reference: https://guides.cocoapods.org/using/using-cocoapods.html)
2. edit podfile - include dcrd dependecy

```
target 'MyApp' do
  pod 'Dcrd', '~> 3.0' # Example
end
```
_Android - automatic dependency (Maven central)_

1. Edit build.gradle - Android's folder

```
repositories {
    mavenCentral()
}

dependencies {
    // All your previous dependencies
    compile 'org.decred:dcrd:1.0' // latest release
}
```