### PR TITLE
Report RPC connection errors

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -122,7 +122,7 @@ func (c *RPCClient) Start(ctx context.Context, retry bool) (err error) {
 		}
 	}
 	if !semverCompatible(requiredChainServerAPI, serverAPI) {
-		return errors.E(op, errors.Errorf("advertised API version %v incompatible"+
+		return errors.E(op, errors.Errorf("advertised API version %v incompatible "+
 			"with required verison %v", serverAPI, requiredChainServerAPI))
 	}
 

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -443,6 +443,7 @@ func rpcClientConnectLoop(ctx context.Context, passphrase []byte, jsonRPCServer 
 	for {
 		chainClient, err := startChainRPC(ctx, certs)
 		if err != nil {
+			log.Errorf("Error connecting to RPC server: %v", err)
 			return
 		}
 


### PR DESCRIPTION
Latest dcrd master updated the rpc api version but the wallet does not
currently report any connection errors. This was added to mirror the
spv connection error reporting, which is done is spvLoop().