### PR TITLE
ipc: add named pipe read end

### DIFF
--- a/config.go
+++ b/config.go
@@ -156,6 +156,7 @@ type config struct {
 	// IPC options
 	PipeTx            *uint `long:"pipetx" description:"File descriptor or handle of write end pipe to enable child -> parent process communication"`
 	PipeRx            *uint `long:"piperx" description:"File descriptor or handle of read end pipe to enable parent -> child process communication"`
+	NamedPipeRx       string `long:"namedpiperx" description:"Named pipe (in windows) or unix socket of read end pipe to enable wallet -> client process communication"`
 	RPCListenerEvents bool  `long:"rpclistenerevents" description:"Notify JSON-RPC and gRPC listener addresses over the TX pipe"`
 
 	TBOpts ticketBuyerOptions `group:"Ticket Buyer Options" namespace:"ticketbuyer"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -101,6 +101,10 @@ func run(ctx context.Context) error {
 		go drainOutgoingPipeMessages()
 	}
 
+	if cfg.NamedPipeRx != "" {
+		go serviceControlNamedPipeRx(ctx, cfg.NamedPipeRx)
+	}
+
 	// Run the pprof profiler if enabled.
 	if len(cfg.Profile) > 0 {
 		if done(ctx) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/decred/dcrwallet
 
 require (
+	github.com/Microsoft/go-winio v0.4.11
 	github.com/decred/dcrd/addrmgr v1.0.2
 	github.com/decred/dcrd/blockchain v1.0.2
 	github.com/decred/dcrd/blockchain/stake v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885 h1:bBmEG9/q1xH07CqeeFw1ejup6Kw+/88WhhLHqIJ0ngQ=
 github.com/aead/siphash v0.0.0-20170329201724-e404fcfc8885/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=

--- a/ipc_posix.go
+++ b/ipc_posix.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package main
+
+import "net"
+
+func serviceControlOpenNamedPipeRx(fname string) (net.Listener, error) {
+	return net.Listen("unix", fname)
+}

--- a/ipc_windows.go
+++ b/ipc_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package main
+
+import (
+	"net"
+	"strings"
+
+	winio "github.com/Microsoft/go-winio"
+	"github.com/decred/dcrwallet/errors"
+)
+
+func serviceControlOpenNamedPipeRx(fname string) (net.Listener, error) {
+	if strings.Index(fname, `\\.\pipe\`) != 0 {
+		return nil, errors.E("pipe path does not start with correct prefix")
+	}
+	return winio.ListenPipe(fname, nil)
+}


### PR DESCRIPTION
Adds a new `--namedpiperx` config option which triggers the creation of a server (either a pipe or unix socket depending on the platform) that can be used by a controlling parent app to start the shutdown of the app.

This is mainly needed for decrediton running in windows, which is having trouble correctly controlling the wallet with the existing filedescriptor based piperx/tx. 

This can be tested in linux (and possibly mac) by using a local netcat connection to the named unix socket.

In windows the easiest way to test is to use this alongside the decrediton PR which modifies the win32ipc module to use named pipes instead of file descriptors.

This currently only implements the reading part, but if this approach is sound, then I can either modify this PR or send a new PR with the writing part, which should allow us to to drop the ugly hack of reading for log messages to discover the grpc port that is currently implemented in windows.