### PR TITLE
Introduce Go 1.10 stdlib features.

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -7,6 +7,8 @@ package chain
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
+	"strings"
 	"sync"
 
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -301,7 +303,7 @@ func (s *RPCSyncer) startupSync(ctx context.Context) error {
 		headers := make([]*wire.BlockHeader, 0, len(headersMsg.Headers))
 		for _, h := range headersMsg.Headers {
 			header := new(wire.BlockHeader)
-			err := header.Deserialize(newHexReader(h))
+			err := header.Deserialize(hex.NewDecoder(strings.NewReader(h)))
 			if err != nil {
 				const op errors.Op = "dcrd.jsonrpc.getheaders"
 				return errors.E(op, err)

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -12,10 +12,10 @@ package.
 package errors
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"runtime/debug"
+	"strings"
 )
 
 // Separator is inserted between nested errors when formatting as strings.  The
@@ -217,8 +217,7 @@ func WithStack(args ...interface{}) error {
 }
 
 func (e *Error) Error() string {
-	// TODO: Switch to strings.Builder (introduced in Go 1.10)
-	var b bytes.Buffer
+	var b strings.Builder
 
 	// Record the last added fields to the string to avoid duplication.
 	var last Error


### PR DESCRIPTION
This change begins to use standard libary features introduced in Go
1.10, such as calls to hex.New{Encoder,Decoder} as well as use of
strings.Builder.  A custom type used to implement io.Reader for hex
strings is removed as it is no longer necessary given these standard
library APIs.