### PR TITLE
Remove embedded Address from cfgutil.AddressFlag

### DIFF
--- a/internal/cfgutil/address.go
+++ b/internal/cfgutil/address.go
@@ -7,10 +7,10 @@ package cfgutil
 
 import "github.com/decred/dcrd/dcrutil"
 
-// AddressFlag embeds a dcrutil.Address and implements the flags.Marshaler and
+// AddressFlag contains a dcrutil.Address and implements the flags.Marshaler and
 // Unmarshaler interfaces so it can be used as a config struct field.
 type AddressFlag struct {
-	dcrutil.Address
+	Address dcrutil.Address
 }
 
 // NewAddressFlag creates an AddressFlag with a default dcrutil.Address.

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -53,7 +53,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 	stakeOptions := &loader.StakeOptions{
 		VotingEnabled: cfg.EnableVoting,
 		AddressReuse:  cfg.ReuseAddresses,
-		VotingAddress: cfg.TBOpts.VotingAddress,
+		VotingAddress: cfg.TBOpts.VotingAddress.Address,
 		TicketFee:     cfg.TicketFee.ToCoin(),
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,


### PR DESCRIPTION
Replace the embedded address with field named Address.  This prevents
AddressFlag from implementing, and accidentally being used as, a
dcrutil.Address interface.