### PR TITLE
Add context to script execution errors.

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -628,7 +628,11 @@ func validateMsgTx(tx *wire.MsgTx, prevScripts [][]byte) error {
 		}
 		err = vm.Execute()
 		if err != nil {
-			return fmt.Errorf("cannot validate transaction: %s", err)
+			prevOut := &tx.TxIn[i].PreviousOutPoint
+			sigScript := tx.TxIn[i].SignatureScript
+			return fmt.Errorf("script execution errored: %s "+
+				"(spending outpoint %v pkscript %x with sigscript %x)",
+				err, prevOut, prevScript, sigScript)
 		}
 	}
 	return nil


### PR DESCRIPTION
This will make debugging failed script executions easier as the error
message now includes the previous outpoint being spent, the previous
output script, and the signature script created by us.  There is
little harm in logging these scripts as we default to using
SIGHASH_ALL.