### PR TITLE
Do not delete log rotation files

### DIFF
--- a/log.go
+++ b/log.go
@@ -102,7 +102,7 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
The previous behavior was to keep at most three rotated log files to
prevent a filesystem from becoming overfilled with old logs.  However,
in practice, this has cause the loss of important logs which could
have been useful in debugging fatal bugs.  This change causes no log
rotation deletions, instead requiring a user (or program set up by the
user) to delete log files after they are no longer deemed necessary.
While this can still cause unnecessary filesystem usage, this is not
deemed an issue since the wallet will already grow to an unbounded
size as it must save the entire header chain and will grow infinitely
long as time progresses.