### PR TITLE
Bump grpc version for previous change

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -57,9 +57,9 @@ import (
 
 // Public API version constants
 const (
-	semverString = "4.37.0"
+	semverString = "4.38.0"
 	semverMajor  = 4
-	semverMinor  = 37
+	semverMinor  = 38
 	semverPatch  = 0
 )
 


### PR DESCRIPTION
Looks like the version in the docs was bumped in #1113 but not in the server.go.