### PR TITLE
Fix check for unset public passphrase.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -180,8 +180,8 @@ func run(ctx context.Context) error {
 			log.Errorf("Failed to open wallet: %v", err)
 			if apperrors.IsError(err, apperrors.ErrWrongPassphrase) {
 				// walletpass not provided, advice using --walletpass or --promptpublicpass
-				if len(walletPass) == 0 {
-					log.Info("Retry with --walletpass or --promptpublicpass.")
+				if cfg.WalletPass == wallet.InsecurePubPassphrase {
+					log.Info("Configure public passphrase with walletpass or promptpublicpass options.")
 				}
 			}
 


### PR DESCRIPTION
The default config value for the public passphrase is "public" not the
empty string.  Fixing this check will correctly log a message to set
the public passphrase with the appropiate config options.

While here, edit the log message to remove -- from the flag names, as
these are more appropiate to add to the config file anyways.