### PR TITLE
multi: add txscript.InputDetail

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -123,12 +123,12 @@ func (w *Wallet) NewUnsignedTransaction(outputs []*wire.TxOut, relayFeePerKb dcr
 		case OutputSelectionAlgorithmAll:
 			// Wrap the source with one that always fetches the max amount
 			// available and ignores insufficient balance issues.
-			inputSource = func(dcrutil.Amount) (dcrutil.Amount, []*wire.TxIn, [][]byte, error) {
-				total, inputs, prevScripts, err := sourceImpl.SelectInputs(dcrutil.MaxAmount)
+			inputSource = func(dcrutil.Amount) (*txauthor.InputDetail, error) {
+				inputDetail, err := sourceImpl.SelectInputs(dcrutil.MaxAmount)
 				if errors.Is(errors.InsufficientBalance, err) {
 					err = nil
 				}
-				return total, inputs, prevScripts, err
+				return inputDetail, err
 			}
 		default:
 			return errors.E(errors.Invalid,

--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -15,9 +15,11 @@ type ScriptSizer interface {
 	ScriptSize() int
 }
 
-type sigScriptSize int
+// SigScriptSize represents an input sig script size.
+type SigScriptSize int
 
-func (s sigScriptSize) ScriptSize() int { return int(s) }
+// ScriptSize returns the input sig script size.
+func (s SigScriptSize) ScriptSize() int { return int(s) }
 
 // TODO: add multi sig sizer type
 
@@ -81,8 +83,8 @@ const (
 	P2PKHOutputSize = 8 + 2 + 1 + 25
 
 	// signature script definitions
-	P2SHScriptSize  = sigScriptSize(RedeemP2SHSigScriptSize)
-	P2PKHScriptSize = sigScriptSize(RedeemP2PKHSigScriptSize)
+	P2SHScriptSize  = SigScriptSize(RedeemP2SHSigScriptSize)
+	P2PKHScriptSize = SigScriptSize(RedeemP2PKHSigScriptSize)
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a


### PR DESCRIPTION
`txscript.InputDetail` was introduced to bundle what `txscript.InputSource`
returned and also return a slice of input script sizes to improve fee
estimation.

This resolves #1161