### PR TITLE
wallet: make ChangeSource an interface.

### DIFF
--- a/wallet/internal/txsizes/size_test.go
+++ b/wallet/internal/txsizes/size_test.go
@@ -32,37 +32,37 @@ func TestEstimateSerializeSize(t *testing.T) {
 	tests := []struct {
 		InputScriptSizers    []ScriptSizer
 		OutputScriptLengths  []int
-		AddChangeOutput      bool
+		ChangeScriptSize     int
 		ExpectedSizeEstimate int
 	}{
-		0: {[]ScriptSizer{P2PKHScriptSize}, []int{}, false, 181},
-		1: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, false, 217},
-		2: {[]ScriptSizer{P2PKHScriptSize}, []int{}, true, 217},
-		3: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, true, 253},
-		4: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, false, 215},
-		5: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, true, 251},
+		0: {[]ScriptSizer{P2PKHScriptSize}, []int{}, 0, 181},
+		1: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, 0, 217},
+		2: {[]ScriptSizer{P2PKHScriptSize}, []int{}, p2pkhScriptSize, 217},
+		3: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 253},
+		4: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, 0, 215},
+		5: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 251},
 
-		6:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, false, 347},
-		7:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, false, 383},
-		8:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, true, 383},
-		9:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, true, 419},
-		10: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, false, 381},
-		11: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, true, 417},
+		6:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, 0, 347},
+		7:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, 0, 383},
+		8:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, p2pkhScriptSize, 383},
+		9:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 419},
+		10: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, 0, 381},
+		11: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 417},
 
 		// 0xfd is discriminant for 16-bit compact ints, compact int
 		// total size increases from 1 byte to 3.
-		12: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), false, 9253},
-		13: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfd), false, 9253 + P2PKHOutputSize + 2},
-		14: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), true, 9253 + P2PKHOutputSize + 2},
-		15: {*makeScriptSizers(0xfc, P2PKHScriptSize), []int{}, false, 41847},
-		16: {*makeScriptSizers(0xfd, P2PKHScriptSize), []int{}, false, 41847 + RedeemP2PKHInputSize + 4}, // 4 not 2, varint encoded twice.
+		12: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), 0, 9253},
+		13: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfd), 0, 9253 + P2PKHOutputSize + 2},
+		14: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), p2pkhScriptSize, 9253 + P2PKHOutputSize + 2},
+		15: {*makeScriptSizers(0xfc, P2PKHScriptSize), []int{}, 0, 41847},
+		16: {*makeScriptSizers(0xfd, P2PKHScriptSize), []int{}, 0, 41847 + RedeemP2PKHInputSize + 4}, // 4 not 2, varint encoded twice.
 	}
 	for i, test := range tests {
 		outputs := make([]*wire.TxOut, 0, len(test.OutputScriptLengths))
 		for _, l := range test.OutputScriptLengths {
 			outputs = append(outputs, &wire.TxOut{PkScript: make([]byte, l)})
 		}
-		actualEstimate := EstimateSerializeSize(test.InputScriptSizers, outputs, test.AddChangeOutput)
+		actualEstimate := EstimateSerializeSize(test.InputScriptSizers, outputs, test.ChangeScriptSize)
 		if actualEstimate != test.ExpectedSizeEstimate {
 			t.Errorf("Test %d: Got %v: Expected %v", i, actualEstimate, test.ExpectedSizeEstimate)
 		}

--- a/wallet/multisig.go
+++ b/wallet/multisig.go
@@ -205,7 +205,7 @@ func (w *Wallet) PrepareRedeemMultiSigOutTxOutput(msgTx *wire.MsgTx, p2shOutput 
 
 	// estimate the output fee
 	txOut := wire.NewTxOut(0, *pkScript)
-	feeSize := txsizes.EstimateSerializeSize(scriptSizers, []*wire.TxOut{txOut}, false)
+	feeSize := txsizes.EstimateSerializeSize(scriptSizers, []*wire.TxOut{txOut}, 0)
 	feeEst := txrules.FeeForSerializeSize(w.RelayFee(), feeSize)
 	if feeEst >= p2shOutput.OutputAmount {
 		return errors.E(op, errors.Errorf("estimated fee %v is above output value %v",

--- a/wallet/txauthor/author_test.go
+++ b/wallet/txauthor/author_test.go
@@ -17,6 +17,17 @@ import (
 	"github.com/decred/dcrwallet/wallet/internal/txsizes"
 )
 
+type AuthorTestChangeSource struct{}
+
+func (src AuthorTestChangeSource) Script() ([]byte, uint16, error) {
+	// Only length matters for these tests.
+	return make([]byte, txsizes.P2PKHPkScriptSize), 0, nil
+}
+
+func (src AuthorTestChangeSource) ScriptSize() int {
+	return txsizes.P2PKHPkScriptSize
+}
+
 func p2pkhOutputs(amounts ...dcrutil.Amount) []*wire.TxOut {
 	v := make([]*wire.TxOut, 0, len(amounts))
 	for _, a := range amounts {
@@ -63,7 +74,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6),
 			RelayFee:       1e3,
 			ChangeAmount: 1e8 - 1e6 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), true)),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		2: {
@@ -71,7 +82,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6),
 			RelayFee:       1e4,
 			ChangeAmount: 1e8 - 1e6 - txrules.FeeForSerializeSize(1e4,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), true)),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		3: {
@@ -79,7 +90,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6, 1e6, 1e6),
 			RelayFee:       1e4,
 			ChangeAmount: 1e8 - 3e6 - txrules.FeeForSerializeSize(1e4,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), true)),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		4: {
@@ -87,7 +98,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6, 1e6, 1e6),
 			RelayFee:       2.55e3,
 			ChangeAmount: 1e8 - 3e6 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), true)),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 
@@ -95,7 +106,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		5: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 602 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -103,7 +114,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		6: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 603 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 603,
 			InputCount:   1,
@@ -113,7 +124,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		7: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 1537 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     2.55e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -121,7 +132,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		8: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 1538 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     2.55e3,
 			ChangeAmount: 1538,
 			InputCount:   1,
@@ -133,7 +144,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		9: {
 			UnspentOutputs: p2pkhOutputs(1e8, 1e8),
 			Outputs: p2pkhOutputs(1e8 - 603 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 603,
 			InputCount:   1,
@@ -147,7 +158,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		10: {
 			UnspentOutputs: p2pkhOutputs(1e8, 1e8),
 			Outputs: p2pkhOutputs(1e8 - 545 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), true))),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -159,7 +170,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e8),
 			RelayFee:       1e3,
 			ChangeAmount: 1e8 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize, txsizes.P2PKHScriptSize}, p2pkhOutputs(1e8), true)),
+				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize, txsizes.P2PKHScriptSize}, p2pkhOutputs(1e8), txsizes.P2PKHPkScriptSize)),
 			InputCount: 2,
 		},
 
@@ -174,10 +185,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		},
 	}
 
-	changeSource := func() ([]byte, uint16, error) {
-		// Only length matters for these tests.
-		return make([]byte, txsizes.P2PKHPkScriptSize), 0, nil
-	}
+	var changeSource AuthorTestChangeSource
 
 	for i, test := range tests {
 		inputSource := makeInputSource(test.UnspentOutputs)


### PR DESCRIPTION
This adds the ChangeSource interface which requires two function implementations: Source() & ScriptSize(). NewUnsignedTransaction() has been updated to use this modification as a result. 

EstimateSerializeSize function signature has also been updated to take the change script size instead of assuming a P2PKH script size for the change output. Passing zero (0) as the change script size does not add a change output.

This is work towards #1162