### PR TITLE
multi: update fee estimation for tickets.

### DIFF
--- a/wallet/internal/txsizes/size.go
+++ b/wallet/internal/txsizes/size.go
@@ -68,6 +68,25 @@ const (
 	//   - OP_CHECKSIG
 	P2PKHPkScriptSize = 1 + 1 + 1 + 20 + 1 + 1
 
+	// P2SHPkScriptSize is the size of a transaction output script that
+	// pays to a script hash.  It is calculated as:
+	//
+	//   - OP_HASH160
+	//   - OP_DATA_20
+	//   - 20 bytes script hash
+	//   - OP_EQUAL
+	P2SHPkScriptSize = 1 + 1 + 20 + 1
+
+	// TicketCommitmentScriptSize is the size of a ticket purchase commitment
+	// script. It is calculated as:
+	//
+	//   - OP_RETURN
+	//   - OP_DATA_30
+	//   - 20 bytes P2SH/P2PKH
+	//   - 8 byte amount
+	//   - 2 byte fee range limits
+	TicketCommitmentScriptSize = 1 + 1 + 20 + 8 + 2
+
 	// P2PKHOutputSize is the serialize size of a transaction output with a
 	// P2PKH output script.  It is calculated as:
 	//


### PR DESCRIPTION
This uses `EstimateSerializeSizeFromScriptSizes` for ticket fee estimation given its standardized format. Constants `doubleInputTicketSize` and `singleInputTicketSize` are also removed.

Resolves #1272