### PR TITLE
[rpc] Fix unmined block test in GetTransactions

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -998,7 +998,7 @@ func (s *walletServer) GetTransactions(req *pb.GetTransactionsRequest,
 
 	rangeFn := func(block *wallet.Block) (bool, error) {
 		var resp *pb.GetTransactionsResponse
-		if block.Header == nil {
+		if block.Header != nil {
 			resp = &pb.GetTransactionsResponse{
 				MinedTransactions: marshalBlock(block),
 			}


### PR DESCRIPTION
The test for unmined block on the `GetTransactions` grpc call was modified in commit 53457bef94772891934219da6510ac6bbef09cee due to a change in the wallet implementation for GetTransactions.

But the new test (`block.Header == nil`) is the opposite of what is needed (previous version was `block.Height != -1`) so this returns the correct test.