### PR TITLE
Temporarily disable gofmt on CI

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,7 +3,7 @@ set -ex
 
 # The script does automatic checking on a Go package and its sub-packages,
 # including:
-# 1. gofmt         (http://golang.org/cmd/gofmt/)
+# 1. gofmt         (http://golang.org/cmd/gofmt/) (Temporarily disabled)
 # 2. golint        (https://github.com/golang/lint)
 # 3. go vet        (http://golang.org/cmd/vet)
 # 4. gosimple      (https://github.com/dominikh/go-simple)
@@ -36,7 +36,7 @@ testrepo () {
 
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m -s testdata \
-    --enable=gofmt \
+    \ #--enable=gofmt \
     --enable=vet \
     --enable=gosimple \
     --enable=unconvert \


### PR DESCRIPTION
The formatting rules have changed for Go 1.11, and with the release so
close several developers are already testing the betas.  To prevent
gofmt formatting from being a blocking issue when submitting pull
requests, gofmt checks on Travis-CI are being temporarily disabled.

Gofmt checks will be reenabled and using Go 1.11 formatting rules when
Go 1.11 is released.