### PR TITLE
Add config option to disable coin type upgrades

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,27 +29,28 @@ import (
 )
 
 const (
-	defaultCAFilename          = "dcrd.cert"
-	defaultConfigFilename      = "dcrwallet.conf"
-	defaultLogLevel            = "info"
-	defaultLogDirname          = "logs"
-	defaultLogFilename         = "dcrwallet.log"
-	defaultRPCMaxClients       = 10
-	defaultRPCMaxWebsockets    = 25
-	defaultEnableTicketBuyer   = false
-	defaultEnableVoting        = false
-	defaultReuseAddresses      = false
-	defaultRollbackTest        = false
-	defaultPruneTickets        = false
-	defaultPurchaseAccount     = "default"
-	defaultAutomaticRepair     = false
-	defaultPromptPass          = false
-	defaultPass                = ""
-	defaultPromptPublicPass    = false
-	defaultGapLimit            = wallet.DefaultGapLimit
-	defaultStakePoolColdExtKey = ""
-	defaultAllowHighFees       = false
-	defaultAccountGapLimit     = wallet.DefaultAccountGapLimit
+	defaultCAFilename              = "dcrd.cert"
+	defaultConfigFilename          = "dcrwallet.conf"
+	defaultLogLevel                = "info"
+	defaultLogDirname              = "logs"
+	defaultLogFilename             = "dcrwallet.log"
+	defaultRPCMaxClients           = 10
+	defaultRPCMaxWebsockets        = 25
+	defaultEnableTicketBuyer       = false
+	defaultEnableVoting            = false
+	defaultReuseAddresses          = false
+	defaultRollbackTest            = false
+	defaultPruneTickets            = false
+	defaultPurchaseAccount         = "default"
+	defaultAutomaticRepair         = false
+	defaultPromptPass              = false
+	defaultPass                    = ""
+	defaultPromptPublicPass        = false
+	defaultGapLimit                = wallet.DefaultGapLimit
+	defaultStakePoolColdExtKey     = ""
+	defaultAllowHighFees           = false
+	defaultAccountGapLimit         = wallet.DefaultAccountGapLimit
+	defaultDisableCoinTypeUpgrades = false
 
 	// ticket buyer options
 	defaultMaxFee                    dcrutil.Amount = 1e6
@@ -98,24 +99,25 @@ type config struct {
 	MemProfile         string                  `long:"memprofile" description:"Write mem profile to the specified file"`
 
 	// Wallet options
-	WalletPass          string               `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
-	PromptPass          bool                 `long:"promptpass" description:"The private wallet password is prompted for at start up, so the wallet starts unlocked without a time limit"`
-	Pass                string               `long:"pass" description:"The private wallet passphrase"`
-	PromptPublicPass    bool                 `long:"promptpublicpass" description:"The public wallet password is prompted for at start up"`
-	DisallowFree        bool                 `long:"disallowfree" description:"Force transactions to always include a fee"`
-	EnableTicketBuyer   bool                 `long:"enableticketbuyer" description:"Enable the automatic ticket buyer"`
-	EnableVoting        bool                 `long:"enablevoting" description:"Enable creation of votes and revocations for owned tickets"`
-	ReuseAddresses      bool                 `long:"reuseaddresses" description:"Reuse addresses for ticket purchase to cut down on address overuse"`
-	PurchaseAccount     string               `long:"purchaseaccount" description:"Name of the account to buy tickets from"`
-	PoolAddress         *cfgutil.AddressFlag `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
-	PoolFees            float64              `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)"`
-	GapLimit            int                  `long:"gaplimit" description:"The size of gaps between used addresses.  Used for address scanning and when generating addresses with the wrap option."`
-	StakePoolColdExtKey string               `long:"stakepoolcoldextkey" description:"Enables the wallet as a stake pool with an extended key in the format of \"xpub...:index\" to derive cold wallet addresses to send fees to"`
-	AllowHighFees       bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
-	RelayFee            *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`
-	TicketFee           *cfgutil.AmountFlag  `long:"ticketfee" description:"Sets the wallet's ticket fee per kb"`
-	AccountGapLimit     int                  `long:"accountgaplimit" description:"Number of accounts that can be created in a row without using any of them"`
-	legacyTicketBuyer   bool
+	WalletPass              string               `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
+	PromptPass              bool                 `long:"promptpass" description:"The private wallet password is prompted for at start up, so the wallet starts unlocked without a time limit"`
+	Pass                    string               `long:"pass" description:"The private wallet passphrase"`
+	PromptPublicPass        bool                 `long:"promptpublicpass" description:"The public wallet password is prompted for at start up"`
+	DisallowFree            bool                 `long:"disallowfree" description:"Force transactions to always include a fee"`
+	EnableTicketBuyer       bool                 `long:"enableticketbuyer" description:"Enable the automatic ticket buyer"`
+	EnableVoting            bool                 `long:"enablevoting" description:"Enable creation of votes and revocations for owned tickets"`
+	ReuseAddresses          bool                 `long:"reuseaddresses" description:"Reuse addresses for ticket purchase to cut down on address overuse"`
+	PurchaseAccount         string               `long:"purchaseaccount" description:"Name of the account to buy tickets from"`
+	PoolAddress             *cfgutil.AddressFlag `long:"pooladdress" description:"The ticket pool address where ticket fees will go to"`
+	PoolFees                float64              `long:"poolfees" description:"The per-ticket fee mandated by the ticket pool as a percent (e.g. 1.00 for 1.00% fee)"`
+	GapLimit                int                  `long:"gaplimit" description:"The size of gaps between used addresses.  Used for address scanning and when generating addresses with the wrap option."`
+	StakePoolColdExtKey     string               `long:"stakepoolcoldextkey" description:"Enables the wallet as a stake pool with an extended key in the format of \"xpub...:index\" to derive cold wallet addresses to send fees to"`
+	AllowHighFees           bool                 `long:"allowhighfees" description:"Force the RPC client to use the 'allowHighFees' flag when sending transactions"`
+	RelayFee                *cfgutil.AmountFlag  `long:"txfee" description:"Sets the wallet's tx fee per kb"`
+	TicketFee               *cfgutil.AmountFlag  `long:"ticketfee" description:"Sets the wallet's ticket fee per kb"`
+	AccountGapLimit         int                  `long:"accountgaplimit" description:"Number of accounts that can be created in a row without using any of them"`
+	DisableCoinTypeUpgrades bool                 `long:"disablecointypeupgrades" description:"Never upgrade from legacy to SLIP0044 coin type keys"`
+	legacyTicketBuyer       bool
 
 	// RPC client options
 	RPCConnect       string                  `short:"c" long:"rpcconnect" description:"Hostname/IP and port of dcrd RPC server to connect to"`
@@ -342,32 +344,33 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 
 	// Default config.
 	cfg := config{
-		DebugLevel:             defaultLogLevel,
-		ConfigFile:             cfgutil.NewExplicitString(defaultConfigFile),
-		AppDataDir:             cfgutil.NewExplicitString(defaultAppDataDir),
-		LogDir:                 cfgutil.NewExplicitString(defaultLogDir),
-		WalletPass:             wallet.InsecurePubPassphrase,
-		CAFile:                 cfgutil.NewExplicitString(""),
-		PromptPass:             defaultPromptPass,
-		Pass:                   defaultPass,
-		PromptPublicPass:       defaultPromptPublicPass,
-		RPCKey:                 cfgutil.NewExplicitString(defaultRPCKeyFile),
-		RPCCert:                cfgutil.NewExplicitString(defaultRPCCertFile),
-		TLSCurve:               cfgutil.NewCurveFlag(cfgutil.CurveP521),
-		LegacyRPCMaxClients:    defaultRPCMaxClients,
-		LegacyRPCMaxWebsockets: defaultRPCMaxWebsockets,
-		EnableTicketBuyer:      defaultEnableTicketBuyer,
-		EnableVoting:           defaultEnableVoting,
-		ReuseAddresses:         defaultReuseAddresses,
-		PruneTickets:           defaultPruneTickets,
-		PurchaseAccount:        defaultPurchaseAccount,
-		GapLimit:               defaultGapLimit,
-		StakePoolColdExtKey:    defaultStakePoolColdExtKey,
-		AllowHighFees:          defaultAllowHighFees,
-		RelayFee:               cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
-		TicketFee:              cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
-		PoolAddress:            cfgutil.NewAddressFlag(nil),
-		AccountGapLimit:        defaultAccountGapLimit,
+		DebugLevel:              defaultLogLevel,
+		ConfigFile:              cfgutil.NewExplicitString(defaultConfigFile),
+		AppDataDir:              cfgutil.NewExplicitString(defaultAppDataDir),
+		LogDir:                  cfgutil.NewExplicitString(defaultLogDir),
+		WalletPass:              wallet.InsecurePubPassphrase,
+		CAFile:                  cfgutil.NewExplicitString(""),
+		PromptPass:              defaultPromptPass,
+		Pass:                    defaultPass,
+		PromptPublicPass:        defaultPromptPublicPass,
+		RPCKey:                  cfgutil.NewExplicitString(defaultRPCKeyFile),
+		RPCCert:                 cfgutil.NewExplicitString(defaultRPCCertFile),
+		TLSCurve:                cfgutil.NewCurveFlag(cfgutil.CurveP521),
+		LegacyRPCMaxClients:     defaultRPCMaxClients,
+		LegacyRPCMaxWebsockets:  defaultRPCMaxWebsockets,
+		EnableTicketBuyer:       defaultEnableTicketBuyer,
+		EnableVoting:            defaultEnableVoting,
+		ReuseAddresses:          defaultReuseAddresses,
+		PruneTickets:            defaultPruneTickets,
+		PurchaseAccount:         defaultPurchaseAccount,
+		GapLimit:                defaultGapLimit,
+		StakePoolColdExtKey:     defaultStakePoolColdExtKey,
+		AllowHighFees:           defaultAllowHighFees,
+		RelayFee:                cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
+		TicketFee:               cfgutil.NewAmountFlag(txrules.DefaultRelayFeePerKb),
+		PoolAddress:             cfgutil.NewAddressFlag(nil),
+		AccountGapLimit:         defaultAccountGapLimit,
+		DisableCoinTypeUpgrades: defaultDisableCoinTypeUpgrades,
 
 		// TODO: DEPRECATED - remove.
 		DataDir:         cfgutil.NewExplicitString(defaultAppDataDir),

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -159,7 +159,8 @@ func run(ctx context.Context) error {
 		TicketFee:           cfg.TicketFee.ToCoin(),
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(), cfg.AccountGapLimit)
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(),
+		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -42,11 +42,12 @@ type Loader struct {
 	purchaseManager *ticketbuyer.PurchaseManager
 	ntfnClient      wallet.MainTipChangedNotificationsClient
 
-	stakeOptions    *StakeOptions
-	gapLimit        int
-	accountGapLimit int
-	allowHighFees   bool
-	relayFee        float64
+	stakeOptions            *StakeOptions
+	gapLimit                int
+	accountGapLimit         int
+	disableCoinTypeUpgrades bool
+	allowHighFees           bool
+	relayFee                float64
 
 	mu sync.Mutex
 }
@@ -64,17 +65,18 @@ type StakeOptions struct {
 
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit int,
-	allowHighFees bool, relayFee float64, accountGapLimit int) *Loader {
+	allowHighFees bool, relayFee float64, accountGapLimit int, disableCoinTypeUpgrades bool) *Loader {
 
 	return &Loader{
-		chainParams:     chainParams,
-		dbDirPath:       dbDirPath,
-		dbDriver:        defaultDbDriver,
-		stakeOptions:    stakeOptions,
-		gapLimit:        gapLimit,
-		accountGapLimit: accountGapLimit,
-		allowHighFees:   allowHighFees,
-		relayFee:        relayFee,
+		chainParams:             chainParams,
+		dbDirPath:               dbDirPath,
+		dbDriver:                defaultDbDriver,
+		stakeOptions:            stakeOptions,
+		gapLimit:                gapLimit,
+		accountGapLimit:         accountGapLimit,
+		disableCoinTypeUpgrades: disableCoinTypeUpgrades,
+		allowHighFees:           allowHighFees,
+		relayFee:                relayFee,
 	}
 }
 
@@ -175,20 +177,21 @@ func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte)
 	// Open the watch-only wallet.
 	so := l.stakeOptions
 	cfg := &wallet.Config{
-		DB:                  db,
-		PubPassphrase:       pubPass,
-		VotingEnabled:       so.VotingEnabled,
-		AddressReuse:        so.AddressReuse,
-		VotingAddress:       so.VotingAddress,
-		PoolAddress:         so.PoolAddress,
-		PoolFees:            so.PoolFees,
-		TicketFee:           so.TicketFee,
-		GapLimit:            l.gapLimit,
-		AccountGapLimit:     l.accountGapLimit,
-		StakePoolColdExtKey: so.StakePoolColdExtKey,
-		AllowHighFees:       l.allowHighFees,
-		RelayFee:            l.relayFee,
-		Params:              l.chainParams,
+		DB:                      db,
+		PubPassphrase:           pubPass,
+		VotingEnabled:           so.VotingEnabled,
+		AddressReuse:            so.AddressReuse,
+		VotingAddress:           so.VotingAddress,
+		PoolAddress:             so.PoolAddress,
+		PoolFees:                so.PoolFees,
+		TicketFee:               so.TicketFee,
+		GapLimit:                l.gapLimit,
+		AccountGapLimit:         l.accountGapLimit,
+		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
+		StakePoolColdExtKey:     so.StakePoolColdExtKey,
+		AllowHighFees:           l.allowHighFees,
+		RelayFee:                l.relayFee,
+		Params:                  l.chainParams,
 	}
 	w, err = wallet.Open(cfg)
 	if err != nil {

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -40,6 +40,10 @@
 ; It also changes a number of accounts that will be scanned during seed restoration
 ; accountgaplimit=10
 
+; Disable coin type upgrades from the legacy to SLIP0044 coin type keys even
+; when no address usage is discovered on the legacy coin type
+; disablecointypeupgrades=0
+
 ; ------------------------------------------------------------------------------
 ; RPC client settings
 ; ------------------------------------------------------------------------------

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -102,12 +102,13 @@ type Wallet struct {
 
 	lockedOutpoints map[wire.OutPoint]struct{}
 
-	relayFee               dcrutil.Amount
-	relayFeeMu             sync.Mutex
-	ticketFeeIncrementLock sync.Mutex
-	ticketFeeIncrement     dcrutil.Amount
-	DisallowFree           bool
-	AllowHighFees          bool
+	relayFee                dcrutil.Amount
+	relayFeeMu              sync.Mutex
+	ticketFeeIncrementLock  sync.Mutex
+	ticketFeeIncrement      dcrutil.Amount
+	DisallowFree            bool
+	AllowHighFees           bool
+	disableCoinTypeUpgrades bool
 
 	// Channel for transaction creation requests.
 	consolidateRequests      chan consolidateRequest
@@ -154,8 +155,9 @@ type Config struct {
 	PoolFees      float64
 	TicketFee     float64
 
-	GapLimit        int
-	AccountGapLimit int
+	GapLimit                int
+	AccountGapLimit         int
+	DisableCoinTypeUpgrades bool
 
 	StakePoolColdExtKey string
 	AllowHighFees       bool
@@ -4472,9 +4474,10 @@ func Open(cfg *Config) (*Wallet, error) {
 		poolFees:      cfg.PoolFees,
 
 		// LoaderOptions
-		gapLimit:        cfg.GapLimit,
-		AllowHighFees:   cfg.AllowHighFees,
-		accountGapLimit: cfg.AccountGapLimit,
+		gapLimit:                cfg.GapLimit,
+		AllowHighFees:           cfg.AllowHighFees,
+		accountGapLimit:         cfg.AccountGapLimit,
+		disableCoinTypeUpgrades: cfg.DisableCoinTypeUpgrades,
 
 		// Chain params
 		subsidyCache: blockchain.NewSubsidyCache(0, cfg.Params),

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -53,7 +53,8 @@ func createWallet(ctx context.Context, cfg *config) error {
 		TicketFee:     cfg.TicketFee.ToCoin(),
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(), cfg.AccountGapLimit)
+		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.ToCoin(),
+		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
This will require the next wallet module release to be a minor bump for the
introduction of a new config struct option.

Closes #1389.