### PR TITLE
Fix wallet getbalance cli output

### DIFF
--- a/internal/rpchelp/methods.go
+++ b/internal/rpchelp/methods.go
@@ -33,7 +33,7 @@ var Methods = []struct {
 	{"getaccount", returnsString},
 	{"getaccountaddress", returnsString},
 	{"getaddressesbyaccount", returnsStringArray},
-	{"getbalance", returnsNumber},
+	{"getbalance", append(returnsNumber, returnsNumber[0])},
 	{"getbestblockhash", returnsString},
 	{"getblockcount", returnsNumber},
 	{"getinfo", []interface{}{(*dcrjson.InfoWalletResult)(nil)}},

--- a/internal/rpchelp/methods.go
+++ b/internal/rpchelp/methods.go
@@ -33,7 +33,7 @@ var Methods = []struct {
 	{"getaccount", returnsString},
 	{"getaccountaddress", returnsString},
 	{"getaddressesbyaccount", returnsStringArray},
-	{"getbalance", append(returnsNumber, returnsNumber[0])},
+	{"getbalance", returnsNumber},
 	{"getbestblockhash", returnsString},
 	{"getblockcount", returnsNumber},
 	{"getinfo", []interface{}{(*dcrjson.InfoWalletResult)(nil)}},

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -639,34 +639,19 @@ func getBalance(s *Server, icmd interface{}) (interface{}, error) {
 		accountName = *cmd.Account
 	}
 
-	blockHash, _ := w.MainChainTip()
-	result := dcrjson.GetBalanceResult{
-		BlockHash: blockHash.String(),
-	}
-
+	var result string
 	if accountName == "*" {
 		balances, err := w.CalculateAccountBalances(int32(*cmd.MinConf))
 		if err != nil {
 			return nil, err
 		}
 
+		var totalBalance float64
 		for _, bal := range balances {
-			accountName, err := w.AccountName(bal.Account)
-			if err != nil {
-				return nil, err
-			}
-			json := dcrjson.GetAccountBalanceResult{
-				AccountName:             accountName,
-				ImmatureCoinbaseRewards: bal.ImmatureCoinbaseRewards.ToCoin(),
-				ImmatureStakeGeneration: bal.ImmatureStakeGeneration.ToCoin(),
-				LockedByTickets:         bal.LockedByTickets.ToCoin(),
-				Spendable:               bal.Spendable.ToCoin(),
-				Total:                   bal.Total.ToCoin(),
-				Unconfirmed:             bal.Unconfirmed.ToCoin(),
-				VotingAuthority:         bal.VotingAuthority.ToCoin(),
-			}
-			result.Balances = append(result.Balances, json)
+			totalBalance += bal.Total.ToCoin()
 		}
+
+		result = fmt.Sprintf("%v The balance of all accounts valued in decred", totalBalance)
 	} else {
 		account, err := w.AccountNumber(accountName)
 		if err != nil {
@@ -677,17 +662,9 @@ func getBalance(s *Server, icmd interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
-		json := dcrjson.GetAccountBalanceResult{
-			AccountName:             accountName,
-			ImmatureCoinbaseRewards: bal.ImmatureCoinbaseRewards.ToCoin(),
-			ImmatureStakeGeneration: bal.ImmatureStakeGeneration.ToCoin(),
-			LockedByTickets:         bal.LockedByTickets.ToCoin(),
-			Spendable:               bal.Spendable.ToCoin(),
-			Total:                   bal.Total.ToCoin(),
-			Unconfirmed:             bal.Unconfirmed.ToCoin(),
-			VotingAuthority:         bal.VotingAuthority.ToCoin(),
-		}
-		result.Balances = append(result.Balances, json)
+
+		result = fmt.Sprintf("%v The balance of \"%s\" valued in decred",
+			bal.Total.ToCoin(), accountName)
 	}
 
 	return result, nil

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -651,7 +651,8 @@ func getBalance(s *Server, icmd interface{}) (interface{}, error) {
 			totalBalance += bal.Total.ToCoin()
 		}
 
-		result = fmt.Sprintf("%v The balance of all accounts valued in decred", totalBalance)
+		result = fmt.Sprintf("%v The balance of all accounts valued in decred",
+			totalBalance)
 	} else {
 		account, err := w.AccountNumber(accountName)
 		if err != nil {


### PR DESCRIPTION
This is a fix for issue #1040 
The new o/p for wallet's getbalance CLI now looks similar to it's help text-

```
➜  ./dcrctl --wallet getbalance
<some floating pt #> The balance of all accounts valued in decred
➜  ./dcrctl --wallet getbalance "default"
<some floating pt #> The balance of "default" valued in decred
➜  ./dcrctl --wallet getbalance "imported"
<some floating pt #> The balance of "imported" valued in decred
```
