### PR TITLE
Allow empty string purchaseticket voting addresses

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -941,7 +941,7 @@ func (w *Wallet) purchaseTickets(op errors.Op, req purchaseTicketRequest) ([]*ch
 	switch req.ticketAddr.(type) {
 	case *dcrutil.AddressScriptHash:
 		stakeSubmissionPkScriptSize = txsizes.P2SHPkScriptSize + 1
-	case *dcrutil.AddressPubKeyHash:
+	case *dcrutil.AddressPubKeyHash, nil:
 		stakeSubmissionPkScriptSize = txsizes.P2PKHPkScriptSize + 1
 	default:
 		return nil, errors.E(op, errors.Invalid,


### PR DESCRIPTION
When an empty string is used as the voting address in a purchaseticket
JSON-RPC call, the wallet will generate a P2PKH voting address.  This
behavior broke in 9fe6e6b6, and is fixed here by allowing the nil
address in a request.