### PR TITLE
Update dcrd, switch to slog logger package.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -24,12 +24,6 @@
 
 [[projects]]
   branch = "master"
-  name = "github.com/btcsuite/btclog"
-  packages = ["."]
-  revision = "84c8d2346e9fc8c7b947e243b9c24e6df9fd206a"
-
-[[projects]]
-  branch = "master"
   name = "github.com/btcsuite/go-socks"
   packages = ["socks"]
   revision = "4720035b7bfd2a9bb130b1c184f8bbe41b6f0d0f"
@@ -83,7 +77,13 @@
     "txscript",
     "wire"
   ]
-  revision = "0921280e6e232b66f19ada00ba9adad1d82c90a5"
+  revision = "678ff1efdd767f84f7787bb29d04542c6c94f636"
+
+[[projects]]
+  name = "github.com/decred/slog"
+  packages = ["."]
+  revision = "fbd821ef791ba2b8ae945f5d44f4e49396d230c5"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -210,6 +210,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "890953b366de351f13c362e03a2d3d137bffc528185ceb18426561fe20d2e651"
+  inputs-digest = "0ad13264d89466ff4c9f2cbb6684367f285cf11bfa56dbaacfddddfca9317edd"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,8 +4,8 @@
   version = "1.3.0"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/btcsuite/btclog"
+  name = "github.com/decred/slog"
+  version = "1.0.0"
 
 [[constraint]]
   branch = "master"

--- a/chain/log.go
+++ b/chain/log.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package chain
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -19,12 +20,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/config.go
+++ b/config.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -16,7 +16,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/btcsuite/btclog"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/internal/cfgutil"
@@ -25,6 +24,7 @@ import (
 	"github.com/decred/dcrwallet/version"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/wallet/txrules"
+	"github.com/decred/slog"
 	flags "github.com/jessevdk/go-flags"
 )
 
