### PR TITLE
multi: change accountgaplimit and add config option

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,6 +49,7 @@ const (
 	defaultGapLimit            = wallet.DefaultGapLimit
 	defaultStakePoolColdExtKey = ""
 	defaultAllowHighFees       = false
+	defaultAccountGapLimit     = wallet.DefaultAccountGapLimit
 
 	// ticket buyer options
 	defaultMaxFee                    dcrutil.Amount = 1e6
@@ -115,6 +116,7 @@ type config struct {
 	AllowHighFees       bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
 	RelayFee            *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`
 	TicketFee           *cfgutil.AmountFlag  `long:"ticketfee" description:"Sets the wallet's ticket fee per kb"`
+	AccountGapLimit     int                  `long:"accountgaplimit" description:"Number of accounts that can be created in a row without using any of them"`
 
 	// RPC client options
 	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to"`
@@ -362,6 +364,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		RelayFee:               cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
 		TicketFee:              cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
 		PoolAddress:            cfgutil.NewAddressFlag(nil),
+		AccountGapLimit:        defaultAccountGapLimit,
 
 		// TODO: DEPRECATED - remove.
 		DataDir:        cfgutil.NewExplicitString(defaultAppDataDir),

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -151,7 +151,7 @@ func run(ctx context.Context) error {
 		TicketFee:           cfg.TicketFee.ToCoin(),
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(), cfg.AccountGapLimit)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -43,6 +43,7 @@ type Loader struct {
 	ntfnClient      wallet.MainTipChangedNotificationsClient
 	stakeOptions    *StakeOptions
 	gapLimit        int
+	accountGapLimit int
 	allowHighFees   bool
 	relayFee        float64
 }
@@ -60,15 +61,16 @@ type StakeOptions struct {
 
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit int,
-	allowHighFees bool, relayFee float64) *Loader {
+	allowHighFees bool, relayFee float64, accountGapLimit int) *Loader {
 
 	return &Loader{
-		chainParams:   chainParams,
-		dbDirPath:     dbDirPath,
-		stakeOptions:  stakeOptions,
-		gapLimit:      gapLimit,
-		allowHighFees: allowHighFees,
-		relayFee:      relayFee,
+		chainParams:     chainParams,
+		dbDirPath:       dbDirPath,
+		stakeOptions:    stakeOptions,
+		gapLimit:        gapLimit,
+		accountGapLimit: accountGapLimit,
+		allowHighFees:   allowHighFees,
+		relayFee:        relayFee,
 	}
 }
 
@@ -320,6 +322,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte) (w *wallet.Wallet, rer
 		PoolFees:            so.PoolFees,
 		TicketFee:           so.TicketFee,
 		GapLimit:            l.gapLimit,
+		AccountGapLimit:     l.accountGapLimit,
 		StakePoolColdExtKey: so.StakePoolColdExtKey,
 		AllowHighFees:       l.allowHighFees,
 		RelayFee:            l.relayFee,

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -33,6 +33,12 @@
 ; txfee=0.001
 ; ticketfee=0.001
 
+; Set a number of unused address gap limit defined by BIP0044
+; gaplimit=20
+
+; Set number of accounts that can be created in a row without using any of them.
+; It also changes a number of accounts that will be scanned during seed restoration
+; accountgaplimit=10
 
 ; ------------------------------------------------------------------------------
 ; RPC client settings

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -20,6 +20,10 @@ import (
 // DefaultGapLimit is the default unused address gap limit defined by BIP0044.
 const DefaultGapLimit = 20
 
+// DefaultAccountGapLimit is the default number of accounts that can be
+// created in a row without using any of them
+const DefaultAccountGapLimit = 10
+
 // gapPolicy defines the policy to use when the BIP0044 address gap limit is
 // exceeded.
 type gapPolicy int

--- a/wallet/sync.go
+++ b/wallet/sync.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (w *Wallet) findLastUsedAccount(n NetworkBackend, coinTypeXpriv *hdkeychain.ExtendedKey) (uint32, error) {
-	const scanLen = 100
+	scanLen := uint32(w.accountGapLimit)
 	var (
 		lastUsed uint32
 		lo, hi   uint32 = 0, hdkeychain.HardenedKeyStart / scanLen
@@ -30,11 +30,11 @@ Bsearch:
 			account uint32
 			err     error
 		}
-		var results [scanLen]result
+		var results = make([]result, scanLen)
 		var wg sync.WaitGroup
 		for i := scanLen - 1; i >= 0; i-- {
 			i := i
-			account := mid*scanLen + uint32(i)
+			account := mid*scanLen + i
 			if account >= hdkeychain.HardenedKeyStart {
 				continue
 			}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -93,6 +93,7 @@ type Wallet struct {
 	// Start up flags/settings
 	initiallyUnlocked bool
 	gapLimit          int
+	accountGapLimit   int
 
 	networkBackend   NetworkBackend
 	networkBackendMu sync.Mutex
@@ -157,7 +158,9 @@ type Config struct {
 	PoolFees      float64
 	TicketFee     float64
 
-	GapLimit            int
+	GapLimit        int
+	AccountGapLimit int
+
 	StakePoolColdExtKey string
 	AllowHighFees       bool
 	RelayFee            float64
@@ -1538,8 +1541,6 @@ func (w *Wallet) RenameAccount(account uint32, newName string) error {
 	return nil
 }
 
-const maxEmptyAccounts = 100
-
 // NextAccount creates the next account and returns its account number.  The
 // name must be unique to the account.  In order to support automatic seed
 // restoring, new accounts may not be created when all of the previous 100
@@ -1547,6 +1548,7 @@ const maxEmptyAccounts = 100
 // spec, which allows no unused account gaps).
 func (w *Wallet) NextAccount(name string) (uint32, error) {
 	const op errors.Op = "wallet.NextAccount"
+	maxEmptyAccounts := uint32(w.accountGapLimit)
 	var account uint32
 	var props *udb.AccountProperties
 	var xpub *hdkeychain.ExtendedKey
@@ -3844,8 +3846,9 @@ func Open(cfg *Config) (*Wallet, error) {
 		poolFees:      cfg.PoolFees,
 
 		// LoaderOptions
-		gapLimit:      cfg.GapLimit,
-		AllowHighFees: cfg.AllowHighFees,
+		gapLimit:        cfg.GapLimit,
+		AllowHighFees:   cfg.AllowHighFees,
+		accountGapLimit: cfg.AccountGapLimit,
 
 		// Chain params
 		subsidyCache: blockchain.NewSubsidyCache(0, cfg.Params),

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -58,7 +58,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 		TicketFee:     cfg.TicketFee.ToCoin(),
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin())
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(), cfg.AccountGapLimit)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
Reduce default allowed account gap limit from 100 to 10 accounts to
improve performance of account discovery. Add configurable
"accountgaplimit" in case user need to scan more accounts

https://github.com/decred/dcrwallet/issues/1143