### PR TITLE
Handle missing unencrypted scripts when processing transactions.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -696,11 +696,7 @@ func (w *Wallet) processTransaction(dbtx walletdb.ReadWriteTx, rec *udb.TxRecord
 				var err error
 				expandedScript, err = w.TxStore.GetTxScript(txmgrNs,
 					addr.ScriptAddress())
-				if err != nil {
-					return errors.E(op, err)
-				}
-
-				if expandedScript == nil {
+				if errors.Is(errors.NotExist, err) {
 					script, done, err := w.Manager.RedeemScript(addrmgrNs, addr)
 					if err != nil {
 						log.Debugf("failed to find redeemscript for "+
@@ -710,6 +706,8 @@ func (w *Wallet) processTransaction(dbtx walletdb.ReadWriteTx, rec *udb.TxRecord
 					}
 					defer done()
 					expandedScript = script
+				} else if err != nil {
+					return errors.E(op, err)
 				}
 			}
 

--- a/wallet/multisig.go
+++ b/wallet/multisig.go
@@ -140,14 +140,7 @@ func (w *Wallet) FetchP2SHMultiSigOutput(outPoint *wire.OutPoint) (*P2SHMultiSig
 		}
 
 		redeemScript, err = w.TxStore.GetTxScript(txmgrNs, mso.ScriptHash[:])
-		if err != nil {
-			return err
-		}
-		if redeemScript == nil {
-			return errors.E(errors.NotExist, "missing redeem script")
-		}
-
-		return nil
+		return err
 	})
 	if err != nil {
 		return nil, errors.E(op, err)


### PR DESCRIPTION
This fixes a bug introduced with the errors package which began to
return errors for missing unencrypted scripts, instead of just
returning nil.  The calling code has been updated in all places to no
longer assume it returns nil scripts and without error when the script
is not found.