### PR TITLE
Watch relevant outputs of processed transactions

### DIFF
--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -163,7 +163,10 @@ type RescanSaver interface {
 	SaveRescanned(hash *chainhash.Hash, txs []*wire.MsgTx) error
 }
 
-// SaveRescanned records transactions from a rescanned block.
+// SaveRescanned records transactions from a rescanned block.  This
+// does not update the network backend with data to watch for future
+// relevant transactions as the rescanner is assumed to handle this
+// task.
 func (w *Wallet) SaveRescanned(hash *chainhash.Hash, txs []*wire.MsgTx) error {
 	const op errors.Op = "wallet.SaveRescanned"
 	err := walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
@@ -182,7 +185,7 @@ func (w *Wallet) SaveRescanned(hash *chainhash.Hash, txs []*wire.MsgTx) error {
 			if err != nil {
 				return err
 			}
-			err = w.processTransactionRecord(dbtx, rec, header, &blockMeta)
+			_, err = w.processTransactionRecord(dbtx, rec, header, &blockMeta)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
When a transaction is processed, either when discovered over the
network, created by this wallet, or published over RPC, the wallet
must begin to watch relevant outputs of the transaction.  This was
prevously not being performed, resulting in transactions being missed
and double spends occuring due to spent outputs not being marked as
spent by the missed redeeming transaction.

In future versions of the wallet module, I hope to modify the APIs to
return new relevant data that must be watched by a syncing network
backend.  However, this is too invasive of a change to perform now and
would clutter the API with several deprecated functions if attempted
without bumping major module versions.  Instead, if a network backend
is associated with the wallet, it is used to load the relevant outputs
into the transaction search filter.