### PR TITLE
config: Add gaplimit and deprecate addridxscanlen

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,7 +45,7 @@ const (
 	defaultPromptPass          = false
 	defaultPass                = ""
 	defaultPromptPublicPass    = false
-	defaultAddrIdxScanLen      = wallet.DefaultGapLimit
+	defaultGapLimit            = wallet.DefaultGapLimit
 	defaultStakePoolColdExtKey = ""
 	defaultAllowHighFees       = false
 
@@ -109,7 +109,7 @@ type config struct {
 	PurchaseAccount     string               `long:"purchaseaccount" description:"Name of the account to buy tickets from"`
 	PoolAddress         *cfgutil.AddressFlag `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
 	PoolFees            float64              `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)"`
-	AddrIdxScanLen      int                  `long:"addridxscanlen" description:"The width of the scan for last used addresses on wallet restore and start up"`
+	GapLimit            int                  `long:"gaplimit" description:"The size of gaps for used addresses.  Used for address scanning and when generating addresses with the wrap option."`
 	StakePoolColdExtKey string               `long:"stakepoolcoldextkey" description:"Enables the wallet as a stake pool with an extended key in the format of \"xpub...:index\" to derive cold wallet addresses to send fees to"`
 	AllowHighFees       bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
 	RelayFee            *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`
@@ -156,9 +156,10 @@ type config struct {
 	tbCfg  ticketbuyer.Config
 
 	// Deprecated options
-	DataDir       *cfgutil.ExplicitString `short:"b" long:"datadir" default-mask:"-" description:"DEPRECATED -- use appdata instead"`
-	PruneTickets  bool                    `long:"prunetickets" description:"DEPRECATED -- old tickets are always pruned"`
-	TicketAddress *cfgutil.AddressFlag    `long:"ticketaddress" description:"DEPRECATED -- use ticketbuyer.votingaddress instead"`
+	DataDir        *cfgutil.ExplicitString `short:"b" long:"datadir" default-mask:"-" description:"DEPRECATED -- use appdata instead"`
+	PruneTickets   bool                    `long:"prunetickets" description:"DEPRECATED -- old tickets are always pruned"`
+	TicketAddress  *cfgutil.AddressFlag    `long:"ticketaddress" description:"DEPRECATED -- use ticketbuyer.votingaddress instead"`
+	AddrIdxScanLen int                     `long:"addridxscanlen" description:"DEPRECATED -- use gaplimit instead"`
 }
 
 type ticketBuyerOptions struct {
@@ -349,7 +350,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		PruneTickets:           defaultPruneTickets,
 		PurchaseAccount:        defaultPurchaseAccount,
 		AutomaticRepair:        defaultAutomaticRepair,
-		AddrIdxScanLen:         defaultAddrIdxScanLen,
+		GapLimit:               defaultGapLimit,
 		StakePoolColdExtKey:    defaultStakePoolColdExtKey,
 		AllowHighFees:          defaultAllowHighFees,
 		RelayFee:               cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
@@ -357,8 +358,9 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		PoolAddress:            cfgutil.NewAddressFlag(nil),
 
 		// TODO: DEPRECATED - remove.
-		DataDir:       cfgutil.NewExplicitString(defaultAppDataDir),
-		TicketAddress: cfgutil.NewAddressFlag(nil),
+		DataDir:        cfgutil.NewExplicitString(defaultAppDataDir),
+		TicketAddress:  cfgutil.NewAddressFlag(nil),
+		AddrIdxScanLen: defaultGapLimit,
 
 		// Ticket Buyer Options
 		TBOpts: ticketBuyerOptions{
@@ -906,6 +908,13 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		if votingAddress == nil {
 			votingAddress = cfg.TicketAddress.Address
 		}
+	}
+
+	// Warn if user still is still using --addridxscanlen
+	if cfg.AddrIdxScanLen != defaultGapLimit && cfg.GapLimit == defaultGapLimit {
+		log.Warnf("--addridxscanlen has been DEPRECATED.  Use " +
+			"--gaplimit instead")
+		cfg.GapLimit = cfg.AddrIdxScanLen
 	}
 
 	// Build ticketbuyer config

--- a/config.go
+++ b/config.go
@@ -109,7 +109,7 @@ type config struct {
 	PurchaseAccount     string               `long:"purchaseaccount" description:"Name of the account to buy tickets from"`
 	PoolAddress         *cfgutil.AddressFlag `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
 	PoolFees            float64              `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)"`
-	GapLimit            int                  `long:"gaplimit" description:"The size of gaps for used addresses.  Used for address scanning and when generating addresses with the wrap option."`
+	GapLimit            int                  `long:"gaplimit" description:"The size of gaps between used addresses.  Used for address scanning and when generating addresses with the wrap option."`
 	StakePoolColdExtKey string               `long:"stakepoolcoldextkey" description:"Enables the wallet as a stake pool with an extended key in the format of \"xpub...:index\" to derive cold wallet addresses to send fees to"`
 	AllowHighFees       bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
 	RelayFee            *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -146,7 +146,7 @@ func run(ctx context.Context) error {
 		TicketFee:           cfg.TicketFee.ToCoin(),
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.AddrIdxScanLen, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -42,7 +42,7 @@ type Loader struct {
 	purchaseManager *ticketbuyer.PurchaseManager
 	ntfnClient      wallet.MainTipChangedNotificationsClient
 	stakeOptions    *StakeOptions
-	addrIdxScanLen  int
+	gapLimit        int
 	allowHighFees   bool
 	relayFee        float64
 }
@@ -59,16 +59,16 @@ type StakeOptions struct {
 }
 
 // NewLoader constructs a Loader.
-func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, addrIdxScanLen int,
+func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit int,
 	allowHighFees bool, relayFee float64) *Loader {
 
 	return &Loader{
-		chainParams:    chainParams,
-		dbDirPath:      dbDirPath,
-		stakeOptions:   stakeOptions,
-		addrIdxScanLen: addrIdxScanLen,
-		allowHighFees:  allowHighFees,
-		relayFee:       relayFee,
+		chainParams:   chainParams,
+		dbDirPath:     dbDirPath,
+		stakeOptions:  stakeOptions,
+		gapLimit:      gapLimit,
+		allowHighFees: allowHighFees,
+		relayFee:      relayFee,
 	}
 }
 
@@ -170,7 +170,7 @@ func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte)
 		PoolAddress:         so.PoolAddress,
 		PoolFees:            so.PoolFees,
 		TicketFee:           so.TicketFee,
