### PR TITLE
Do not strip . delimiters from semver build metadata.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 )
 
-const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"
+// semverAlphabet is an alphabet of all characters allowed in semver prerelease
+// or build metadata identifiers, and the . separator.
+const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-."
 
 // Constants defining the application version number.
 const (


### PR DESCRIPTION
The dot delimiter is used to separate identifiers in semver build and
release metadata.  Adding dot to the alphabet will prevent the
delimiter from being stripped out of the version.