### PR TITLE
Improve errors for missing credit value failures

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -996,7 +996,8 @@ func (s *Store) moveMinedTx(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.Read
 
 		credVal := existsRawCredit(ns, credKey)
 		if credVal == nil {
-			return errors.E(errors.IO, "missing credit value")
+			return errors.E(errors.IO, errors.Errorf("missing credit "+
+				"%v, key %x, spent by %v", &input.PreviousOutPoint, credKey, &rec.Hash))
 		}
 		creditOpCode := fetchRawCreditTagOpCode(credVal)
 
@@ -1739,7 +1740,8 @@ func (s *Store) rollback(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.ReadBuc
 					credVal = removedCredits[string(credKey)]
 				}
 				if credVal == nil {
-					return errors.E(errors.IO, "missing credit value")
+					return errors.E(errors.IO, errors.Errorf("missing credit "+
+						"%v, key %x, spent by %v", prevOut, credKey, &rec.Hash))
 				}
 				creditOpCode := fetchRawCreditTagOpCode(credVal)
 


### PR DESCRIPTION
Errors now report the outpoint of the missing credit, the transaction which
supposedly spends the missing credit, and the key used to attempt the lookup.