### PR TITLE
Add unspent and unspentexpired fields to getstakeinfo

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1358,19 +1358,23 @@ func getStakeInfo(s *Server, icmd interface{}) (interface{}, error) {
 	}
 
 	resp := &dcrjson.GetStakeInfoResult{
-		BlockHeight:      stakeInfo.BlockHeight,
+		BlockHeight:  stakeInfo.BlockHeight,
+		Difficulty:   sdiff.NextStakeDifficulty,
+		TotalSubsidy: stakeInfo.TotalSubsidy.ToCoin(),
+
+		OwnMempoolTix:  stakeInfo.OwnMempoolTix,
+		Immature:       stakeInfo.Immature,
+		Unspent:        stakeInfo.Unspent,
+		Voted:          stakeInfo.Voted,
+		Revoked:        stakeInfo.Revoked,
+		UnspentExpired: stakeInfo.UnspentExpired,
+
 		PoolSize:         stakeInfo.PoolSize,
-		Difficulty:       sdiff.NextStakeDifficulty,
 		AllMempoolTix:    stakeInfo.AllMempoolTix,
-		OwnMempoolTix:    stakeInfo.OwnMempoolTix,
-		Immature:         stakeInfo.Immature,
 		Live:             stakeInfo.Live,
 		ProportionLive:   proportionLive,
-		Voted:            stakeInfo.Voted,
-		TotalSubsidy:     stakeInfo.TotalSubsidy.ToCoin(),
 		Missed:           stakeInfo.Missed,
 		ProportionMissed: proportionMissed,
-		Revoked:          stakeInfo.Revoked,
 		Expired:          stakeInfo.Expired,
 	}
 


### PR DESCRIPTION
These fields are able to be set by SPV wallets while other fields such
as missed and expired can not be.  They are being added to provide a
fuller picture of ticket state counts for SPV wallets, but should be
implemented by other syncing modes as well.