### PR TITLE
Fix previous database upgrade.

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -1794,7 +1794,7 @@ func (s *Store) rollback(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBuc
 				}
 				opCode := fetchRawCreditTagOpCode(v)
 				isCoinbase := fetchRawCreditIsCoinbase(v)
-				hasExpiry := fetchRawCreditHasExpiry(v)
+				hasExpiry := fetchRawCreditHasExpiry(v, DBVersion)
 
 				scrType := pkScriptType(output.PkScript)
 				scrLoc := rec.MsgTx.PkScriptLocs()[i]
@@ -1960,7 +1960,7 @@ func (s *Store) outputCreditInfo(ns walletdb.ReadBucket, op wire.OutPoint,
 
 		opCode = fetchRawUnminedCreditTagOpcode(unminedCredV)
 		isCoinbase = fetchRawCreditIsCoinbase(unminedCredV)
-		hasExpiry = fetchRawCreditHasExpiry(unminedCredV)
+		hasExpiry = fetchRawCreditHasExpiry(unminedCredV, DBVersion)
 
 		// These errors are skipped because they may throw incorrectly
 		// on values recorded in older versions of the wallet. 0-offset
@@ -1978,7 +1978,7 @@ func (s *Store) outputCreditInfo(ns walletdb.ReadBucket, op wire.OutPoint,
 
 		opCode = fetchRawCreditTagOpCode(minedCredV)
 		isCoinbase = fetchRawCreditIsCoinbase(minedCredV)
-		hasExpiry = fetchRawCreditHasExpiry(minedCredV)
+		hasExpiry = fetchRawCreditHasExpiry(minedCredV, DBVersion)
 
 		// Same error caveat as above.
 		scrLoc = fetchRawCreditScriptOffset(minedCredV)
@@ -2857,7 +2857,7 @@ func (s *Store) unspentOutputsForAmount(ns, addrmgrNs walletdb.ReadBucket, neede
 		}
 		// Skip outputs that have an expiry but have not yet reached
 		// coinbase maturity .
-		if fetchRawCreditHasExpiry(cVal) {
+		if fetchRawCreditHasExpiry(cVal, DBVersion) {
 			if !confirmed(int32(s.chainParams.CoinbaseMaturity), txHeight,
 				syncHeight) {
 				return nil

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -33,6 +33,7 @@ var dbUpgradeTests = [...]struct {
 	{verifyV6Upgrade, "v5.db.gz"},
 	// No upgrade test for V7, it is a backwards-compatible upgrade
 	{verifyV8Upgrade, "v7.db.gz"},
+	// No upgrade test for V9, it is a fix for V8 and the previous test still applies
 }
 
 var pubPass = []byte("public")
@@ -349,7 +350,7 @@ func verifyV8Upgrade(t *testing.T, db walletdb.DB) {
 		ns := tx.ReadBucket(wtxmgrBucketKey)
 		creditBucket := ns.NestedReadBucket(bucketCredits)
 		err := creditBucket.ForEach(func(k []byte, v []byte) error {
-			hasExpiry := fetchRawCreditHasExpiry(v)
+			hasExpiry := fetchRawCreditHasExpiry(v, DBVersion)
 			if !hasExpiry {
 				t.Errorf("expected expiry to be set")
 			}
@@ -361,7 +362,7 @@ func verifyV8Upgrade(t *testing.T, db walletdb.DB) {
 
 		unminedCreditBucket := ns.NestedReadBucket(bucketUnminedCredits)
 		err = unminedCreditBucket.ForEach(func(k []byte, v []byte) error {
-			hasExpiry := fetchRawCreditHasExpiry(v)
+			hasExpiry := fetchRawCreditHasExpiry(v, DBVersion)
 
 			if !hasExpiry {
 				t.Errorf("expected expiry to be set")


### PR DESCRIPTION
The previous database upgrade wrote data to the wrong bits and could
cause ticket outputs to be wrongly chosen as spendable outputs to use
for regular transactions.  This change introduces another database
upgrade which corrects the previous issue and updates comments
describing the format of saved values to make these mistakes less
likely to occur in the future.

Fixes #1057.