### PR TITLE
Revert RPC address discovery to prior algorithm

### DIFF
--- a/chain/backendwrapper.go
+++ b/chain/backendwrapper.go
@@ -184,6 +184,10 @@ func (b *rpcBackend) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error
 	return amount, nil
 }
 
+func (b *rpcBackend) RPCClient() *rpcclient.Client {
+	return b.rpcClient
+}
+
 // hexReader implements io.Reader to read bytes from a hexadecimal string.
 // TODO: Replace with hex.NewDecoder (available since Go 1.10)
 type hexReader struct {


### PR DESCRIPTION
When address/account discovery is performed in the RPC sync mode, it must
support features used by voting wallets, such as discovering usage of addresses
as voting addresses in ticket purchases.  These output scripts are not included
in the committed filters by design (to make SPV voting impossible), but without
them it is not possible to correctly restore a voting wallet.

Due to this limitation of using committed filters for address discovery, the
prior algorithm which depends on the dcrd address exists index is being
reintroduced and is used when the Peer implementation is the RPC network
backend.

Fixes #1224 