@@ -244,7 +244,7 @@ func cleanAndExpandPath(path string) string {
 
 // validLogLevel returns whether or not logLevel is a valid debug log level.
 func validLogLevel(logLevel string) bool {
-	_, ok := btclog.LevelFromString(logLevel)
+	_, ok := slog.LevelFromString(logLevel)
 	return ok
 }
 

--- a/go.mod
+++ b/go.mod
@@ -2,15 +2,12 @@ module github.com/decred/dcrwallet
 
 require (
 	github.com/boltdb/bolt v1.3.1
-	github.com/decred/dcrd v0.0.0-20180523063551-02558ca948f4
+	github.com/decred/dcrd v0.0.0-20180523192210-678ff1efdd76
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.1.0
-	github.com/jessevdk/go-flags v1.4.0
-	github.com/jrick/bitset v1.0.0
 	github.com/jrick/logrotate v1.0.0
 	github.com/onsi/ginkgo v1.5.0
 	github.com/onsi/gomega v1.4.0
-	golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78
 	golang.org/x/net v0.0.0-20180522190444-9ef9f5bb98a1
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	golang.org/x/text v0.3.0

--- a/go.modverify
+++ b/go.modverify
@@ -8,10 +8,13 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723 h1:ZA/jbKoGcVAn
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/winsvc v0.0.0-20150117052343-f8fb11f83f7e h1:Yf0qH7/DA25s5wOtKffIg9hGSyTj9dXCnbqXr2UugNk=
 github.com/davecgh/go-spew v0.0.0-20180221232628-8991bc29aa16 h1:HqkufMBR7waVfFFRABWqHa1WgTvjtVDJTLJe3CR576A=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/dchest/blake256 v0.0.0-20150903101604-dee3fe6eb0e9 h1:R1zSOsHbPX/UQdOJzWPonBFMFa8BJpd3BIfK9nRXF70=
 github.com/decred/base58 v0.0.0-20180302003706-56c501706f00 h1:ejXqeY7P4O22qIxzhsWOq9N3An1kEmWcTjFfM6QGkyg=
 github.com/decred/dcrd v0.0.0-20180523063551-02558ca948f4 h1:gRXjP6rCWwgr1NKWqG2vGeRe/ONF4aM06aiuvWQthEQ=
+github.com/decred/dcrd v0.0.0-20180523192210-678ff1efdd76 h1:uvBLVraITUHCKGwBmaqbuV7qVJ+dRMgpEMzprLwhrJI=
 github.com/decred/dcrd v1.2.0 h1:RWx91j1kMgYmrgZ+JGGaIMDTejroN4Y8pVEzdmPilDs=
+github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
@@ -23,6 +26,7 @@ golang.org/x/crypto v0.0.0-20180515001509-1a580b3eff78 h1:uJIReYEB1ZZLarzi83Pmig
 golang.org/x/net v0.0.0-20180522190444-9ef9f5bb98a1 h1:+2KJRQYVS4oeIZqXrgNLH7FxyXp+eVs2kLuG5pWupfY=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
 golang.org/x/sys v0.0.0-20180326154331-13d03a9a82fb h1:w1eDrzbtlRsu1SyjnZZFUBVuhRN2Rn6DlrHCx9s4ud0=
+golang.org/x/sys v0.0.0-20180522224204-88eb85aaee56 h1:ALdc3t+jAqSs6+pzVEioBeI8YtMICgYVFhEy6P69czc=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 google.golang.org/genproto v0.0.0-20180518175338-11a468237815 h1:p3qKkjcSW6m32Lr1CInA3jW53vG29/JB6QOvQWie5WI=
 google.golang.org/grpc v1.12.0 h1:Mm8atZtkT+P6R43n/dqNDWkPPu5BwRVu/1rJnJCeZH8=

--- a/loader/log.go
+++ b/loader/log.go
@@ -1,16 +1,16 @@
 // Copyright (c) 2015 The btcsuite developers
-// Copyright (c) 2017 The Decred developers
+// Copyright (c) 2017-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package loader
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -20,12 +20,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/log.go
+++ b/log.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/btcsuite/btclog"
 	dcrrpcclient "github.com/decred/dcrd/rpcclient"
 	"github.com/decred/dcrwallet/chain"
 	"github.com/decred/dcrwallet/loader"
@@ -19,6 +18,7 @@ import (
 	"github.com/decred/dcrwallet/ticketbuyer"
 	"github.com/decred/dcrwallet/wallet"
 	"github.com/decred/dcrwallet/wallet/udb"
+	"github.com/decred/slog"
 	"github.com/jrick/logrotate/rotator"
 )
 
@@ -44,7 +44,7 @@ var (
 	// backendLog is the logging backend used to create all subsystem loggers.
 	// The backend must not be used before the log rotator has been initialized,
 	// or data races and/or nil pointer dereferences will occur.
-	backendLog = btclog.NewBackend(logWriter{})
+	backendLog = slog.NewBackend(logWriter{})
 
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
@@ -72,7 +72,7 @@ func init() {
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.
-var subsystemLoggers = map[string]btclog.Logger{
+var subsystemLoggers = map[string]slog.Logger{
 	"DCRW": log,
 	"LODR": loaderLog,
 	"WLLT": walletLog,
@@ -112,7 +112,7 @@ func setLogLevel(subsystemID string, logLevel string) {
 	}
 
 	// Defaults to info if the log level is invalid.
-	level, _ := btclog.LevelFromString(logLevel)
+	level, _ := slog.LevelFromString(logLevel)
 	logger.SetLevel(level)
 }
 

--- a/rpc/legacyrpc/log.go
+++ b/rpc/legacyrpc/log.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package legacyrpc
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
-var log = btclog.Disabled
+var log = slog.Disabled
 
 // UseLogger sets the package-wide logger.  Any calls to this function must be
 // made before a server is created and used (it is not concurrent safe).
-func UseLogger(logger btclog.Logger) {
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/rpc/rpcserver/log.go
+++ b/rpc/rpcserver/log.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
+// Copyright (c) 2018 The Decred devlopers
 //
 // Permission to use, copy, modify, and distribute this software for any
 // purpose with or without fee is hereby granted, provided that the above
@@ -18,23 +19,22 @@ import (
 	"os"
 	"strings"
 
+	"github.com/decred/slog"
 	"google.golang.org/grpc/grpclog"
-
-	"github.com/btcsuite/btclog"
 )
 
 // UseLogger sets the logger to use for the gRPC server.
-func UseLogger(l btclog.Logger) {
+func UseLogger(l slog.Logger) {
 	grpclog.SetLogger(logger{l})
 }
 
-// logger uses a btclog.Logger to implement the grpclog.Logger interface.
+// logger uses a slog.Logger to implement the grpclog.Logger interface.
 type logger struct {
-	btclog.Logger
+	slog.Logger
 }
 
 // stripGrpcPrefix removes the package prefix for all logs made to the grpc
-// logger, since these are already included as the btclog subsystem name.
+// logger, since these are already included as the slog subsystem name.
 func stripGrpcPrefix(logstr string) string {
 	return strings.TrimPrefix(logstr, "grpc: ")
 }

--- a/ticketbuyer/log.go
+++ b/ticketbuyer/log.go
@@ -1,25 +1,25 @@
-// Copyright (c) 2016 The Decred developers
+// Copyright (c) 2016-2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package ticketbuyer
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log = btclog.Disabled
+var log = slog.Disabled
 
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/wallet/log.go
+++ b/wallet/log.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package wallet
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log btclog.Logger
+var log slog.Logger
 
 // The default amount of logging is none.
 func init() {
@@ -19,12 +20,12 @@ func init() {
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }

--- a/wallet/udb/log.go
+++ b/wallet/udb/log.go
@@ -1,25 +1,26 @@
 // Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2018 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package udb
 
-import "github.com/btcsuite/btclog"
+import "github.com/decred/slog"
 
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log = btclog.Disabled
+var log = slog.Disabled
 
 // DisableLog disables all library log output.  Logging output is disabled
 // by default until either UseLogger or SetLogWriter are called.
 func DisableLog() {
-	log = btclog.Disabled
+	log = slog.Disabled
 }
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
-// using btclog.
-func UseLogger(logger btclog.Logger) {
+// using slog.
+func UseLogger(logger slog.Logger) {
 	log = logger
 }


### PR DESCRIPTION
dcrd was updated to use the new package github.com/decred/slog for all
logging prior to introducing submodules (which would have required a
version bump).  Update for this dcrd change in anticipation for
depending on dcrd submodules as well as defining our own.