### PR TITLE
Allocate before copying into first block locator hash.

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -273,6 +273,7 @@ func (s *Store) BlockLocators(ns walletdb.ReadBucket) []*chainhash.Hash {
 	height := extractBlockHeaderHeight(headerBucket.Get(hash))
 
 	locators := make([]*chainhash.Hash, 1, 10+log2(int(height)))
+	locators[0] = new(chainhash.Hash)
 	copy(locators[0][:], hash)
 	var skip, skips int32 = 0, 1
 	for height >= 0 {


### PR DESCRIPTION
This fixes an issue in the previous commit which updated to the latest
dcrd.