### PR TITLE
Bump version for 1.5 release cycle.

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -18,7 +18,7 @@ const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 // Constants defining the application version number.
 const (
 	Major = 1
-	Minor = 4
+	Minor = 5
 	Patch = 0
 )
 


### PR DESCRIPTION
The 1.4 release branch and 1.4.0-rc1 tags have been created branched off from
master.  It's time to start work on 1.5.