### PR TITLE
spv sync: reset peer connection status after error

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -412,6 +412,9 @@ func (s *Syncer) connectToCandidates(ctx context.Context) error {
 
 			rp, err := s.lp.ConnectOutbound(ctx, raddr, reqSvcs)
 			if err != nil {
+				s.remotesMu.Lock()
+				delete(s.connectingRemotes, k)
+				s.remotesMu.Unlock()
 				if ctx.Err() == nil {
 					log.Warnf("Peering attempt failed: %v", err)
 				}


### PR DESCRIPTION
A connecting peer should be set to not connecting status after failing due to error.  This is causing problems for dcrandroid.

Ps. I'm new.  Plz check my work and any criticisms are welcome.