### PR TITLE
Close created DB before os.Exit

### DIFF
--- a/walletsetup.go
+++ b/walletsetup.go
@@ -87,8 +87,12 @@ func createWallet(ctx context.Context, cfg *config) error {
 		}
 	}
 
-	fmt.Println("The wallet has been created successfully.")
+	err = loader.UnloadWallet()
+	if err != nil {
+		return err
+	}
 
+	fmt.Println("The wallet has been created successfully.")
 	return nil
 }
 


### PR DESCRIPTION
When creating a new wallet, the database should be cleanly closed
before the process exits.  Otherwise, even though the database might
be consistent, not all intended changes may be written to it.