### PR TITLE
Prevent signrawtransaction panic on gettxout result.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -2945,7 +2945,12 @@ func signRawTransaction(s *Server, icmd interface{}) (interface{}, error) {
 	for outPoint, resp := range requested {
 		result, err := resp.Receive()
 		if err != nil {
-			return nil, err
+			return nil, errors.E(errors.Op("dcrd.jsonrpc.gettxout"), err)
+		}
+		// gettxout returns JSON null if the output is found, but is spent by
+		// another transaction in the main chain.
+		if result == nil {
+			continue
 		}
 		script, err := hex.DecodeString(result.ScriptPubKey.Hex)
 		if err != nil {


### PR DESCRIPTION
The dcrd gettxout JSON-RPC method is invoked by signrawtransaction to
look up previous output scripts that the wallet may not record itself.
When gettxout is queried for an output that is already spent in the
main chain, it will return the JSON null without any error.  This
requires special casing in the signrawtransaction implementation to
avoid a possible nil pointer dereference.

Fixes #1148