### PR TITLE
Feature/dcrwallet 1311 subtractfeefromamount

### DIFF
--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -2612,11 +2612,8 @@ func sendToAddress(s *Server, icmd interface{}) (interface{}, error) {
 		cmd.Address: amt,
 	}
 
-	// replace hardcoded default value with dynamic subtractfeefromamount flag
-	recipientPaysFee := false
-
 	// sendtoaddress always spends from the default account, this matches bitcoind
-	return sendPairs(w, pairs, udb.DefaultAccountNum, 1, recipientPaysFee)
+	return sendPairs(w, pairs, udb.DefaultAccountNum, 1, cmd.SubtractFeeFromAmount)
 }
 
 // sendToMultiSig handles a sendtomultisig RPC request by creating a new

--- a/rpc/legacyrpc/methods.go
+++ b/rpc/legacyrpc/methods.go
@@ -2612,8 +2612,13 @@ func sendToAddress(s *Server, icmd interface{}) (interface{}, error) {
 		cmd.Address: amt,
 	}
 
+	recipientPaysFee := false
+	if cmd.SubtractFeeFromAmount != nil {
+		recipientPaysFee = *cmd.SubtractFeeFromAmount
+	}
+
 	// sendtoaddress always spends from the default account, this matches bitcoind
-	return sendPairs(w, pairs, udb.DefaultAccountNum, 1, cmd.SubtractFeeFromAmount)
+	return sendPairs(w, pairs, udb.DefaultAccountNum, 1, recipientPaysFee)
 }
 
 // sendToMultiSig handles a sendtomultisig RPC request by creating a new

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -281,7 +281,7 @@ func (w *Wallet) checkHighFees(totalInput dcrutil.Amount, tx *wire.MsgTx) error 
 // with no less than minconf confirmations, and creates a signed transaction
 // that pays to each of the outputs.
 func (w *Wallet) txToOutputs(op errors.Op, outputs []*wire.TxOut, account uint32,
-	minconf int32, randomizeChangeIdx bool) (*txauthor.AuthoredTx, error) {
+	minconf int32, randomizeChangeIdx bool, recipientPaysFee bool) (*txauthor.AuthoredTx, error) {
 
 	n, err := w.NetworkBackend()
 	if err != nil {
@@ -289,7 +289,7 @@ func (w *Wallet) txToOutputs(op errors.Op, outputs []*wire.TxOut, account uint32
 	}
 
 	return w.txToOutputsInternal(op, outputs, account, minconf, n,
-		randomizeChangeIdx, w.RelayFee())
+		randomizeChangeIdx, w.RelayFee(), false)
 }
 
 // txToOutputsInternal creates a signed transaction which includes each output
@@ -304,7 +304,7 @@ func (w *Wallet) txToOutputs(op errors.Op, outputs []*wire.TxOut, account uint32
 // into the database, rather than delegating this work to the caller as
 // btcwallet does.
 func (w *Wallet) txToOutputsInternal(op errors.Op, outputs []*wire.TxOut, account uint32, minconf int32,
-	n NetworkBackend, randomizeChangeIdx bool, txFee dcrutil.Amount) (*txauthor.AuthoredTx, error) {
+	n NetworkBackend, randomizeChangeIdx bool, txFee dcrutil.Amount, recipientPaysFee bool) (*txauthor.AuthoredTx, error) {
 
 	var atx *txauthor.AuthoredTx
 	var changeSourceUpdates []func(walletdb.ReadWriteTx) error
@@ -321,9 +321,23 @@ func (w *Wallet) txToOutputsInternal(op errors.Op, outputs []*wire.TxOut, accoun
 			account: account,
 			wallet:  w,
 		}
+
+
 		var err error
-		atx, err = txauthor.NewUnsignedTransaction(outputs, txFee,
-			inputSource.SelectInputs, changeSource)
+
+		if recipientPaysFee {
+			if len(outputs) != 1 {
+				return errors.E(op, "Expected only one provided output for " +
+					"transaction where recipient pays the fee")
+			}
+
+			output := outputs[0]
+			atx, err = txauthor.NewUnsignedTransactionMinusFee(output, txFee,
+				inputSource.SelectInputs, changeSource)
+		} else {
+			atx, err = txauthor.NewUnsignedTransaction(outputs, txFee,
+				inputSource.SelectInputs, changeSource)
+		}
 		if err != nil {
 			return err
 		}
@@ -1074,7 +1088,7 @@ func (w *Wallet) purchaseTickets(op errors.Op, req purchaseTicketRequest) ([]*ch
 		txFeeIncrement = w.RelayFee()
 	}
 	splitTx, err := w.txToOutputsInternal(op, splitOuts, account, req.minConf,
-		n, false, txFeeIncrement)
+		n, false, txFeeIncrement, false)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -289,7 +289,7 @@ func (w *Wallet) txToOutputs(op errors.Op, outputs []*wire.TxOut, account uint32
 	}
 
 	return w.txToOutputsInternal(op, outputs, account, minconf, n,
-		randomizeChangeIdx, w.RelayFee(), false)
+		randomizeChangeIdx, w.RelayFee(), recipientPaysFee)
 }
 
 // txToOutputsInternal creates a signed transaction which includes each output
