### PR TITLE
Update README for Go 1.11 and module builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,86 +68,51 @@ Wallet clients interact with the wallet using one of two RPC servers:
 
 ## Installation and updating
 
-### Windows - MSIs Available
+### Binaries (Windows/Linux/macOS)
 
-Install the latest MSIs available here:
+Binary releases are provided for common operating systems and architectures:
 
-https://github.com/decred/decred-release/releases
+https://github.com/decred/decred-binaries/releases
 
-### Windows/Linux/BSD/POSIX - Build from source
+### Build from source (all platforms)
 
 Building or updating from source requires the following build dependencies:
 
-- **Go 1.9 or 1.10**
+- **Go 1.10 or 1.11**
 
-  Installation instructions can be found here: http://golang.org/doc/install.
+  Installation instructions can be found here: https://golang.org/doc/install.
   It is recommended to add `$GOPATH/bin` to your `PATH` at this point.
 
-- **Dep**
+- **Vgo (Go 1.10 only)**
 
-  Dep is used to manage project dependencies and provide reproducible builds.
-  It is recommended to use the latest Dep release, unless a bug prevents doing
-  so.  The latest releases (for both binary and source) can be found
-  [here](https://github.com/golang/dep/releases).
+  The `GO111MODULE` experiment is used to manage project dependencies and
+  provide reproducible builds.  The module experiment is provided by the Go 1.11
+  toolchain, but the Go 1.10 toolchain does not provide any module support.  To
+  perform module-aware builds with Go 1.10,
+  [vgo](https://godoc.org/golang.org/x/vgo) (a drop-in replacement for the go
+  command) must be used instead.
 
-Unfortunately, the use of `dep` prevents a handy tool such as `go get` from
-automatically downloading, building, and installing the source in a single
-command.  Instead, the latest project and dependency sources must be first
-obtained manually with `git` and `dep`, and then `go` is used to build and
-install the project.
+To build and install from a checked-out repo, run `go install` in the repo's
+root directory.  Some notes:
 
-**Getting the source**:
+* Set the `GO111MODULE=on` environment variable if using Go 1.11 and building
+  from within `GOPATH`.
 
-For a first time installation, the project and dependency sources can be
-obtained manually with `git` and `dep` (create directories as needed):
+* Replace `go` with `vgo` when using Go 1.10.
 
-```
-git clone https://github.com/decred/dcrwallet $GOPATH/src/github.com/decred/dcrwallet
-cd $GOPATH/src/github.com/decred/dcrwallet
-dep ensure
-```
-
-To update an existing source tree, pull the latest changes and install the
-matching dependencies:
-
-```
-cd $GOPATH/src/github.com/decred/dcrwallet
-git pull
-dep ensure
-```
-
-**Building/Installing**:
-
-The `go` tool is used to build or install (to `GOPATH`) the project.  Some
-example build instructions are provided below (all must run from the `dcrwallet`
-project directory).
-
-To build and install `dcrwallet` and all helper commands (in the `cmd`
-directory) to `$GOPATH/bin/`, as well as installing all compiled packages to
-`$GOPATH/pkg/` (**use this if you are unsure which command to run**):
-
-```
-go install . ./cmd/...
-```
-
-To build a `dcrwallet` executable and install it to `$GOPATH/bin/`:
-
-```
-go install
-```
-
-To build a `dcrwallet` executable and place it in the current directory:
-
-```
-go build
-```
+* The `dcrwallet` executable will be installed to `$GOPATH/bin`.  `GOPATH`
+  defaults to `$HOME/go` (or `%USERPROFILE%\go` on Windows) if unset.
 
 ## Docker
 
-All tests and linters may be run in a docker container using the script `run_tests.sh`.  This script defaults to using the current supported version of go.  You can run it with the major version of go you would like to use as the only arguement to test a previous on a previous version of go (generally decred supports the current version of go and the previous one).
+All tests and linters may be run in a docker container using the script
+`run_tests.sh`.  This script defaults to using the current supported version of
+go.  You can run it with the major version of go you would like to use as the
+only arguement to test a previous on a previous version of go (generally decred
+supports the current version of go and the previous one).
 
 ```
-./run_tests.sh 1.9
+./run_tests.sh 1.10
 ```
 
 To run the tests locally without docker:
@@ -183,14 +148,6 @@ dcrwallet -u rpcuser -P rpcpass
 If everything appears to be working, it is recommended at this point to
 copy the sample dcrd and dcrwallet configurations and update with your
 RPC username and password.
-
-PowerShell (Installed from MSI):
-```
-PS> cp "$env:ProgramFiles\Decred\Dcrd\sample-dcrd.conf" $env:LOCALAPPDATA\Dcrd\dcrd.conf
-PS> cp "$env:ProgramFiles\Decred\Dcrwallet\sample-dcrwallet.conf" $env:LOCALAPPDATA\Dcrwallet\dcrwallet.conf
-PS> $editor $env:LOCALAPPDATA\Dcrd\dcrd.conf
-PS> $editor $env:LOCALAPPDATA\Dcrwallet\dcrwallet.conf
-```
 
 PowerShell (Installed from source):
 ```


### PR DESCRIPTION
The building from source section has been simplified for the instructions to
perform a module-aware build.

For the dcrwallet 1.4 development cycle, Go 1.9 is no longer supported, and
module builds must be performed with Go 1.10 or Go 1.11 instead.

While here, remove all references to Windows MSIs, as none are provided.