-		GapLimit:            l.addrIdxScanLen,
+		GapLimit:            l.gapLimit,
 		StakePoolColdExtKey: so.StakePoolColdExtKey,
 		AllowHighFees:       l.allowHighFees,
 		RelayFee:            l.relayFee,
@@ -258,7 +258,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 		PoolAddress:         so.PoolAddress,
 		PoolFees:            so.PoolFees,
 		TicketFee:           so.TicketFee,
-		GapLimit:            l.addrIdxScanLen,
+		GapLimit:            l.gapLimit,
 		StakePoolColdExtKey: so.StakePoolColdExtKey,
 		AllowHighFees:       l.allowHighFees,
 		RelayFee:            l.relayFee,
@@ -313,7 +313,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte) (w *wallet.Wallet, rer
 		PoolAddress:         so.PoolAddress,
 		PoolFees:            so.PoolFees,
 		TicketFee:           so.TicketFee,
-		GapLimit:            l.addrIdxScanLen,
+		GapLimit:            l.gapLimit,
 		StakePoolColdExtKey: so.StakePoolColdExtKey,
 		AllowHighFees:       l.allowHighFees,
 		RelayFee:            l.relayFee,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -57,7 +57,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 		TicketFee:     cfg.TicketFee.ToCoin(),
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.AddrIdxScanLen, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
We had discussed doing this a few times.

`--gaplimit` is very descriptive about what the option accomplishes and is easier to explain to users.