### PR TITLE
Prevent RPC sync loop on duplicate transactions.

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -417,7 +417,10 @@ func (s *RPCSyncer) startupSync(ctx context.Context) error {
 	// Rebroadcast unmined transactions
 	err = s.wallet.PublishUnminedTransactions(ctx, n)
 	if err != nil {
-		return err
+		// Returning this error would end and (likely) restart sync in
+		// an endless loop.  It's possible a transaction should be
+		// removed, but this is difficult to reliably detect over RPC.
+		log.Warnf("Could not publish one or more unmined transactions: %v", err)
 	}
 
 	_, err = s.rpcClient.RawRequest("rebroadcastwinners", nil)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3980,12 +3980,10 @@ func (w *Wallet) PublishUnminedTransactions(ctx context.Context, p Peer) error {
 	const op errors.Op = "wallet.PublishUnminedTransactions"
 	unminedTxs, err := w.UnminedTransactions()
 	if err != nil {
-		log.Errorf("Cannot load unmined transactions for resending: %v", err)
 		return errors.E(op, err)
 	}
 	err = p.PublishTransactions(ctx, unminedTxs...)
 	if err != nil {
-		log.Warnf("Could not resend one or more unmined transactions: %v", err)
 		return errors.E(op, err)
 	}
 	return nil


### PR DESCRIPTION
The dcrd RPC sendrawtransaction errors if an identical transaction
already exists in mempool.  Therefore, do not end RPC sync if an error
occurs during the publishing of unmined transactions.