### PR TITLE
Do not test Gopkg.lock is tidy.

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -27,12 +27,7 @@ DOCKER_IMAGE_TAG=decred-golang-builder-$GOVERSION
 testrepo () {
   TMPFILE=$(mktemp)
 
-  # Check lockfile
-  cp Gopkg.lock $TMPFILE && dep ensure && diff Gopkg.lock $TMPFILE >/dev/null
-  if [ $? != 0 ]; then
-    echo 'lockfile must be updated with dep ensure'
-    exit 1
-  fi
+  dep ensure
 
   # Check linters
   gometalinter --vendor --disable-all --deadline=10m -s testdata \


### PR DESCRIPTION
The CI runners currently use a newer version of dep that produces different
output for the lockfile when running dep ensure.  Remove this test since it
doesn't check anything particularly useful and because a switch to module builds
is planned for the 1.4 development cycle.