### PR TITLE
wallet: fix findEligibleOutputsAmount.

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1287,14 +1287,11 @@ func (w *Wallet) FindEligibleOutputs(account uint32, minconf int32, currentHeigh
 
 // findEligibleOutputsAmount uses wtxmgr to find a number of unspent outputs
 // while doing maturity checks there.
-//
-// TODO: This is wrong as it clips the result set returned from the DB without
-// including more outputs to reach the target amount.  Remove.
 func (w *Wallet) findEligibleOutputsAmount(dbtx walletdb.ReadTx, account uint32, minconf int32,
 	amount dcrutil.Amount, currentHeight int32) ([]udb.Credit, error) {
-
 	addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
 	txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+	var outTotal dcrutil.Amount
 
 	unspent, err := w.TxStore.UnspentOutputsForAmount(txmgrNs, addrmgrNs,
 		amount, currentHeight, minconf, false, account)
@@ -1335,6 +1332,11 @@ func (w *Wallet) findEligibleOutputsAmount(dbtx walletdb.ReadTx, account uint32,
 		}
 
 		eligible = append(eligible, *output)
+		outTotal += output.Amount
+	}
+
+	if outTotal < amount {
+		return nil, nil
 	}
 
 	return eligible, nil


### PR DESCRIPTION
This adds a value check after output filtering checks to assert the returned outputs set  is at least equal to the desired amount.