### PR TITLE
Allow process interrupt when blocked on DB lock.

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -299,7 +299,9 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte) (w *wallet.Wallet, rer
 
 	// Open the database using the boltdb backend.
 	dbPath := filepath.Join(l.dbDirPath, walletDbName)
+	l.mu.Unlock()
 	db, err := wallet.OpenDB("bdb", dbPath)
+	l.mu.Lock()
 	if err != nil {
 		log.Errorf("Failed to open database: %v", err)
 		return nil, errors.E(op, err)


### PR DESCRIPTION
This change moves the opening of an existing wallet DB into a
background goroutine so that main can return and the process will exit
if an interrupt signal is sent to a wallet process that is blocked on
a database lock.

To support this change, the loader mutex must be released during the
loader's open database call.

Fixes #1296