### PR TITLE
Declare a walletrpc module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/decred/dcrwallet/internal/helpers v1.0.0
 	github.com/decred/dcrwallet/internal/zero v1.0.0
 	github.com/decred/dcrwallet/p2p v1.0.0
+	github.com/decred/dcrwallet/rpc/walletrpc v0.1.0
 	github.com/decred/dcrwallet/spv v1.0.0
 	github.com/decred/dcrwallet/ticketbuyer v1.0.0
 	github.com/decred/dcrwallet/ticketbuyer/v2 v2.0.0
@@ -30,14 +31,10 @@ require (
 	github.com/decred/dcrwallet/wallet v1.0.0
 	github.com/decred/dcrwallet/walletseed v1.0.0
 	github.com/decred/slog v1.0.0
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
-	github.com/golang/protobuf v1.1.0
 	github.com/gorilla/websocket v1.2.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 	golang.org/x/crypto v0.0.0-20180808211826-de0752318171
-	golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24
-	google.golang.org/genproto v0.0.0-20180808183934-383e8b2c3b9e // indirect
 	google.golang.org/grpc v1.14.0
 )
 
@@ -50,6 +47,7 @@ replace (
 	github.com/decred/dcrwallet/lru => ./lru
 	github.com/decred/dcrwallet/p2p => ./p2p
 	github.com/decred/dcrwallet/pgpwordlist => ./pgpwordlist
+	github.com/decred/dcrwallet/rpc/walletrpc => ./rpc/walletrpc
 	github.com/decred/dcrwallet/spv => ./spv
 	github.com/decred/dcrwallet/ticketbuyer => ./ticketbuyer
 	github.com/decred/dcrwallet/ticketbuyer/v2 => ./ticketbuyer/v2

--- a/rpc/walletrpc/go.mod
+++ b/rpc/walletrpc/go.mod
@@ -1,0 +1,12 @@
+module github.com/decred/dcrwallet/rpc/walletrpc
+
+require (
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
+	github.com/golang/protobuf v1.1.0
+	golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
+	golang.org/x/sys v0.0.0-20180810070207-f0d5e33068cb // indirect
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20180808183934-383e8b2c3b9e // indirect
+	google.golang.org/grpc v1.14.0
+)

--- a/rpc/walletrpc/go.sum
+++ b/rpc/walletrpc/go.sum
@@ -1,0 +1,16 @@
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
+github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24 h1:mEsFm194MmS9vCwxFy+zwu0EU7ZkxxMD1iH++vmGdUY=
+golang.org/x/net v0.0.0-20180808004115-f9ce57c11b24/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=
+golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20180810070207-f0d5e33068cb h1:8RtOlGoYzeQE/7H55BC4Ct/2wxzIXu6esHJefkHwc48=
+golang.org/x/sys v0.0.0-20180810070207-f0d5e33068cb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+google.golang.org/genproto v0.0.0-20180808183934-383e8b2c3b9e h1:8mImbC+7codRhTIUj7Js3/j98gpxyF7C4RlC0OdGh64=
+google.golang.org/genproto v0.0.0-20180808183934-383e8b2c3b9e/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
+google.golang.org/grpc v1.14.0 h1:ArxJuB1NWfPY6r9Gp9gqwplT0Ge7nqv9msgu03lHLmo=
+google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=


### PR DESCRIPTION
The github.com/decred/dcrwallet/rpc/walletrpc package, which contains
the autogenerated gRPC service bindings, is imported by other projects
for service definitions to create wallet RPC clients.  This package
was previously part of the main module, so it was not properly
versioned and separated for use as a library for other projects.

The module is given version 0.1.0 and the current plan is to always
stay at major version 0, while incrementing the minor version for any
modifications.  I am reluctant to give this a major API version (let
alone the same version as the API itself) since the file is
autogenerated.  A switch to major versions is always possible later if
this system does not work out.