### PR TITLE
Remove testify dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,12 +32,6 @@
   revision = "31079b6807923eb23992c421b114992b95131b55"
 
 [[projects]]
-  name = "github.com/davecgh/go-spew"
-  packages = ["spew"]
-  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
-  version = "v1.1.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/dchest/blake256"
   packages = ["."]
@@ -78,18 +72,6 @@
   name = "github.com/jrick/logrotate"
   packages = ["rotator"]
   revision = "a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a"
-
-[[projects]]
-  name = "github.com/pmezard/go-difflib"
-  packages = ["difflib"]
-  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
-  version = "v1.0.0"
-
-[[projects]]
-  name = "github.com/stretchr/testify"
-  packages = ["assert"]
-  revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
-  version = "v1.1.4"
 
 [[projects]]
   branch = "master"
@@ -136,6 +118,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1dbc675d3a3b4557ec94bea9940ee54cde41c803bde70067168b3463231b1aa2"
+  inputs-digest = "890953b366de351f13c362e03a2d3d137bffc528185ceb18426561fe20d2e651"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pgpwordlist/pgpwordlist_test.go
+++ b/pgpwordlist/pgpwordlist_test.go
@@ -17,10 +17,9 @@
 package pgpwordlist
 
 import (
+	"bytes"
 	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var tests = []struct {
@@ -44,8 +43,13 @@ var tests = []struct {
 func TestDecode(t *testing.T) {
 	for _, test := range tests {
 		data, err := DecodeMnemonics(strings.Split(test.mnemonics, " "))
-		assert.NoError(t, err)
-		assert.Equal(t, test.data, data)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if !bytes.Equal(data, test.data) {
+			t.Errorf("decoded data %x differs from expected %x", data, test.data)
+		}
 	}
 }
 
@@ -54,7 +58,9 @@ func TestEncodeMnemonics(t *testing.T) {
 		mnemonicsSlice := strings.Split(test.mnemonics, " ")
 		for i, b := range test.data {
 			mnemonic := ByteToMnemonic(b, i)
-			assert.Equal(t, mnemonicsSlice[i], mnemonic)
+			if mnemonic != mnemonicsSlice[i] {
+				t.Errorf("returned mnemonic %s differs from expected %s", mnemonic, mnemonicsSlice[i])
+			}
 		}
 	}
 }


### PR DESCRIPTION
It's not worth pulling this and other transient deps in for a few
calls in one test file.