@@ -322,12 +322,11 @@ func (w *Wallet) txToOutputsInternal(op errors.Op, outputs []*wire.TxOut, accoun
 			wallet:  w,
 		}
 
-
 		var err error
 
 		if recipientPaysFee {
 			if len(outputs) != 1 {
-				return errors.E(op, "Expected only one provided output for " +
+				return errors.E(op, "Expected exactly one output for "+
 					"transaction where recipient pays the fee")
 			}
 

--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -154,6 +154,20 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, relayFeePerKb dcrutil.Amount,
 	}
 }
 
+func NewUnsignedTransactionMinusFee(output *wire.TxOut, relayFeePerKb dcrutil.Amount,
+	fetchInputs InputSource, fetchChange ChangeSource) (*AuthoredTx, error) {
+
+	// Since the fee will come directly from the full output amount,
+	// defer fee calculation until enough inputs have been consumed.
+	authoredTx, err := NewUnsignedTransaction([]*wire.TxOut{ output }, 0, fetchInputs, fetchChange)
+	if err != nil {
+		return nil, err
+	}
+
+	output.Value -= int64(txrules.FeeForSerializeSize(relayFeePerKb, authoredTx.EstimatedSignedSerializeSize))
+	return authoredTx, nil
+}
+
 // RandomizeOutputPosition randomizes the position of a transaction's output by
 // swapping it with a random output.  The new index is returned.  This should be
 // done before signing.

--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -154,17 +154,27 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, relayFeePerKb dcrutil.Amount,
 	}
 }
 
+// NewUnsignedTransactionMinusFee creates an unsigned transaction paying to one
+// non-change output.  An appropriate transaction fee is included based on the
+// transaction size, and is subtracted from the provided `output` parameter.
+//
+// Behavior mirrors a call to `NewUnsignedTransaction` with the only differences
+// being that this method takes a single `output`, and all fees are subtracted from
+// the output rather than from change.
 func NewUnsignedTransactionMinusFee(output *wire.TxOut, relayFeePerKb dcrutil.Amount,
 	fetchInputs InputSource, fetchChange ChangeSource) (*AuthoredTx, error) {
 
 	// Since the fee will come directly from the full output amount,
 	// defer fee calculation until enough inputs have been consumed.
-	authoredTx, err := NewUnsignedTransaction([]*wire.TxOut{ output }, 0, fetchInputs, fetchChange)
+	authoredTx, err := NewUnsignedTransaction([]*wire.TxOut{output}, 0, fetchInputs, fetchChange)
 	if err != nil {
 		return nil, err
 	}
 
-	output.Value -= int64(txrules.FeeForSerializeSize(relayFeePerKb, authoredTx.EstimatedSignedSerializeSize))
+	// At this point, all inputs have been determined and the size of the transaction is fixed.
+	// Calculate the fee and subtract it from the single provided output.
+	feeAmount := txrules.FeeForSerializeSize(relayFeePerKb, authoredTx.EstimatedSignedSerializeSize)
+	output.Value -= int64(feeAmount)
 	return authoredTx, nil
 }
 

--- a/wallet/txauthor/author.go
+++ b/wallet/txauthor/author.go
@@ -158,9 +158,10 @@ func NewUnsignedTransaction(outputs []*wire.TxOut, relayFeePerKb dcrutil.Amount,
 // non-change output.  An appropriate transaction fee is included based on the
 // transaction size, and is subtracted from the provided `output` parameter.
 //
-// Behavior mirrors a call to `NewUnsignedTransaction` with the only differences
-// being that this method takes a single `output`, and all fees are subtracted from
-// the output rather than from change.
+// The behavior of this method mirrors a call to `NewUnsignedTransaction` with the
+// only differences being that:
+// * this method takes a single `output` and
+// * all fees are subtracted from the provided output rather than from change.
 func NewUnsignedTransactionMinusFee(output *wire.TxOut, relayFeePerKb dcrutil.Amount,
 	fetchInputs InputSource, fetchChange ChangeSource) (*AuthoredTx, error) {
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1192,11 +1192,11 @@ out:
 				continue
 			}
 
-			tx, errOut := w.txToOutputs("wallet.SendOutputs", txr.outputs,
+			tx, err := w.txToOutputs("wallet.SendOutputs", txr.outputs,
 				txr.account, txr.minconf, true, txr.recipientPaysFee)
 
 			heldUnlock.release()
-			txr.resp <- createTxResponse{tx, errOut}
+			txr.resp <- createTxResponse{tx, err}
 
 		case txr := <-w.createMultisigTxRequests:
 			heldUnlock, err := w.holdUnlock()


### PR DESCRIPTION
This PR resolves issue https://github.com/decred/dcrwallet/issues/1311

Add flag that allows the fee to be subtracted from the destination address when performing a call to `sendtoaddress`.  The default behavior is to subtract the fee from excess input value.