### PR TITLE
udb: Upgrade coin types.

### DIFF
--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -15,7 +15,6 @@ import (
 	"github.com/decred/dcrd/chaincfg/chainec"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/decred/dcrd/hdkeychain"
-	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/internal/zero"
 	"github.com/decred/dcrwallet/wallet/internal/snacl"
@@ -2200,19 +2199,9 @@ func loadManager(ns walletdb.ReadBucket, pubPassphrase []byte, chainParams *chai
 }
 
 // CoinTypes returns the legacy and SLIP0044 coin types for the chain
-// parameters.  At the moment, the parameters have not been upgraded for the new
-// coin types.
+// parameters.
 func CoinTypes(params *chaincfg.Params) (legacyCoinType, slip0044CoinType uint32) {
-	// This will need to be rewritten after the chaincfg parameters are updated
-	// for the SLIP0044 coin types.  A test function, TestCoinTypes, exists to
-	// check that the output of this function remains correct after the
-	// parameters are eventually changed.
-	switch params.Net {
-	case wire.MainNet:
-		return params.HDCoinType, 42
-	default:
-		return params.HDCoinType, 1
-	}
+	return params.LegacyCoinType, params.SLIP0044CoinType
 }
 
 // createAddressManager creates a new address manager in the given namespace.


### PR DESCRIPTION
Implement CoinTypes() with params.LegacyCoinType and
params.SLIP0044CoinType instead of old params.HDCoinType.

The PR has requires decred/dcrd#1293 to be merged first.
After the dcrd PR has been merged I will fix the dependencies here.