### PR TITLE
wallet: remove tx hash from watching list after block invalidation

### DIFF
--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -810,7 +810,7 @@ type confNtfnResult struct {
 // ConfirmationNotification describes the number of confirmations of a single
 // transaction, or -1 if the transaction is unknown or removed from the wallet.
 // If the transaction is mined (Confirmations >= 1), the block hash and height
-// is included.  Otherwise the block hash is nil and the block hegiht is set to
+// is included.  Otherwise the block hash is nil and the block height is set to
 // -1.
 type ConfirmationNotification struct {
 	TxHash        *chainhash.Hash
@@ -838,6 +838,19 @@ func (c *ConfirmationNotificationsClient) Watch(txHashes []*chainhash.Hash, stop
 			case errors.Is(errors.NotExist, err):
 				confs = -1
 			default:
+				// Remove tx hash from watching list if tx block has been mined
+				// and then invalidated by next block
+				if tipHeight > height && height > 0 {
+					txDetails, err := w.TxStore.TxDetails(txmgrNs, h)
+					if err != nil {
+						return err
+					}
+					_, invalidated := w.TxStore.BlockInMainChain(dbtx, &txDetails.Block.Hash)
+					if invalidated {
+						confs = -1
+						break
+					}
+				}
 				confs = confirms(height, tipHeight)
 			case err != nil:
 				return err
@@ -919,6 +932,19 @@ func (c *ConfirmationNotificationsClient) process(tipHeight int32) {
 			case errors.Is(errors.NotExist, err):
 				confs = -1
 			default:
+				// Remove tx hash from watching list if tx block has been mined
+				// and then invalidated by next block
+				if tipHeight > height && height > 0 {
+					txDetails, err := w.TxStore.TxDetails(txmgrNs, &txHash)
+					if err != nil {
+						return err
+					}
+					_, invalidated := w.TxStore.BlockInMainChain(dbtx, &txDetails.Block.Hash)
+					if invalidated {
+						confs = -1
+						break
+					}
+				}
 				confs = confirms(height, tipHeight)
 			case err != nil:
 				return err


### PR DESCRIPTION
Description: Remove transaction hash from watching list if block has been already
mined and then invalidated by next best block.

Comment: as we discussed in chat there could be 3 cases on invalidation:
1. Tx was kicked back into mempool - this case is covered by confirm's func condition `txHeight == -1` and return `0` to subscriber
2. Tx was mined in new best block - this case is covered by `height, err := w.TxStore.TxBlockHeight(dbtx, &txHash)`. TxBlockHeight will return height of newly mined tx block and no need to check if previous block was invalidated or not.
3. Tx block was invalidated by new best block and doesn't fit any previously mentioned case. This is covered by new code

I decided to put code out of `confirms` method as we have some duplicate methods in other packages and `confirms` used across different places without need to return -1 in confirmations number

Fixes #1086