### PR TITLE
Update default relay fee to 0.0001

### DIFF
--- a/wallet/txrules/rules.go
+++ b/wallet/txrules/rules.go
@@ -14,7 +14,7 @@ import (
 )
 
 // DefaultRelayFeePerKb is the default minimum relay fee policy for a mempool.
-const DefaultRelayFeePerKb dcrutil.Amount = 1e5
+const DefaultRelayFeePerKb dcrutil.Amount = 1e4
 
 // IsDustAmount determines whether a transaction output value and script length would
 // cause the output to be considered dust.  Transactions with dust outputs are


### PR DESCRIPTION
Network has sufficiently upgraded to nodes that are running with the 0.0001 min tx relay fee, so we can also update wallets to use this default as well.