### PR TITLE
[grpc] return pk instead of pkh in validateAddress

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -61,10 +61,10 @@ import (
 
 // Public API version constants
 const (
-	semverString = "5.1.0"
+	semverString = "5.1.1"
 	semverMajor  = 5
 	semverMinor  = 1
-	semverPatch  = 0
+	semverPatch  = 1
 )
 
 // translateError creates a new gRPC error with an appropiate error code for
@@ -1696,7 +1696,7 @@ func (s *walletServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddr
 		if err != nil {
 			return nil, err
 		}
-		result.PubKeyAddr = pubKeyAddr.EncodeAddress()
+		result.PubKeyAddr = pubKeyAddr.String()
 
 	case udb.ManagedScriptAddress:
 		result.IsScript = true


### PR DESCRIPTION
Fix #1254 

The grpc endpoint ValidateAddress was previously returning the original public key hash address of the requested address instead of the correct public key address. This fixes the problem and bumps the patch level of the api.