### PR TITLE
Bump required dcrd JSON-RPC API version

### DIFF
--- a/chain/chain.go
+++ b/chain/chain.go
@@ -18,7 +18,7 @@ import (
 	"github.com/decred/dcrwallet/errors"
 )
 
-var requiredChainServerAPI = semver{major: 4, minor: 0, patch: 0}
+var requiredChainServerAPI = semver{major: 5, minor: 0, patch: 0}
 
 // RPCClient represents a persistent client connection to a decred RPC server
 // for information regarding the current best block chain.


### PR DESCRIPTION
This matches dcrd's RPC server version bump in PR https://github.com/decred/dcrd/pull/1531.

As discussed on Slack, dcrwallet does not depend on the order of reorg and block connected notifications, but the bump is still needed unless a range of major versions is to be supported.