### PR TITLE
Buy max tickets mineable per block.

### DIFF
--- a/ticketbuyer/v2/tb.go
+++ b/ticketbuyer/v2/tb.go
@@ -185,7 +185,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *chainhash.Hash) e
 		log.Debugf("Skipping purchase: low available balance")
 		return nil
 	}
-	if max := int(w.ChainParams().TicketsPerBlock); buy > max {
+	if max := int(w.ChainParams().MaxFreshStakePerBlock); buy > max {
 		buy = max
 	}
 


### PR DESCRIPTION
The previous logic limited the total number of buyable tickets per block to the
number of picked tickets per block.  This is not the desired behavior, and the
buyer should buy as many tickets as can be mined in the next block but no more.

Noticed by @alexlyp who had to switch back to the v1 buyer temporarily on
testnet3 as the v2 buyer was not buying enough tickets to support the target
ticket pool.