### PR TITLE
[release-v1.3] multi: Fix GetTickets on non-voted (#1289)

### DIFF
--- a/wallet/udb/txquery.go
+++ b/wallet/udb/txquery.go
@@ -225,7 +225,7 @@ func (s *Store) TicketDetails(ns walletdb.ReadBucket, txDetails *TxDetails) (*Ti
 		}
 	}
 	spenderDetails, err := s.TxDetails(ns, &spenderHash)
-	if err != nil {
+	if (err != nil) && (!errors.Is(errors.NotExist, err)) {
 		return nil, err
 	}
 	ticketDetails.Spender = spenderDetails

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2480,7 +2480,7 @@ func (w *Wallet) GetTicketsPrecise(f func([]*TicketSummary, *wire.BlockHeader) (
 		return w.TxStore.RangeTransactions(txmgrNs, start, end, rangeFn)
 	})
 	if err != nil {
-		errors.E(op, err)
+		return errors.E(op, err)
 	}
 	return nil
 }
@@ -2591,7 +2591,7 @@ func (w *Wallet) GetTickets(f func([]*TicketSummary, *wire.BlockHeader) (bool, e
 		return w.TxStore.RangeTransactions(txmgrNs, start, end, rangeFn)
 	})
 	if err != nil {
-		errors.E(op, err)
+		return errors.E(op, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This fixes two small issues related to the GetTickets grpc call:

- The error was not correctly returned in GetTickets/GetTicketsPrecise,
causing it to not bubble up the stack
- The udb function Store.TxDetails was recently changed to return an
error when a transaction is not found; this kind of error needs to be
ignored in TicketDetails when loading the voting details of a ticket
that hasn't yet voted.

This is a backport of 39d3bc0.