### PR TITLE
Fix test script to work on Darwin OS 

### DIFF
--- a/testmodules.sh
+++ b/testmodules.sh
@@ -9,7 +9,7 @@ fi
 
 ROOTPATH=$($GO list -m -f {{.Dir}} 2>/dev/null)
 ROOTPATHPATTERN=$(echo $ROOTPATH | sed 's/\\/\\\\/g' | sed 's/\//\\\//g')
-MODPATHS=$($GO list -m -f {{.Dir}} all 2>/dev/null | grep "^$ROOTPATHPATTERN" | sed -e "s/^$ROOTPATHPATTERN//" -e 's/^\\\|\///')
+MODPATHS=$($GO list -m -f {{.Dir}} all 2>/dev/null | grep "^$ROOTPATHPATTERN" | sed -e "s/^$ROOTPATHPATTERN//" -e 's/^\\//' -e 's/^\///')
 MODPATHS=". $MODPATHS"
 
 tests () {


### PR DESCRIPTION
Change script so it works on darwin, currently it fails on MAC OSX : 

`./run_tests.sh
+ [[ ! -n '' ]]
+ GOVERSION=1.11
+ REPO=dcrwallet
+ DOCKER=
+ [[ '' == \d\o\c\k\e\r ]]
+ [[ '' == \p\o\d\m\a\n ]]
+ [[ ! -n '' ]]
+ testrepo
+ go version
go version go1.11 darwin/amd64
+ env GORACE=halt_on_error=1 CC=gcc 'GOTESTFLAGS=-race -short' bash ./testmodules.sh
?   	github.com/decred/dcrwallet	[no test files]
?   	github.com/decred/dcrwallet/cmd/movefunds[no test files]
?   	github.com/decred/dcrwallet/cmd/sweepaccount	[no test files]
?   	github.com/decred/dcrwallet/internal/cfgutil	[no test files]
?   	github.com/decred/dcrwallet/internal/prompt	[no test files]
?   	github.com/decred/dcrwallet/internal/rpchelp	[no test files]
?   	github.com/decred/dcrwallet/loader	[no test files]
?   	github.com/decred/dcrwallet/netparams	[no test files]
?   	github.com/decred/dcrwallet/prompt	[no test files]
ok  	github.com/decred/dcrwallet/rpc/legacyrpc(cached)
?   	github.com/decred/dcrwallet/rpc/rpcserver[no test files]
ok  	github.com/decred/dcrwallet/rpctest	(cached)
?   	github.com/decred/dcrwallet/rpctest/mkharness	[no test files]
./testmodules.sh: line 20: cd: /chain: No such file or directory`