### PR TITLE
[release-v1.3] Return errors for details of unknown transactions.

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -1466,11 +1466,10 @@ func getTransaction(s *Server, icmd interface{}) (interface{}, error) {
 
 	// returns nil details when not found
 	txd, err := wallet.UnstableAPI(w).TxDetails(txHash)
-	if err != nil {
-		return nil, err
-	}
-	if txd == nil {
+	if errors.Is(errors.NotExist, err) {
 		return nil, rpcErrorf(dcrjson.ErrRPCNoTxInfo, "no information for transaction")
+	} else if err != nil {
+		return nil, err
 	}
 
 	_, tipHeight := w.MainChainTip()

--- a/wallet/udb/txquery.go
+++ b/wallet/udb/txquery.go
@@ -170,9 +170,6 @@ func (s *Store) unminedTxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash,
 // TxDetails looks up all recorded details regarding a transaction with some
 // hash.  In case of a hash collision, the most recent transaction with a
 // matching hash is returned.
-//
-// Not finding a transaction with this hash is not an error.  In this case,
-// a nil TxDetails is returned.
 func (s *Store) TxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash) (*TxDetails, error) {
 	// First, check whether there exists an unmined transaction with this
 	// hash.  Use it if found.
@@ -185,8 +182,7 @@ func (s *Store) TxDetails(ns walletdb.ReadBucket, txHash *chainhash.Hash) (*TxDe
 	// hash, skip over to the newest and begin fetching all details.
 	k, v := latestTxRecord(ns, txHash[:])
 	if v == nil {
-		// not found
-		return nil, nil
+		return nil, errors.E(errors.NotExist)
 	}
 	return s.minedTxDetails(ns, txHash, k, v)
 }


### PR DESCRIPTION
When a transaction is not yet known, lookups for details of the tx
must return an appropriate error.  This commit modifies the internal
TxDetails function to return non-nil errors rather than nil details
structs if the transaction is not recorded.

This is not a breaking change to consumers of the wallet module as the
udb package is a candidate for becoming internal and is not possible
to use in other projects as an internal walletdb interface is
necessary to create a udb.Store.

This is a backport of 58cf828.