### PR TITLE
Fix 'too many arguments error'

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1292,7 +1292,7 @@ func (w *Wallet) SignMessage(msg string, addr dcrutil.Address) (sig []byte, err 
 		return nil, fmt.Errorf("Unable to create secp256k1.PrivateKey" +
 			"from chainec.PrivateKey")
 	}
-	return secp256k1.SignCompact(secp256k1.S256(), pkCast, messageHash, true)
+	return secp256k1.SignCompact(pkCast, messageHash, true)
 }
 
 // VerifyMessage verifies that sig is a valid signature of msg and was created


### PR DESCRIPTION
[This commit](https://github.com/decred/dcrd/commit/2be3bf663937a7a9a450abdfa7e9621d8dec1f43) breaks dcrwallet/master. 

That modifies dcrd SignCompact function, reducing the number of arguments to two. This PR adjusts dcrwallet's calling code to pass the right/right number of arguments, thus fixing the error
  