### PR TITLE
Prevent empty filepaths from being cleaned to .

### DIFF
--- a/config.go
+++ b/config.go
@@ -190,6 +190,11 @@ type ticketBuyerOptions struct {
 // cleanAndExpandPath expands environement variables and leading ~ in the
 // passed path, cleans the result, and returns it.
 func cleanAndExpandPath(path string) string {
+	// Do not try to clean the empty string
+	if path == "" {
+		return ""
+	}
+
 	// NOTE: The os.ExpandEnv doesn't work with Windows cmd.exe-style
 	// %VARIABLE%, but they variables can still be expanded via POSIX-style
 	// $VARIABLE.


### PR DESCRIPTION
The function which cleans and expands filepaths for config options
erroneously converted the empty string to a single dot.  Correct this
by checking for an empty path as input and returning the empty path
back.

Discovered and previously fixed in dcrd, which contained a ported
version of dcrwallet's filepath cleaning.