### PR TITLE
wallet: added functions to access db 

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1848,6 +1848,36 @@ func (w *Wallet) MasterPubKey(account uint32) (*hdkeychain.ExtendedKey, error) {
 	return extKey, nil
 }
 
+// CoinTypePrivKey returns the BIP0044 coin type private key.
+func (w *Wallet) CoinTypePrivKey() (*hdkeychain.ExtendedKey, error) {
+	const op errors.Op = "wallet.CoinTypeKey"
+	var coinTypePrivateKey *hdkeychain.ExtendedKey
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		var err error
+		coinTypePrivateKey, err = w.Manager.CoinTypePrivKey(tx)
+		return err
+	})
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	return coinTypePrivateKey, nil
+}
+
+// CoinType returns the SLIP0044 or legacy coin type for the passed account.
+func (w *Wallet) CoinType() (uint32, error) {
+	const op errors.Op = "wallet.CoinType"
+	var coinType uint32
+	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+		var err error
+		coinType, err = w.Manager.CoinType(tx)
+		return err
+	})
+	if err != nil {
+		return 0, errors.E(op, err)
+	}
+	return coinType, nil
+}
+
 // GetTransactionsByHashes returns all known transactions identified by a slice
 // of transaction hashes.  It is possible that not all transactions are found,
 // and in this case the known results will be returned along with an inventory


### PR DESCRIPTION
Dividing up work into branches to allow dependencies to be separately merged.

1. `CoinTypeKey` is needed for future pay to contract hash PR and verifyseed RPC.
2. `CoinType` is needed for `verifyseedcmd`.  
