### PR TITLE
wallet: remove ScriptSizer interface.

### DIFF
--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -10,19 +10,6 @@ import (
 	h "github.com/decred/dcrwallet/internal/helpers"
 )
 
-// ScriptSizer signature script sizing interface
-type ScriptSizer interface {
-	ScriptSize() int
-}
-
-// SigScriptSize represents an input sig script size.
-type SigScriptSize int
-
-// ScriptSize returns the input sig script size.
-func (s SigScriptSize) ScriptSize() int { return int(s) }
-
-// TODO: add multi sig sizer type
-
 // Worst case script and input/output size estimates.
 const (
 	// RedeemP2PKHSigScriptSize is the worst case (largest) serialize size
@@ -81,10 +68,6 @@ const (
 	//   - 1 byte compact int encoding value 25
 	//   - 25 bytes P2PKH output script
 	P2PKHOutputSize = 8 + 2 + 1 + 25
-
-	// signature script definitions
-	P2SHScriptSize  = SigScriptSize(RedeemP2SHSigScriptSize)
-	P2PKHScriptSize = SigScriptSize(RedeemP2PKHSigScriptSize)
 )
 
 // EstimateSerializeSize returns a worst case serialize size estimate for a
@@ -92,14 +75,14 @@ const (
 // transaction output from txOuts. The estimated size is incremented for an
 // additional change output if changeScriptSize is greater than 0. Passing 0
 // does not add a change output.
-func EstimateSerializeSize(scriptSizers []ScriptSizer, txOuts []*wire.TxOut, changeScriptSize int) int {
+func EstimateSerializeSize(scriptSizes []int, txOuts []*wire.TxOut, changeScriptSize int) int {
 	// generate the estimated sizes of the inputs
 	txInsSize := 0
-	for _, sizer := range scriptSizers {
-		txInsSize += EstimateInputSize(sizer.ScriptSize())
+	for _, size := range scriptSizes {
+		txInsSize += EstimateInputSize(size)
 	}
 
-	inputCount := len(scriptSizers)
+	inputCount := len(scriptSizes)
 	outputCount := len(txOuts)
 	changeSize := 0
 	if changeScriptSize > 0 {

--- a/wallet/internal/txsizes/size_test.go
+++ b/wallet/internal/txsizes/size_test.go
@@ -12,12 +12,12 @@ const (
 	p2shScriptSize  = 23
 )
 
-func makeScriptSizers(count int, sizer ScriptSizer) *[]ScriptSizer {
-	scriptSizers := make([]ScriptSizer, count)
+func makeScriptSizes(count int, size int) *[]int {
+	scriptSizes := make([]int, count)
 	for idx := 0; idx < count; idx++ {
-		scriptSizers[idx] = sizer
+		scriptSizes[idx] = size
 	}
-	return &scriptSizers
+	return &scriptSizes
 }
 
 func makeInts(value int, n int) []int {
@@ -30,39 +30,39 @@ func makeInts(value int, n int) []int {
 
 func TestEstimateSerializeSize(t *testing.T) {
 	tests := []struct {
-		InputScriptSizers    []ScriptSizer
+		InputScriptSizes     []int
 		OutputScriptLengths  []int
 		ChangeScriptSize     int
 		ExpectedSizeEstimate int
 	}{
-		0: {[]ScriptSizer{P2PKHScriptSize}, []int{}, 0, 181},
-		1: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, 0, 217},
-		2: {[]ScriptSizer{P2PKHScriptSize}, []int{}, p2pkhScriptSize, 217},
-		3: {[]ScriptSizer{P2PKHScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 253},
-		4: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, 0, 215},
-		5: {[]ScriptSizer{P2PKHScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 251},
+		0: {[]int{RedeemP2PKHSigScriptSize}, []int{}, 0, 181},
+		1: {[]int{RedeemP2PKHSigScriptSize}, []int{p2pkhScriptSize}, 0, 217},
+		2: {[]int{RedeemP2PKHSigScriptSize}, []int{}, p2pkhScriptSize, 217},
+		3: {[]int{RedeemP2PKHSigScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 253},
+		4: {[]int{RedeemP2PKHSigScriptSize}, []int{p2shScriptSize}, 0, 215},
+		5: {[]int{RedeemP2PKHSigScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 251},
 
-		6:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, 0, 347},
-		7:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, 0, 383},
-		8:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{}, p2pkhScriptSize, 383},
-		9:  {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 419},
-		10: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, 0, 381},
-		11: {[]ScriptSizer{P2PKHScriptSize, P2PKHScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 417},
+		6:  {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{}, 0, 347},
+		7:  {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{p2pkhScriptSize}, 0, 383},
+		8:  {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{}, p2pkhScriptSize, 383},
+		9:  {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{p2pkhScriptSize}, p2pkhScriptSize, 419},
+		10: {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{p2shScriptSize}, 0, 381},
+		11: {[]int{RedeemP2PKHSigScriptSize, RedeemP2PKHSigScriptSize}, []int{p2shScriptSize}, p2pkhScriptSize, 417},
 
 		// 0xfd is discriminant for 16-bit compact ints, compact int
 		// total size increases from 1 byte to 3.
-		12: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), 0, 9253},
-		13: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfd), 0, 9253 + P2PKHOutputSize + 2},
-		14: {[]ScriptSizer{P2PKHScriptSize}, makeInts(p2pkhScriptSize, 0xfc), p2pkhScriptSize, 9253 + P2PKHOutputSize + 2},
-		15: {*makeScriptSizers(0xfc, P2PKHScriptSize), []int{}, 0, 41847},
-		16: {*makeScriptSizers(0xfd, P2PKHScriptSize), []int{}, 0, 41847 + RedeemP2PKHInputSize + 4}, // 4 not 2, varint encoded twice.
+		12: {[]int{RedeemP2PKHSigScriptSize}, makeInts(p2pkhScriptSize, 0xfc), 0, 9253},
+		13: {[]int{RedeemP2PKHSigScriptSize}, makeInts(p2pkhScriptSize, 0xfd), 0, 9253 + P2PKHOutputSize + 2},
+		14: {[]int{RedeemP2PKHSigScriptSize}, makeInts(p2pkhScriptSize, 0xfc), p2pkhScriptSize, 9253 + P2PKHOutputSize + 2},
+		15: {*makeScriptSizes(0xfc, RedeemP2PKHSigScriptSize), []int{}, 0, 41847},
+		16: {*makeScriptSizes(0xfd, RedeemP2PKHSigScriptSize), []int{}, 0, 41847 + RedeemP2PKHInputSize + 4}, // 4 not 2, varint encoded twice.
 	}
 	for i, test := range tests {
 		outputs := make([]*wire.TxOut, 0, len(test.OutputScriptLengths))
 		for _, l := range test.OutputScriptLengths {
 			outputs = append(outputs, &wire.TxOut{PkScript: make([]byte, l)})
 		}
-		actualEstimate := EstimateSerializeSize(test.InputScriptSizers, outputs, test.ChangeScriptSize)
+		actualEstimate := EstimateSerializeSize(test.InputScriptSizes, outputs, test.ChangeScriptSize)
 		if actualEstimate != test.ExpectedSizeEstimate {
 			t.Errorf("Test %d: Got %v: Expected %v", i, actualEstimate, test.ExpectedSizeEstimate)
 		}

--- a/wallet/multisig.go
+++ b/wallet/multisig.go
@@ -197,15 +197,15 @@ func (w *Wallet) FetchAllRedeemScripts() ([][]byte, error) {
 func (w *Wallet) PrepareRedeemMultiSigOutTxOutput(msgTx *wire.MsgTx, p2shOutput *P2SHMultiSigOutput, pkScript *[]byte) error {
 	const op errors.Op = "wallet.PrepareRedeemMultiSigOutTxOutput"
 
-	scriptSizers := []txsizes.ScriptSizer{}
-	// generate the script sizers for the inputs
+	scriptSizes := []int{}
+	// generate the script sizes for the inputs
 	for range msgTx.TxIn {
-		scriptSizers = append(scriptSizers, txsizes.P2SHScriptSize)
+		scriptSizes = append(scriptSizes, txsizes.RedeemP2SHSigScriptSize)
 	}
 
 	// estimate the output fee
 	txOut := wire.NewTxOut(0, *pkScript)
-	feeSize := txsizes.EstimateSerializeSize(scriptSizers, []*wire.TxOut{txOut}, 0)
+	feeSize := txsizes.EstimateSerializeSize(scriptSizes, []*wire.TxOut{txOut}, 0)
 	feeEst := txrules.FeeForSerializeSize(w.RelayFee(), feeSize)
 	if feeEst >= p2shOutput.OutputAmount {
 		return errors.E(op, errors.Errorf("estimated fee %v is above output value %v",

--- a/wallet/txauthor/author_test.go
+++ b/wallet/txauthor/author_test.go
@@ -50,7 +50,7 @@ func makeInputSource(unspents []*wire.TxOut) InputSource {
 			nextInput := wire.NewTxIn(&wire.OutPoint{}, u.Value, nil)
 			currentTotal += dcrutil.Amount(u.Value)
 			currentInputs = append(currentInputs, nextInput)
-			redeemScriptSizes = append(redeemScriptSizes, txsizes.P2PKHScriptSize.ScriptSize())
+			redeemScriptSizes = append(redeemScriptSizes, txsizes.RedeemP2PKHSigScriptSize)
 		}
 
 		inputDetail := txauthor.InputDetail{
@@ -84,7 +84,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6),
 			RelayFee:       1e3,
 			ChangeAmount: 1e8 - 1e6 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		2: {
@@ -92,7 +92,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6),
 			RelayFee:       1e4,
 			ChangeAmount: 1e8 - 1e6 - txrules.FeeForSerializeSize(1e4,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		3: {
@@ -100,7 +100,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6, 1e6, 1e6),
 			RelayFee:       1e4,
 			ChangeAmount: 1e8 - 3e6 - txrules.FeeForSerializeSize(1e4,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 		4: {
@@ -108,7 +108,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e6, 1e6, 1e6),
 			RelayFee:       2.55e3,
 			ChangeAmount: 1e8 - 3e6 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(1e6, 1e6, 1e6), txsizes.P2PKHPkScriptSize)),
 			InputCount: 1,
 		},
 
@@ -116,7 +116,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		5: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 602 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -124,7 +124,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		6: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 603 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 603,
 			InputCount:   1,
@@ -134,7 +134,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		7: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 1537 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     2.55e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -142,7 +142,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		8: {
 			UnspentOutputs: p2pkhOutputs(1e8),
 			Outputs: p2pkhOutputs(1e8 - 1538 - txrules.FeeForSerializeSize(2.55e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     2.55e3,
 			ChangeAmount: 1538,
 			InputCount:   1,
@@ -154,7 +154,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		9: {
 			UnspentOutputs: p2pkhOutputs(1e8, 1e8),
 			Outputs: p2pkhOutputs(1e8 - 603 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 603,
 			InputCount:   1,
@@ -168,7 +168,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 		10: {
 			UnspentOutputs: p2pkhOutputs(1e8, 1e8),
 			Outputs: p2pkhOutputs(1e8 - 545 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(0), txsizes.P2PKHPkScriptSize))),
 			RelayFee:     1e3,
 			ChangeAmount: 0,
 			InputCount:   1,
@@ -180,7 +180,7 @@ func TestNewUnsignedTransaction(t *testing.T) {
 			Outputs:        p2pkhOutputs(1e8),
 			RelayFee:       1e3,
 			ChangeAmount: 1e8 - txrules.FeeForSerializeSize(1e3,
-				txsizes.EstimateSerializeSize([]txsizes.ScriptSizer{txsizes.P2PKHScriptSize, txsizes.P2PKHScriptSize}, p2pkhOutputs(1e8), txsizes.P2PKHPkScriptSize)),
+				txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHSigScriptSize, txsizes.RedeemP2PKHSigScriptSize}, p2pkhOutputs(1e8), txsizes.P2PKHPkScriptSize)),
 			InputCount: 2,
 		},
 


### PR DESCRIPTION
The interface can be succintly represented as an int. This chance also circumvents exporting txsizes to get access to the interface for utilities like sweepaccount.