### PR TITLE
Multi: Update wallet/wallet.go method, MasterPubKey, and its dependencies

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1258,7 +1258,7 @@ func getMasterPubkey(s *Server, icmd interface{}) (interface{}, error) {
 	}
 	
 	// Obtain MasterPubkey of index "account" from wallet
-	masterPubKey, err := w.MasterPubKey(account)
+	MasterPubKey, err := w.MasterPubKey(account)
 	if err != nil {
 		return nil, err 
 	}

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1256,8 +1256,15 @@ func getMasterPubkey(s *Server, icmd interface{}) (interface{}, error) {
 			return nil, err
 		}
 	}
-
-	return w.MasterPubKey(account)
+	
+	// Obtain MasterPubkey of index "account" from wallet
+	masterPubKey, err := w.MasterPubKey(account)
+	if err != nil {
+		return nil, err 
+	}
+	
+	// Return master pubkey as encoded as a string 
+	return MasterPubKey.String()
 }
 
 // getStakeInfo gets a large amounts of information about the stake environment

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1263,7 +1263,7 @@ func getMasterPubkey(s *Server, icmd interface{}) (interface{}, error) {
 		return nil, err 
 	}
 	
-	// Return master pubkey as encoded as a string 
+	// Return master pubkey as a string 
 	return MasterPubKey.String()
 }
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1538,7 +1538,6 @@ func (w *Wallet) MasterPubKey(account uint32) (*hdkeychain.ExtendedKey, error) {
 		masterPubKey, err = w.Manager.GetMasterPubkey(addrmgrNs, account)
 		return err
 	})
-	return masterPubKey, err
 	
 	extendedKey, err := hdkeychain.NewKeyFromString(masterPubKey)
 	if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1530,9 +1530,7 @@ func (w *Wallet) NextAccount(name string) (uint32, error) {
 }
 
 // MasterPubKey returns the BIP0044 master public key for the passed account.
-//
-// TODO: This should not be returning the key as a string.
-func (w *Wallet) MasterPubKey(account uint32) (string, error) {
+func (w *Wallet) MasterPubKey(account uint32) (*hdkeychain.ExtendedKey, error) {
 	var masterPubKey string
 	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
@@ -1541,6 +1539,13 @@ func (w *Wallet) MasterPubKey(account uint32) (string, error) {
 		return err
 	})
 	return masterPubKey, err
+	
+	extendedKey, err := hdkeychain.NewKeyFromString(masterPubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	return extendedKey, nil 
 }
 
 // CreditCategory describes the type of wallet transaction output.  The category


### PR DESCRIPTION
- `wallet/wallet.go` is changed  to return an extendedKey. 
- `rpc/legacyrpc/methods.go` is updated to suit the changes of wallet.go