### PR TITLE
Improve various aspects of run_tests.sh.

### DIFF
--- a/testmodules.sh
+++ b/testmodules.sh
@@ -14,7 +14,6 @@ MODPATHS=". $MODPATHS"
 
 tests () {
     $GO test $GOTESTFLAGS ./...
-    $GO mod verify >/dev/null
 }
 
 for m in $MODPATHS; do


### PR DESCRIPTION
Source files are no longer built inside the container user's GOPATH,
but instead a module build is performed from /src.

The :Z attribute has been added to the -v mount option.  This applies
the correct SELinux settings so the container is able to access the
files inside /src.  Tested on Fedora 28 using the default SELinux
policies.  See [1] for further details about this attribute.

Support for podman (a drop-in replacement for docker) is also added.
To use, call the script as './run_tests.sh podman'.

While here, also remove 'go mod verify' from the test script.  Module
verification is implicitly done for any build/test operation, so this
is unnecessary and running it again marginally slows down CI testing.

[1] https://www.projectatomic.io/blog/2015/06/using-volumes-with-docker-can-cause-problems-with-selinux/