### PR TITLE
jsonrpc/types: Implement new module for dcrjson.

### DIFF
--- a/rpc/jsonrpc/types/README.md
+++ b/rpc/jsonrpc/types/README.md
@@ -1,0 +1,36 @@
+jsonrpc/types
+=============
+
+[![Build Status](https://travis-ci.org/decred/dcrwallet.png?branch=master)](https://travis-ci.org/decred/dcrwallet)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/decred/dcrwallet/rpc/jsonrpc/types)
+
+Package types implements concrete types for marshalling to and from the
+dcrwallet JSON-RPC API.  A comprehensive suite of tests is provided to ensure
+proper functionality.
+
+The provided types are automatically registered with
+[dcrjson](https://github.com/decred/dcrd/tree/master/dcrjson) when the package
+is imported.  Although this package was primarily written for dcrwallet, it has
+intentionally been designed so it can be used as a standalone package for any
+projects needing to marshal to and from dcrwallet JSON-RPC requests and
+responses.
+
+Note that although it's possible to use this package directly to implement an
+RPC client, it is not recommended since it is only intended as an infrastructure
+package.  Instead, RPC clients should use the
+[rpcclient](https://github.com/decred/dcrd/tree/master/rpcclient) package which
+provides a full blown RPC client with many features such as automatic connection
+management, websocket support, automatic notification re-registration on
+reconnect, and conversion from the raw underlying RPC types (strings, floats,
+ints, etc) to higher-level types with many nice and useful properties.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/decred/dcrwallet/rpc/jsonrpc/types
+```
+
+## License
+
+Package types is licensed under the [copyfree](http://copyfree.org) ISC License.

--- a/rpc/jsonrpc/types/doc.go
+++ b/rpc/jsonrpc/types/doc.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+/*
+Package types implements concrete types for the dcrwallet JSON-RPC API.
+
+Overview
+
+When communicating via the JSON-RPC protocol, all of the commands need to be
+marshalled to and from the the wire in the appropriate format.  This package
+provides data structures and primitives that are registered with dcrjson to ease
+this process.  An overview specific to this package is provided here, however it
+is also instructive to read the documentation for the dcrjson package
+(http://godoc.org/github.com/decred/dcrd/dcrjson).
+
+Marshalling and Unmarshalling
+
+The types in this package map to the required parts of the protocol as discussed
+in the dcrjson documention
+
+  - Request Objects (type Request)
+    - Commands (type <Foo>Cmd)
+    - Notifications (type <Foo>Ntfn)
+  - Response Objects (type Response)
+    - Result (type <Foo>Result)
+
+To simplify the marshalling of the requests and responses, the
+dcrjson.MarshalCmd and dcrjson.MarshalResponse functions may be used.  They
+return the raw bytes ready to be sent across the wire.
+
+Unmarshalling a received Request object is a two step process:
+  1) Unmarshal the raw bytes into a Request struct instance via json.Unmarshal
+  2) Use UnmarshalCmd on the Result field of the unmarshalled Request to create
+     a concrete command or notification instance with all struct fields set
+     accordingly
+
+This approach is used since it provides the caller with access to the additional
+fields in the request that are not part of the command such as the ID.
+
+Unmarshalling a received Response object is also a two step process:
+  1) Unmarshal the raw bytes into a Response struct instance via json.Unmarshal
+  2) Depending on the ID, unmarshal the Result field of the unmarshalled
+     Response to create a concrete type instance
+
+As above, this approach is used since it provides the caller with access to the
+fields in the response such as the ID and Error.
+
+Command Creation
+
+This package provides two approaches for creating a new command.  This first,
+and preferred, method is to use one of the New<Foo>Cmd functions.  This allows
+static compile-time checking to help ensure the parameters stay in sync with
+the struct definitions.
+
+The second approach is the dcrjson.NewCmd function which takes a method
+(command) name and variable arguments.  Since this package registers all of its
+types with dcrjson, the function will recognize them and includes full checking
+to ensure the parameters are accurate according to provided method, however
+these checks are, obviously, run-time which means any mistakes won't be found
+until the code is actually executed.  However, it is quite useful for
+user-supplied commands that are intentionally dynamic.
+
+Help Generation
+
+To facilitate providing consistent help to users of the RPC server, the dcrjson
+package exposes the GenerateHelp and function which uses reflection on commands
+and notifications registered by this package, as well as the provided expected
+result types, to generate the final help text.
+
+In addition, the dcrjson.MethodUsageText function may be used to generate
+consistent one-line usage for registered commands and notifications using
+reflection.
+*/
+package types

--- a/rpc/jsonrpc/types/go.mod
+++ b/rpc/jsonrpc/types/go.mod
@@ -1,0 +1,3 @@
+module github.com/decred/dcrwallet/rpc/jsonrpc/types
+
+require github.com/decred/dcrd/dcrjson/v2 v2.0.0

--- a/rpc/jsonrpc/types/go.sum
+++ b/rpc/jsonrpc/types/go.sum
@@ -1,0 +1,6 @@
+github.com/dchest/blake256 v1.0.0 h1:6gUgI5MHdz9g0TdrgKqXsoDX+Zjxmm1Sc6OsoGru50I=
+github.com/dchest/blake256 v1.0.0/go.mod h1:xXNWCE1jsAP8DAjP+rKw2MbeqLczjI3TRx2VK+9OEYY=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
+github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0 h1:W0q4Alh36c5N318eUpfmU8kXoCNgImMLI87NIXni9Us=
+github.com/decred/dcrd/dcrjson/v2 v2.0.0/go.mod h1:FYueNy8BREAFq04YNEwcTsmGFcNqY+ehUUO81w2igi4=

--- a/rpc/jsonrpc/types/walletsvrcmds.go
+++ b/rpc/jsonrpc/types/walletsvrcmds.go
@@ -1,0 +1,1196 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// NOTE: This file is intended to house the RPC commands that are supported by
+// a wallet server.
+
+package types
+
+import "github.com/decred/dcrd/dcrjson/v2"
+
+// AccountAddressIndexCmd is a type handling custom marshaling and
+// unmarshaling of accountaddressindex JSON wallet extension
+// commands.
+type AccountAddressIndexCmd struct {
+	Account string `json:"account"`
+	Branch  int    `json:"branch"`
+}
+
+// NewAccountAddressIndexCmd creates a new AccountAddressIndexCmd.
+func NewAccountAddressIndexCmd(acct string, branch int) *AccountAddressIndexCmd {
+	return &AccountAddressIndexCmd{
+		Account: acct,
+		Branch:  branch,
+	}
+}
+
+// AccountSyncAddressIndexCmd is a type handling custom marshaling and
+// unmarshaling of accountsyncaddressindex JSON wallet extension
+// commands.
+type AccountSyncAddressIndexCmd struct {
+	Account string `json:"account"`
+	Branch  int    `json:"branch"`
+	Index   int    `json:"index"`
+}
+
+// NewAccountSyncAddressIndexCmd creates a new AccountSyncAddressIndexCmd.
+func NewAccountSyncAddressIndexCmd(acct string, branch int,
+	idx int) *AccountSyncAddressIndexCmd {
+	return &AccountSyncAddressIndexCmd{
+		Account: acct,
+		Branch:  branch,
+		Index:   idx,
+	}
+}
+
+// AddMultisigAddressCmd defines the addmutisigaddress JSON-RPC command.
+type AddMultisigAddressCmd struct {
+	NRequired int
+	Keys      []string
+	Account   *string
+}
+
+// NewAddMultisigAddressCmd returns a new instance which can be used to issue a
+// addmultisigaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewAddMultisigAddressCmd(nRequired int, keys []string, account *string) *AddMultisigAddressCmd {
+	return &AddMultisigAddressCmd{
+		NRequired: nRequired,
+		Keys:      keys,
+		Account:   account,
+	}
+}
+
+// AddTicketCmd forces a ticket into the wallet stake manager, for example if
+// someone made an invalid ticket for a stake pool and the pool manager wanted
+// to manually add it.
+type AddTicketCmd struct {
+	TicketHex string `json:"tickethex"`
+}
+
+// NewAddTicketCmd creates a new AddTicketCmd.
+func NewAddTicketCmd(ticketHex string) *AddTicketCmd {
+	return &AddTicketCmd{TicketHex: ticketHex}
+}
+
+// ConsolidateCmd is a type handling custom marshaling and
+// unmarshaling of consolidate JSON wallet extension
+// commands.
+type ConsolidateCmd struct {
+	Inputs  int `json:"inputs"`
+	Account *string
+	Address *string
+}
+
+// CreateMultiSigResult models the data returned from the createmultisig
+// command.
+type CreateMultiSigResult struct {
+	Address      string `json:"address"`
+	RedeemScript string `json:"redeemScript"`
+}
+
+// NewConsolidateCmd creates a new ConsolidateCmd.
+func NewConsolidateCmd(inputs int, acct *string, addr *string) *ConsolidateCmd {
+	return &ConsolidateCmd{Inputs: inputs, Account: acct, Address: addr}
+}
+
+// CreateMultisigCmd defines the createmultisig JSON-RPC command.
+type CreateMultisigCmd struct {
+	NRequired int
+	Keys      []string
+}
+
+// NewCreateMultisigCmd returns a new instance which can be used to issue a
+// createmultisig JSON-RPC command.
+func NewCreateMultisigCmd(nRequired int, keys []string) *CreateMultisigCmd {
+	return &CreateMultisigCmd{
+		NRequired: nRequired,
+		Keys:      keys,
+	}
+}
+
+// CreateNewAccountCmd defines the createnewaccount JSON-RPC command.
+type CreateNewAccountCmd struct {
+	Account string
+}
+
+// NewCreateNewAccountCmd returns a new instance which can be used to issue a
+// createnewaccount JSON-RPC command.
+func NewCreateNewAccountCmd(account string) *CreateNewAccountCmd {
+	return &CreateNewAccountCmd{
+		Account: account,
+	}
+}
+
+// CreateVotingAccountCmd is a type for handling custom marshaling and
+// unmarshalling of createvotingaccount JSON-RPC command.
+type CreateVotingAccountCmd struct {
+	Name       string
+	PubKey     string
+	ChildIndex *uint32 `jsonrpcdefault:"0"`
+}
+
+// NewCreateVotingAccountCmd creates a new CreateVotingAccountCmd.
+func NewCreateVotingAccountCmd(name, pubKey string, childIndex *uint32) *CreateVotingAccountCmd {
+	return &CreateVotingAccountCmd{name, pubKey, childIndex}
+}
+
+// DropVotingAccountCmd is a type for handling custom marshaling and
+// unmarshalling of dropvotingaccount JSON-RPC command
+type DropVotingAccountCmd struct {
+}
+
+// NewDropVotingAccountCmd creates a new DropVotingAccountCmd.
+func NewDropVotingAccountCmd() *DropVotingAccountCmd {
+	return &DropVotingAccountCmd{}
+}
+
+// DumpPrivKeyCmd defines the dumpprivkey JSON-RPC command.
+type DumpPrivKeyCmd struct {
+	Address string
+}
+
+// NewDumpPrivKeyCmd returns a new instance which can be used to issue a
+// dumpprivkey JSON-RPC command.
+func NewDumpPrivKeyCmd(address string) *DumpPrivKeyCmd {
+	return &DumpPrivKeyCmd{
+		Address: address,
+	}
+}
+
+// EstimatePriorityCmd defines the estimatepriority JSON-RPC command.
+type EstimatePriorityCmd struct {
+	NumBlocks int64
+}
+
+// NewEstimatePriorityCmd returns a new instance which can be used to issue a
+// estimatepriority JSON-RPC command.
+func NewEstimatePriorityCmd(numBlocks int64) *EstimatePriorityCmd {
+	return &EstimatePriorityCmd{
+		NumBlocks: numBlocks,
+	}
+}
+
+// FundRawTransactionOptions represents the optional inputs to fund
+// a raw transaction.
+type FundRawTransactionOptions struct {
+	ChangeAddress *string  `json:"changeaddress"`
+	FeeRate       *float64 `json:"feerate"`
+	ConfTarget    *int32   `json:"conf_target"`
+}
+
+// FundRawTransactionCmd is a type handling custom marshaling and
+// unmarshaling of fundrawtransaction JSON wallet extension commands.
+type FundRawTransactionCmd struct {
+	HexString   string
+	FundAccount string
+	Options     *FundRawTransactionOptions
+}
+
+// NewFundRawTransactionCmd returns a new instance which can be used to issue a
+// fundrawtransaction JSON-RPC command.
+func NewFundRawTransactionCmd(hexString string, fundAccount string, options *FundRawTransactionOptions) *FundRawTransactionCmd {
+	return &FundRawTransactionCmd{
+		HexString:   hexString,
+		FundAccount: fundAccount,
+		Options:     options,
+	}
+}
+
+// GenerateVoteCmd is a type handling custom marshaling and
+// unmarshaling of generatevote JSON wallet extension commands.
+type GenerateVoteCmd struct {
+	BlockHash   string
+	Height      int64
+	TicketHash  string
+	VoteBits    uint16
+	VoteBitsExt string
+}
+
+// NewGenerateVoteCmd creates a new GenerateVoteCmd.
+func NewGenerateVoteCmd(blockhash string, height int64, tickethash string, votebits uint16, voteBitsExt string) *GenerateVoteCmd {
+	return &GenerateVoteCmd{
+		BlockHash:   blockhash,
+		Height:      height,
+		TicketHash:  tickethash,
+		VoteBits:    votebits,
+		VoteBitsExt: voteBitsExt,
+	}
+}
+
+// GetAccountCmd defines the getaccount JSON-RPC command.
+type GetAccountCmd struct {
+	Address string
+}
+
+// NewGetAccountCmd returns a new instance which can be used to issue a
+// getaccount JSON-RPC command.
+func NewGetAccountCmd(address string) *GetAccountCmd {
+	return &GetAccountCmd{
+		Address: address,
+	}
+}
+
+// GetAccountAddressCmd defines the getaccountaddress JSON-RPC command.
+type GetAccountAddressCmd struct {
+	Account string
+}
+
+// NewGetAccountAddressCmd returns a new instance which can be used to issue a
+// getaccountaddress JSON-RPC command.
+func NewGetAccountAddressCmd(account string) *GetAccountAddressCmd {
+	return &GetAccountAddressCmd{
+		Account: account,
+	}
+}
+
+// GetAddressesByAccountCmd defines the getaddressesbyaccount JSON-RPC command.
+type GetAddressesByAccountCmd struct {
+	Account string
+}
+
+// NewGetAddressesByAccountCmd returns a new instance which can be used to issue
+// a getaddressesbyaccount JSON-RPC command.
+func NewGetAddressesByAccountCmd(account string) *GetAddressesByAccountCmd {
+	return &GetAddressesByAccountCmd{
+		Account: account,
+	}
+}
+
+// GetBalanceCmd defines the getbalance JSON-RPC command.
+type GetBalanceCmd struct {
+	Account *string
+	MinConf *int `jsonrpcdefault:"1"`
+}
+
+// NewGetBalanceCmd returns a new instance which can be used to issue a
+// getbalance JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetBalanceCmd(account *string, minConf *int) *GetBalanceCmd {
+	return &GetBalanceCmd{
+		Account: account,
+		MinConf: minConf,
+	}
+}
+
+// GetContractHashCmd defines the getcontracthash JSON-RPC command.
+type GetContractHashCmd struct {
+	FilePath []string
+}
+
+// NewGetContractHashCmd returns a new instance which can be used to issue a
+// getcontracthash JSON-RPC command.
+func NewGetContractHashCmd(filepaths []string) *GetContractHashCmd {
+	return &GetContractHashCmd{FilePath: filepaths}
+}
+
+// GetMasterPubkeyCmd is a type handling custom marshaling and unmarshaling of
+// getmasterpubkey JSON wallet extension commands.
+type GetMasterPubkeyCmd struct {
+	Account *string
+}
+
+// NewGetMasterPubkeyCmd creates a new GetMasterPubkeyCmd.
+func NewGetMasterPubkeyCmd(acct *string) *GetMasterPubkeyCmd {
+	return &GetMasterPubkeyCmd{Account: acct}
+}
+
+// GetMultisigOutInfoCmd is a type handling custom marshaling and
+// unmarshaling of getmultisigoutinfo JSON websocket extension
+// commands.
+type GetMultisigOutInfoCmd struct {
+	Hash  string
+	Index uint32
+}
+
+// NewGetMultisigOutInfoCmd creates a new GetMultisigOutInfoCmd.
+func NewGetMultisigOutInfoCmd(hash string, index uint32) *GetMultisigOutInfoCmd {
+	return &GetMultisigOutInfoCmd{hash, index}
+}
+
+// GetNewAddressCmd defines the getnewaddress JSON-RPC command.
+type GetNewAddressCmd struct {
+	Account   *string
+	GapPolicy *string
+}
+
+// NewGetNewAddressCmd returns a new instance which can be used to issue a
+// getnewaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetNewAddressCmd(account *string, gapPolicy *string) *GetNewAddressCmd {
+	return &GetNewAddressCmd{
+		Account:   account,
+		GapPolicy: gapPolicy,
+	}
+}
+
+// GetPayToContractAddressCmd defines the getpaytocontracthash JSON-RPC command.
+type GetPayToContractAddressCmd struct {
+	FilePath []string
+}
+
+// NewGetPayToContractAddressCmd returns a new instance which can be used to issue a
+// getpaytocontractaddress JSON-RPC command.
+func NewGetPayToContractAddressCmd(filepaths []string) *GetPayToContractAddressCmd {
+	return &GetPayToContractAddressCmd{
+		FilePath: filepaths,
+	}
+}
+
+// GetRawChangeAddressCmd defines the getrawchangeaddress JSON-RPC command.
+type GetRawChangeAddressCmd struct {
+	Account *string
+}
+
+// NewGetRawChangeAddressCmd returns a new instance which can be used to issue a
+// getrawchangeaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetRawChangeAddressCmd(account *string) *GetRawChangeAddressCmd {
+	return &GetRawChangeAddressCmd{
+		Account: account,
+	}
+}
+
+// GetReceivedByAccountCmd defines the getreceivedbyaccount JSON-RPC command.
+type GetReceivedByAccountCmd struct {
+	Account string
+	MinConf *int `jsonrpcdefault:"1"`
+}
+
+// NewGetReceivedByAccountCmd returns a new instance which can be used to issue
+// a getreceivedbyaccount JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetReceivedByAccountCmd(account string, minConf *int) *GetReceivedByAccountCmd {
+	return &GetReceivedByAccountCmd{
+		Account: account,
+		MinConf: minConf,
+	}
+}
+
+// GetReceivedByAddressCmd defines the getreceivedbyaddress JSON-RPC command.
+type GetReceivedByAddressCmd struct {
+	Address string
+	MinConf *int `jsonrpcdefault:"1"`
+}
+
+// NewGetReceivedByAddressCmd returns a new instance which can be used to issue
+// a getreceivedbyaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetReceivedByAddressCmd(address string, minConf *int) *GetReceivedByAddressCmd {
+	return &GetReceivedByAddressCmd{
+		Address: address,
+		MinConf: minConf,
+	}
+}
+
+// GetStakeInfoCmd is a type handling custom marshaling and
+// unmarshaling of getstakeinfo JSON wallet extension commands.
+type GetStakeInfoCmd struct {
+}
+
+// NewGetStakeInfoCmd creates a new GetStakeInfoCmd.
+func NewGetStakeInfoCmd() *GetStakeInfoCmd {
+	return &GetStakeInfoCmd{}
+}
+
+// GetTicketFeeCmd is a type handling custom marshaling and
+// unmarshaling of getticketfee JSON wallet extension
+// commands.
+type GetTicketFeeCmd struct {
+}
+
+// NewGetTicketFeeCmd creates a new GetTicketFeeCmd.
+func NewGetTicketFeeCmd() *GetTicketFeeCmd {
+	return &GetTicketFeeCmd{}
+}
+
+// GetTicketsCmd is a type handling custom marshaling and
+// unmarshaling of gettickets JSON wallet extension
+// commands.
+type GetTicketsCmd struct {
+	IncludeImmature bool
+}
+
+// NewGetTicketsCmd returns a new instance which can be used to issue a
+// gettickets JSON-RPC command.
+func NewGetTicketsCmd(includeImmature bool) *GetTicketsCmd {
+	return &GetTicketsCmd{includeImmature}
+}
+
+// GetTransactionCmd defines the gettransaction JSON-RPC command.
+type GetTransactionCmd struct {
+	Txid             string
+	IncludeWatchOnly *bool `jsonrpcdefault:"false"`
+}
+
+// NewGetTransactionCmd returns a new instance which can be used to issue a
+// gettransaction JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetTransactionCmd(txHash string, includeWatchOnly *bool) *GetTransactionCmd {
+	return &GetTransactionCmd{
+		Txid:             txHash,
+		IncludeWatchOnly: includeWatchOnly,
+	}
+}
+
+// GetVoteChoicesCmd returns a new instance which can be used to issue a
+// getvotechoices JSON-RPC command.
+type GetVoteChoicesCmd struct {
+}
+
+// NewGetVoteChoicesCmd returns a new instance which can be used to
+// issue a JSON-RPC getvotechoices command.
+func NewGetVoteChoicesCmd() *GetVoteChoicesCmd {
+	return &GetVoteChoicesCmd{}
+}
+
+// GetWalletFeeCmd defines the getwalletfee JSON-RPC command.
+type GetWalletFeeCmd struct{}
+
+// NewGetWalletFeeCmd returns a new instance which can be used to issue a
+// getwalletfee JSON-RPC command.
+//
+func NewGetWalletFeeCmd() *GetWalletFeeCmd {
+	return &GetWalletFeeCmd{}
+}
+
+// ImportPrivKeyCmd defines the importprivkey JSON-RPC command.
+type ImportPrivKeyCmd struct {
+	PrivKey  string
+	Label    *string
+	Rescan   *bool `jsonrpcdefault:"true"`
+	ScanFrom *int
+}
+
+// NewImportPrivKeyCmd returns a new instance which can be used to issue a
+// importprivkey JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewImportPrivKeyCmd(privKey string, label *string, rescan *bool, scanFrom *int) *ImportPrivKeyCmd {
+	return &ImportPrivKeyCmd{
+		PrivKey:  privKey,
+		Label:    label,
+		Rescan:   rescan,
+		ScanFrom: scanFrom,
+	}
+}
+
+// ImportScriptCmd is a type for handling custom marshaling and
+// unmarshaling of importscript JSON wallet extension commands.
+type ImportScriptCmd struct {
+	Hex      string
+	Rescan   *bool `jsonrpcdefault:"true"`
+	ScanFrom *int
+}
+
+// NewImportScriptCmd creates a new GetImportScriptCmd.
+func NewImportScriptCmd(hex string, rescan *bool, scanFrom *int) *ImportScriptCmd {
+	return &ImportScriptCmd{hex, rescan, scanFrom}
+}
+
+// KeyPoolRefillCmd defines the keypoolrefill JSON-RPC command.
+type KeyPoolRefillCmd struct {
+	NewSize *uint `jsonrpcdefault:"100"`
+}
+
+// NewKeyPoolRefillCmd returns a new instance which can be used to issue a
+// keypoolrefill JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewKeyPoolRefillCmd(newSize *uint) *KeyPoolRefillCmd {
+	return &KeyPoolRefillCmd{
+		NewSize: newSize,
+	}
+}
+
+// ListAccountsCmd defines the listaccounts JSON-RPC command.
+type ListAccountsCmd struct {
+	MinConf *int `jsonrpcdefault:"1"`
+}
+
+// NewListAccountsCmd returns a new instance which can be used to issue a
+// listaccounts JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListAccountsCmd(minConf *int) *ListAccountsCmd {
+	return &ListAccountsCmd{
+		MinConf: minConf,
+	}
+}
+
+// ListTicketsCmd defines the listtickets JSON-RPC command.
+type ListTicketsCmd struct {
+}
+
+// NewListTicketsCmd returns a new instance which can be used to issue a
+// listtickets JSON-RPC command.
+func NewListTicketsCmd() *ListTicketsCmd {
+	return &ListTicketsCmd{}
+}
+
+// ListLockUnspentCmd defines the listlockunspent JSON-RPC command.
+type ListLockUnspentCmd struct{}
+
+// NewListLockUnspentCmd returns a new instance which can be used to issue a
+// listlockunspent JSON-RPC command.
+func NewListLockUnspentCmd() *ListLockUnspentCmd {
+	return &ListLockUnspentCmd{}
+}
+
+// ListReceivedByAccountCmd defines the listreceivedbyaccount JSON-RPC command.
+type ListReceivedByAccountCmd struct {
+	MinConf          *int  `jsonrpcdefault:"1"`
+	IncludeEmpty     *bool `jsonrpcdefault:"false"`
+	IncludeWatchOnly *bool `jsonrpcdefault:"false"`
+}
+
+// NewListReceivedByAccountCmd returns a new instance which can be used to issue
+// a listreceivedbyaccount JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListReceivedByAccountCmd(minConf *int, includeEmpty, includeWatchOnly *bool) *ListReceivedByAccountCmd {
+	return &ListReceivedByAccountCmd{
+		MinConf:          minConf,
+		IncludeEmpty:     includeEmpty,
+		IncludeWatchOnly: includeWatchOnly,
+	}
+}
+
+// ListReceivedByAddressCmd defines the listreceivedbyaddress JSON-RPC command.
+type ListReceivedByAddressCmd struct {
+	MinConf          *int  `jsonrpcdefault:"1"`
+	IncludeEmpty     *bool `jsonrpcdefault:"false"`
+	IncludeWatchOnly *bool `jsonrpcdefault:"false"`
+}
+
+// NewListReceivedByAddressCmd returns a new instance which can be used to issue
+// a listreceivedbyaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListReceivedByAddressCmd(minConf *int, includeEmpty, includeWatchOnly *bool) *ListReceivedByAddressCmd {
+	return &ListReceivedByAddressCmd{
+		MinConf:          minConf,
+		IncludeEmpty:     includeEmpty,
+		IncludeWatchOnly: includeWatchOnly,
+	}
+}
+
+// ListScriptsCmd is a type for handling custom marshaling and
+// unmarshaling of listscripts JSON wallet extension commands.
+type ListScriptsCmd struct {
+}
+
+// NewListScriptsCmd returns a new instance which can be used to issue a
+// listscripts JSON-RPC command.
+func NewListScriptsCmd() *ListScriptsCmd {
+	return &ListScriptsCmd{}
+}
+
+// ListSinceBlockCmd defines the listsinceblock JSON-RPC command.
+type ListSinceBlockCmd struct {
+	BlockHash           *string
+	TargetConfirmations *int  `jsonrpcdefault:"1"`
+	IncludeWatchOnly    *bool `jsonrpcdefault:"false"`
+}
+
+// NewListSinceBlockCmd returns a new instance which can be used to issue a
+// listsinceblock JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListSinceBlockCmd(blockHash *string, targetConfirms *int, includeWatchOnly *bool) *ListSinceBlockCmd {
+	return &ListSinceBlockCmd{
+		BlockHash:           blockHash,
+		TargetConfirmations: targetConfirms,
+		IncludeWatchOnly:    includeWatchOnly,
+	}
+}
+
+// ListTransactionsCmd defines the listtransactions JSON-RPC command.
+type ListTransactionsCmd struct {
+	Account          *string
+	Count            *int  `jsonrpcdefault:"10"`
+	From             *int  `jsonrpcdefault:"0"`
+	IncludeWatchOnly *bool `jsonrpcdefault:"false"`
+}
+
+// NewListTransactionsCmd returns a new instance which can be used to issue a
+// listtransactions JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListTransactionsCmd(account *string, count, from *int, includeWatchOnly *bool) *ListTransactionsCmd {
+	return &ListTransactionsCmd{
+		Account:          account,
+		Count:            count,
+		From:             from,
+		IncludeWatchOnly: includeWatchOnly,
+	}
+}
+
+// ListUnspentCmd defines the listunspent JSON-RPC command.
+type ListUnspentCmd struct {
+	MinConf   *int `jsonrpcdefault:"1"`
+	MaxConf   *int `jsonrpcdefault:"9999999"`
+	Addresses *[]string
+}
+
+// NewListUnspentCmd returns a new instance which can be used to issue a
+// listunspent JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListUnspentCmd(minConf, maxConf *int, addresses *[]string) *ListUnspentCmd {
+	return &ListUnspentCmd{
+		MinConf:   minConf,
+		MaxConf:   maxConf,
+		Addresses: addresses,
+	}
+}
+
+// LockUnspentCmd defines the lockunspent JSON-RPC command.
+type LockUnspentCmd struct {
+	Unlock       bool
+	Transactions []dcrjson.TransactionInput
+}
+
+// NewLockUnspentCmd returns a new instance which can be used to issue a
+// lockunspent JSON-RPC command.
+func NewLockUnspentCmd(unlock bool, transactions []dcrjson.TransactionInput) *LockUnspentCmd {
+	return &LockUnspentCmd{
+		Unlock:       unlock,
+		Transactions: transactions,
+	}
+}
+
+// PurchaseTicketCmd is a type handling custom marshaling and
+// unmarshaling of purchaseticket JSON RPC commands.
+type PurchaseTicketCmd struct {
+	FromAccount   string
+	SpendLimit    float64 // In Coins
+	MinConf       *int    `jsonrpcdefault:"1"`
+	TicketAddress *string
+	NumTickets    *int
+	PoolAddress   *string
+	PoolFees      *float64
+	Expiry        *int
+	Comment       *string
+	TicketFee     *float64
+}
+
+// NewPurchaseTicketCmd creates a new PurchaseTicketCmd.
+func NewPurchaseTicketCmd(fromAccount string, spendLimit float64, minConf *int,
+	ticketAddress *string, numTickets *int, poolAddress *string, poolFees *float64,
+	expiry *int, comment *string, ticketFee *float64) *PurchaseTicketCmd {
+	return &PurchaseTicketCmd{
+		FromAccount:   fromAccount,
+		SpendLimit:    spendLimit,
+		MinConf:       minConf,
+		TicketAddress: ticketAddress,
+		NumTickets:    numTickets,
+		PoolAddress:   poolAddress,
+		PoolFees:      poolFees,
+		Expiry:        expiry,
+		Comment:       comment,
+		TicketFee:     ticketFee,
+	}
+}
+
+// RedeemMultiSigOutCmd is a type handling custom marshaling and
+// unmarshaling of redeemmultisigout JSON RPC commands.
+type RedeemMultiSigOutCmd struct {
+	Hash    string
+	Index   uint32
+	Tree    int8
+	Address *string
+}
+
+// NewRedeemMultiSigOutCmd creates a new RedeemMultiSigOutCmd.
+func NewRedeemMultiSigOutCmd(hash string, index uint32, tree int8,
+	address *string) *RedeemMultiSigOutCmd {
+	return &RedeemMultiSigOutCmd{
+		Hash:    hash,
+		Index:   index,
+		Tree:    tree,
+		Address: address,
+	}
+}
+
+// RedeemMultiSigOutsCmd is a type handling custom marshaling and
+// unmarshaling of redeemmultisigout JSON RPC commands.
+type RedeemMultiSigOutsCmd struct {
+	FromScrAddress string
+	ToAddress      *string
+	Number         *int
+}
+
+// NewRedeemMultiSigOutsCmd creates a new RedeemMultiSigOutsCmd.
+func NewRedeemMultiSigOutsCmd(from string, to *string,
+	number *int) *RedeemMultiSigOutsCmd {
+	return &RedeemMultiSigOutsCmd{
+		FromScrAddress: from,
+		ToAddress:      to,
+		Number:         number,
+	}
+}
+
+// RenameAccountCmd defines the renameaccount JSON-RPC command.
+type RenameAccountCmd struct {
+	OldAccount string
+	NewAccount string
+}
+
+// NewRenameAccountCmd returns a new instance which can be used to issue a
+// renameaccount JSON-RPC command.
+func NewRenameAccountCmd(oldAccount, newAccount string) *RenameAccountCmd {
+	return &RenameAccountCmd{
+		OldAccount: oldAccount,
+		NewAccount: newAccount,
+	}
+}
+
+// RescanWalletCmd describes the rescanwallet JSON-RPC request and parameters.
+type RescanWalletCmd struct {
+	BeginHeight *int `jsonrpcdefault:"0"`
+}
+
+// RevokeTicketsCmd describes the revoketickets JSON-RPC request and parameters.
+type RevokeTicketsCmd struct {
+}
+
+// NewRevokeTicketsCmd creates a new RevokeTicketsCmd.
+func NewRevokeTicketsCmd() *RevokeTicketsCmd {
+	return &RevokeTicketsCmd{}
+}
+
+// SendFromCmd defines the sendfrom JSON-RPC command.
+type SendFromCmd struct {
+	FromAccount string
+	ToAddress   string
+	Amount      float64 // In DCR
+	MinConf     *int    `jsonrpcdefault:"1"`
+	Comment     *string
+	CommentTo   *string
+}
+
+// NewSendFromCmd returns a new instance which can be used to issue a sendfrom
+// JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewSendFromCmd(fromAccount, toAddress string, amount float64, minConf *int, comment, commentTo *string) *SendFromCmd {
+	return &SendFromCmd{
+		FromAccount: fromAccount,
+		ToAddress:   toAddress,
+		Amount:      amount,
+		MinConf:     minConf,
+		Comment:     comment,
+		CommentTo:   commentTo,
+	}
+}
+
+// SendManyCmd defines the sendmany JSON-RPC command.
+type SendManyCmd struct {
+	FromAccount string
+	Amounts     map[string]float64 `jsonrpcusage:"{\"address\":amount,...}"` // In DCR
+	MinConf     *int               `jsonrpcdefault:"1"`
+	Comment     *string
+}
+
+// NewSendManyCmd returns a new instance which can be used to issue a sendmany
+// JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewSendManyCmd(fromAccount string, amounts map[string]float64, minConf *int, comment *string) *SendManyCmd {
+	return &SendManyCmd{
+		FromAccount: fromAccount,
+		Amounts:     amounts,
+		MinConf:     minConf,
+		Comment:     comment,
+	}
+}
+
+// SendToAddressCmd defines the sendtoaddress JSON-RPC command.
+type SendToAddressCmd struct {
+	Address   string
+	Amount    float64
+	Comment   *string
+	CommentTo *string
+}
+
+// NewSendToAddressCmd returns a new instance which can be used to issue a
+// sendtoaddress JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewSendToAddressCmd(address string, amount float64, comment, commentTo *string) *SendToAddressCmd {
+	return &SendToAddressCmd{
+		Address:   address,
+		Amount:    amount,
+		Comment:   comment,
+		CommentTo: commentTo,
+	}
+}
+
+// SendToMultiSigCmd is a type handling custom marshaling and
+// unmarshaling of sendtomultisig JSON RPC commands.
+type SendToMultiSigCmd struct {
+	FromAccount string
+	Amount      float64
+	Pubkeys     []string
+	NRequired   *int `jsonrpcdefault:"1"`
+	MinConf     *int `jsonrpcdefault:"1"`
+	Comment     *string
+}
+
+// NewSendToMultiSigCmd creates a new SendToMultiSigCmd.
+func NewSendToMultiSigCmd(fromaccount string, amount float64, pubkeys []string,
+	nrequired *int, minConf *int, comment *string) *SendToMultiSigCmd {
+	return &SendToMultiSigCmd{
+		FromAccount: fromaccount,
+		Amount:      amount,
+		Pubkeys:     pubkeys,
+		NRequired:   nrequired,
+		MinConf:     minConf,
+		Comment:     comment,
+	}
+}
+
+// SetTxFeeCmd defines the settxfee JSON-RPC command.
+type SetTxFeeCmd struct {
+	Amount float64 // In DCR
+}
+
+// NewSetTxFeeCmd returns a new instance which can be used to issue a settxfee
+// JSON-RPC command.
+func NewSetTxFeeCmd(amount float64) *SetTxFeeCmd {
+	return &SetTxFeeCmd{
+		Amount: amount,
+	}
+}
+
+// SetTicketFeeCmd is a type handling custom marshaling and
+// unmarshaling of setticketfee JSON RPC commands.
+type SetTicketFeeCmd struct {
+	Fee float64
+}
+
+// NewSetTicketFeeCmd creates a new instance of the setticketfee
+// command.
+func NewSetTicketFeeCmd(fee float64) *SetTicketFeeCmd {
+	return &SetTicketFeeCmd{
+		Fee: fee,
+	}
+}
+
+// SetVoteChoiceCmd defines the parameters to the setvotechoice method.
+type SetVoteChoiceCmd struct {
+	AgendaID string
+	ChoiceID string
+}
+
+// NewSetVoteChoiceCmd returns a new instance which can be used to issue a
+// setvotechoice JSON-RPC command.
+func NewSetVoteChoiceCmd(agendaID, choiceID string) *SetVoteChoiceCmd {
+	return &SetVoteChoiceCmd{AgendaID: agendaID, ChoiceID: choiceID}
+}
+
+// SignMessageCmd defines the signmessage JSON-RPC command.
+type SignMessageCmd struct {
+	Address string
+	Message string
+}
+
+// NewSignMessageCmd returns a new instance which can be used to issue a
+// signmessage JSON-RPC command.
+func NewSignMessageCmd(address, message string) *SignMessageCmd {
+	return &SignMessageCmd{
+		Address: address,
+		Message: message,
+	}
+}
+
+// RawTxInput models the data needed for raw transaction input that is used in
+// the SignRawTransactionCmd struct.  Contains Decred additions.
+type RawTxInput struct {
+	Txid         string `json:"txid"`
+	Vout         uint32 `json:"vout"`
+	Tree         int8   `json:"tree"`
+	ScriptPubKey string `json:"scriptPubKey"`
+	RedeemScript string `json:"redeemScript"`
+}
+
+// SignRawTransactionCmd defines the signrawtransaction JSON-RPC command.
+type SignRawTransactionCmd struct {
+	RawTx    string
+	Inputs   *[]RawTxInput
+	PrivKeys *[]string
+	Flags    *string `jsonrpcdefault:"\"ALL\""`
+}
+
+// NewSignRawTransactionCmd returns a new instance which can be used to issue a
+// signrawtransaction JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewSignRawTransactionCmd(hexEncodedTx string, inputs *[]RawTxInput, privKeys *[]string, flags *string) *SignRawTransactionCmd {
+	return &SignRawTransactionCmd{
+		RawTx:    hexEncodedTx,
+		Inputs:   inputs,
+		PrivKeys: privKeys,
+		Flags:    flags,
+	}
+}
+
+// SignRawTransactionsCmd defines the signrawtransactions JSON-RPC command.
+type SignRawTransactionsCmd struct {
+	RawTxs []string
+	Send   *bool `jsonrpcdefault:"true"`
+}
+
+// NewSignRawTransactionsCmd returns a new instance which can be used to issue a
+// signrawtransactions JSON-RPC command.
+func NewSignRawTransactionsCmd(hexEncodedTxs []string,
+	send *bool) *SignRawTransactionsCmd {
+	return &SignRawTransactionsCmd{
+		RawTxs: hexEncodedTxs,
+		Send:   send,
+	}
+}
+
+// StakePoolUserInfoCmd defines the stakepooluserinfo JSON-RPC command.
+type StakePoolUserInfoCmd struct {
+	User string
+}
+
+// NewStakePoolUserInfoCmd returns a new instance which can be used to issue a
+// signrawtransactions JSON-RPC command.
+func NewStakePoolUserInfoCmd(user string) *StakePoolUserInfoCmd {
+	return &StakePoolUserInfoCmd{
+		User: user,
+	}
+}
+
+// StartAutoBuyerCmd is a type handling custom marshaling and
+// unmarshaling of startautobuyer JSON RPC commands.
+type StartAutoBuyerCmd struct {
+	Account           string
+	Passphrase        string
+	BalanceToMaintain *int64
+	MaxFeePerKb       *int64
+	MaxPriceRelative  *float64
+	MaxPriceAbsolute  *int64
+	VotingAddress     *string
+	PoolAddress       *string
+	PoolFees          *float64
+	MaxPerBlock       *int64
+}
+
+// NewStartAutoBuyerCmd creates a new StartAutoBuyerCmd.
+func NewStartAutoBuyerCmd(account string, passphrase string, balanceToMaintain *int64, maxFeePerKb *int64, maxPriceRelative *float64, maxPriceAbsolute *int64, votingAddress *string, poolAddress *string, poolFees *float64,
+	maxPerBlock *int64) *StartAutoBuyerCmd {
+	return &StartAutoBuyerCmd{
+		Account:           account,
+		Passphrase:        passphrase,
+		BalanceToMaintain: balanceToMaintain,
+		MaxFeePerKb:       maxFeePerKb,
+		MaxPriceRelative:  maxPriceRelative,
+		MaxPriceAbsolute:  maxPriceAbsolute,
+		VotingAddress:     votingAddress,
+		PoolAddress:       poolAddress,
+		PoolFees:          poolFees,
+		MaxPerBlock:       maxPerBlock,
+	}
+}
+
+// StopAutoBuyerCmd is a type handling custom marshaling and
+// unmarshaling of stopautobuyer JSON RPC commands.
+type StopAutoBuyerCmd struct {
+}
+
+// NewStopAutoBuyerCmd creates a new StopAutoBuyerCmd.
+func NewStopAutoBuyerCmd() *StopAutoBuyerCmd {
+	return &StopAutoBuyerCmd{}
+}
+
+// SweepAccountCmd defines the sweep account JSON-RPC command.
+type SweepAccountCmd struct {
+	SourceAccount         string
+	DestinationAddress    string
+	RequiredConfirmations *uint32
+	FeePerKb              *float64
+}
+
+// NewSweepAccountCmd returns a new instance which can be used to issue a JSON-RPC SweepAccountCmd command.
+func NewSweepAccountCmd(sourceAccount string, destinationAddress string, requiredConfs *uint32, feePerKb *float64) *SweepAccountCmd {
+	return &SweepAccountCmd{
+		SourceAccount:         sourceAccount,
+		DestinationAddress:    destinationAddress,
+		RequiredConfirmations: requiredConfs,
+		FeePerKb:              feePerKb,
+	}
+}
+
+// VerifySeedCmd defines the verifyseed JSON-RPC command.
+type VerifySeedCmd struct {
+	Seed    string
+	Account *uint32
+}
+
+// NewVerifySeedCmd returns a new instance which can be used to issue a
+// walletlock JSON-RPC command.
+//
+// The parameters which are pointers indicate that they are optional. Passing
+// nil for the optional parameters will use the default value.
+func NewVerifySeedCmd(seed string, account *uint32) *VerifySeedCmd {
+	return &VerifySeedCmd{
+		Seed:    seed,
+		Account: account,
+	}
+}
+
+// WalletInfoCmd defines the walletinfo JSON-RPC command.
+type WalletInfoCmd struct {
+}
+
+// NewWalletInfoCmd returns a new instance which can be used to issue a
+// walletinfo JSON-RPC command.
+func NewWalletInfoCmd() *WalletInfoCmd {
+	return &WalletInfoCmd{}
+}
+
+// WalletLockCmd defines the walletlock JSON-RPC command.
+type WalletLockCmd struct{}
+
+// NewWalletLockCmd returns a new instance which can be used to issue a
+// walletlock JSON-RPC command.
+func NewWalletLockCmd() *WalletLockCmd {
+	return &WalletLockCmd{}
+}
+
+// WalletPassphraseCmd defines the walletpassphrase JSON-RPC command.
+type WalletPassphraseCmd struct {
+	Passphrase string
+	Timeout    int64
+}
+
+// NewWalletPassphraseCmd returns a new instance which can be used to issue a
+// walletpassphrase JSON-RPC command.
+func NewWalletPassphraseCmd(passphrase string, timeout int64) *WalletPassphraseCmd {
+	return &WalletPassphraseCmd{
+		Passphrase: passphrase,
+		Timeout:    timeout,
+	}
+}
+
+// WalletPassphraseChangeCmd defines the walletpassphrase JSON-RPC command.
+type WalletPassphraseChangeCmd struct {
+	OldPassphrase string
+	NewPassphrase string
+}
+
+// NewWalletPassphraseChangeCmd returns a new instance which can be used to
+// issue a walletpassphrasechange JSON-RPC command.
+func NewWalletPassphraseChangeCmd(oldPassphrase, newPassphrase string) *WalletPassphraseChangeCmd {
+	return &WalletPassphraseChangeCmd{
+		OldPassphrase: oldPassphrase,
+		NewPassphrase: newPassphrase,
+	}
+}
+
+func init() {
+	// The commands in this file are only usable with a wallet server.
+	flags := dcrjson.UFWalletOnly
+
+	dcrjson.MustRegisterCmd("accountaddressindex", (*AccountAddressIndexCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("accountsyncaddressindex", (*AccountSyncAddressIndexCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("addmultisigaddress", (*AddMultisigAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("addticket", (*AddTicketCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("consolidate", (*ConsolidateCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("createmultisig", (*CreateMultisigCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("createnewaccount", (*CreateNewAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("createvotingaccount", (*CreateVotingAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("dropvotingaccount", (*DropVotingAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("dumpprivkey", (*DumpPrivKeyCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("estimatepriority", (*EstimatePriorityCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("fundrawtransaction", (*FundRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("generatevote", (*GenerateVoteCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getaccount", (*GetAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getaccountaddress", (*GetAccountAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getaddressesbyaccount", (*GetAddressesByAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getbalance", (*GetBalanceCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getcontracthash", (*GetContractHashCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getmasterpubkey", (*GetMasterPubkeyCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getmultisigoutinfo", (*GetMultisigOutInfoCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getnewaddress", (*GetNewAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getpaytocontractaddress", (*GetPayToContractAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getrawchangeaddress", (*GetRawChangeAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getreceivedbyaccount", (*GetReceivedByAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getreceivedbyaddress", (*GetReceivedByAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getstakeinfo", (*GetStakeInfoCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getticketfee", (*GetTicketFeeCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("gettickets", (*GetTicketsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("gettransaction", (*GetTransactionCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getvotechoices", (*GetVoteChoicesCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getwalletfee", (*GetWalletFeeCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("importprivkey", (*ImportPrivKeyCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("importscript", (*ImportScriptCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("keypoolrefill", (*KeyPoolRefillCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listaccounts", (*ListAccountsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listlockunspent", (*ListLockUnspentCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listreceivedbyaccount", (*ListReceivedByAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listreceivedbyaddress", (*ListReceivedByAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listscripts", (*ListScriptsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listsinceblock", (*ListSinceBlockCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listtickets", (*ListTicketsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listtransactions", (*ListTransactionsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listunspent", (*ListUnspentCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("lockunspent", (*LockUnspentCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("purchaseticket", (*PurchaseTicketCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("redeemmultisigout", (*RedeemMultiSigOutCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("redeemmultisigouts", (*RedeemMultiSigOutsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("renameaccount", (*RenameAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("rescanwallet", (*RescanWalletCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("revoketickets", (*RevokeTicketsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("sendfrom", (*SendFromCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("sendmany", (*SendManyCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("sendtoaddress", (*SendToAddressCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("sendtomultisig", (*SendToMultiSigCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("settxfee", (*SetTxFeeCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("setticketfee", (*SetTicketFeeCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("setvotechoice", (*SetVoteChoiceCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("signmessage", (*SignMessageCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("signrawtransaction", (*SignRawTransactionCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("signrawtransactions", (*SignRawTransactionsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("stakepooluserinfo", (*StakePoolUserInfoCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("startautobuyer", (*StartAutoBuyerCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("stopautobuyer", (*StopAutoBuyerCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("sweepaccount", (*SweepAccountCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("verifyseed", (*VerifySeedCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("walletinfo", (*WalletInfoCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("walletlock", (*WalletLockCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("walletpassphrase", (*WalletPassphraseCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("walletpassphrasechange", (*WalletPassphraseChangeCmd)(nil), flags)
+}

--- a/rpc/jsonrpc/types/walletsvrcmds_test.go
+++ b/rpc/jsonrpc/types/walletsvrcmds_test.go
@@ -1,0 +1,1255 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+import "github.com/decred/dcrd/dcrjson/v2"
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// TestWalletSvrCmds tests all of the wallet server commands marshal and
+// unmarshal into valid results include handling of optional fields being
+// omitted in the marshalled command, while optional fields with defaults have
+// the default assigned on unmarshalled commands.
+func TestWalletSvrCmds(t *testing.T) {
+	t.Parallel()
+
+	testID := int(1)
+	tests := []struct {
+		name         string
+		newCmd       func() (interface{}, error)
+		staticCmd    func() interface{}
+		marshalled   string
+		unmarshalled interface{}
+	}{
+		{
+			name: "addmultisigaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("addmultisigaddress", 2, []string{"031234", "035678"})
+			},
+			staticCmd: func() interface{} {
+				keys := []string{"031234", "035678"}
+				return NewAddMultisigAddressCmd(2, keys, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"addmultisigaddress","params":[2,["031234","035678"]],"id":1}`,
+			unmarshalled: &AddMultisigAddressCmd{
+				NRequired: 2,
+				Keys:      []string{"031234", "035678"},
+				Account:   nil,
+			},
+		},
+		{
+			name: "addmultisigaddress optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("addmultisigaddress", 2, []string{"031234", "035678"}, "test")
+			},
+			staticCmd: func() interface{} {
+				keys := []string{"031234", "035678"}
+				return NewAddMultisigAddressCmd(2, keys, dcrjson.String("test"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"addmultisigaddress","params":[2,["031234","035678"],"test"],"id":1}`,
+			unmarshalled: &AddMultisigAddressCmd{
+				NRequired: 2,
+				Keys:      []string{"031234", "035678"},
+				Account:   dcrjson.String("test"),
+			},
+		},
+		{
+			name: "createmultisig",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("createmultisig", 2, []string{"031234", "035678"})
+			},
+			staticCmd: func() interface{} {
+				keys := []string{"031234", "035678"}
+				return NewCreateMultisigCmd(2, keys)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createmultisig","params":[2,["031234","035678"]],"id":1}`,
+			unmarshalled: &CreateMultisigCmd{
+				NRequired: 2,
+				Keys:      []string{"031234", "035678"},
+			},
+		},
+		{
+			name: "createnewaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("createnewaccount", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewCreateNewAccountCmd("acct")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createnewaccount","params":["acct"],"id":1}`,
+			unmarshalled: &CreateNewAccountCmd{
+				Account: "acct",
+			},
+		},
+		{
+			name: "dumpprivkey",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("dumpprivkey", "1Address")
+			},
+			staticCmd: func() interface{} {
+				return NewDumpPrivKeyCmd("1Address")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"dumpprivkey","params":["1Address"],"id":1}`,
+			unmarshalled: &DumpPrivKeyCmd{
+				Address: "1Address",
+			},
+		},
+		{
+			name: "estimatepriority",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("estimatepriority", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewEstimatePriorityCmd(6)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"estimatepriority","params":[6],"id":1}`,
+			unmarshalled: &EstimatePriorityCmd{
+				NumBlocks: 6,
+			},
+		},
+		{
+			name: "getaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getaccount", "1Address")
+			},
+			staticCmd: func() interface{} {
+				return NewGetAccountCmd("1Address")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getaccount","params":["1Address"],"id":1}`,
+			unmarshalled: &GetAccountCmd{
+				Address: "1Address",
+			},
+		},
+		{
+			name: "getaccountaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getaccountaddress", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetAccountAddressCmd("acct")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getaccountaddress","params":["acct"],"id":1}`,
+			unmarshalled: &GetAccountAddressCmd{
+				Account: "acct",
+			},
+		},
+		{
+			name: "getaddressesbyaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getaddressesbyaccount", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetAddressesByAccountCmd("acct")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getaddressesbyaccount","params":["acct"],"id":1}`,
+			unmarshalled: &GetAddressesByAccountCmd{
+				Account: "acct",
+			},
+		},
+		{
+			name: "getbalance",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getbalance")
+			},
+			staticCmd: func() interface{} {
+				return NewGetBalanceCmd(nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":[],"id":1}`,
+			unmarshalled: &GetBalanceCmd{
+				Account: nil,
+				MinConf: dcrjson.Int(1),
+			},
+		},
+		{
+			name: "getbalance optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getbalance", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetBalanceCmd(dcrjson.String("acct"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":["acct"],"id":1}`,
+			unmarshalled: &GetBalanceCmd{
+				Account: dcrjson.String("acct"),
+				MinConf: dcrjson.Int(1),
+			},
+		},
+		{
+			name: "getbalance optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getbalance", "acct", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewGetBalanceCmd(dcrjson.String("acct"), dcrjson.Int(6))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":["acct",6],"id":1}`,
+			unmarshalled: &GetBalanceCmd{
+				Account: dcrjson.String("acct"),
+				MinConf: dcrjson.Int(6),
+			},
+		},
+		{
+			name: "getnewaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getnewaddress")
+			},
+			staticCmd: func() interface{} {
+				return NewGetNewAddressCmd(nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":[],"id":1}`,
+			unmarshalled: &GetNewAddressCmd{
+				Account:   nil,
+				GapPolicy: nil,
+			},
+		},
+		{
+			name: "getnewaddress optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getnewaddress", "acct", "ignore")
+			},
+			staticCmd: func() interface{} {
+				return NewGetNewAddressCmd(dcrjson.String("acct"), dcrjson.String("ignore"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":["acct","ignore"],"id":1}`,
+			unmarshalled: &GetNewAddressCmd{
+				Account:   dcrjson.String("acct"),
+				GapPolicy: dcrjson.String("ignore"),
+			},
+		},
+		{
+			name: "getrawchangeaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getrawchangeaddress")
+			},
+			staticCmd: func() interface{} {
+				return NewGetRawChangeAddressCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":[],"id":1}`,
+			unmarshalled: &GetRawChangeAddressCmd{
+				Account: nil,
+			},
+		},
+		{
+			name: "getrawchangeaddress optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getrawchangeaddress", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetRawChangeAddressCmd(dcrjson.String("acct"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":["acct"],"id":1}`,
+			unmarshalled: &GetRawChangeAddressCmd{
+				Account: dcrjson.String("acct"),
+			},
+		},
+		{
+			name: "getreceivedbyaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getreceivedbyaccount", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetReceivedByAccountCmd("acct", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaccount","params":["acct"],"id":1}`,
+			unmarshalled: &GetReceivedByAccountCmd{
+				Account: "acct",
+				MinConf: dcrjson.Int(1),
+			},
+		},
+		{
+			name: "getreceivedbyaccount optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getreceivedbyaccount", "acct", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewGetReceivedByAccountCmd("acct", dcrjson.Int(6))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaccount","params":["acct",6],"id":1}`,
+			unmarshalled: &GetReceivedByAccountCmd{
+				Account: "acct",
+				MinConf: dcrjson.Int(6),
+			},
+		},
+		{
+			name: "getreceivedbyaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getreceivedbyaddress", "1Address")
+			},
+			staticCmd: func() interface{} {
+				return NewGetReceivedByAddressCmd("1Address", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaddress","params":["1Address"],"id":1}`,
+			unmarshalled: &GetReceivedByAddressCmd{
+				Address: "1Address",
+				MinConf: dcrjson.Int(1),
+			},
+		},
+		{
+			name: "getreceivedbyaddress optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getreceivedbyaddress", "1Address", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewGetReceivedByAddressCmd("1Address", dcrjson.Int(6))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getreceivedbyaddress","params":["1Address",6],"id":1}`,
+			unmarshalled: &GetReceivedByAddressCmd{
+				Address: "1Address",
+				MinConf: dcrjson.Int(6),
+			},
+		},
+		{
+			name: "gettransaction",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("gettransaction", "123")
+			},
+			staticCmd: func() interface{} {
+				return NewGetTransactionCmd("123", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"gettransaction","params":["123"],"id":1}`,
+			unmarshalled: &GetTransactionCmd{
+				Txid:             "123",
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "gettransaction optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("gettransaction", "123", true)
+			},
+			staticCmd: func() interface{} {
+				return NewGetTransactionCmd("123", dcrjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"gettransaction","params":["123",true],"id":1}`,
+			unmarshalled: &GetTransactionCmd{
+				Txid:             "123",
+				IncludeWatchOnly: dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "importprivkey",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("importprivkey", "abc")
+			},
+			staticCmd: func() interface{} {
+				return NewImportPrivKeyCmd("abc", nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"importprivkey","params":["abc"],"id":1}`,
+			unmarshalled: &ImportPrivKeyCmd{
+				PrivKey: "abc",
+				Label:   nil,
+				Rescan:  dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "importprivkey optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("importprivkey", "abc", "label")
+			},
+			staticCmd: func() interface{} {
+				return NewImportPrivKeyCmd("abc", dcrjson.String("label"), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"importprivkey","params":["abc","label"],"id":1}`,
+			unmarshalled: &ImportPrivKeyCmd{
+				PrivKey: "abc",
+				Label:   dcrjson.String("label"),
+				Rescan:  dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "importprivkey optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("importprivkey", "abc", "label", false)
+			},
+			staticCmd: func() interface{} {
+				return NewImportPrivKeyCmd("abc", dcrjson.String("label"), dcrjson.Bool(false), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"importprivkey","params":["abc","label",false],"id":1}`,
+			unmarshalled: &ImportPrivKeyCmd{
+				PrivKey: "abc",
+				Label:   dcrjson.String("label"),
+				Rescan:  dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "importprivkey optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("importprivkey", "abc", "label", false, 12345)
+			},
+			staticCmd: func() interface{} {
+				return NewImportPrivKeyCmd("abc", dcrjson.String("label"), dcrjson.Bool(false), dcrjson.Int(12345))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"importprivkey","params":["abc","label",false,12345],"id":1}`,
+			unmarshalled: &ImportPrivKeyCmd{
+				PrivKey:  "abc",
+				Label:    dcrjson.String("label"),
+				Rescan:   dcrjson.Bool(false),
+				ScanFrom: dcrjson.Int(12345),
+			},
+		},
+		{
+			name: "keypoolrefill",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("keypoolrefill")
+			},
+			staticCmd: func() interface{} {
+				return NewKeyPoolRefillCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"keypoolrefill","params":[],"id":1}`,
+			unmarshalled: &KeyPoolRefillCmd{
+				NewSize: dcrjson.Uint(100),
+			},
+		},
+		{
+			name: "keypoolrefill optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("keypoolrefill", 200)
+			},
+			staticCmd: func() interface{} {
+				return NewKeyPoolRefillCmd(dcrjson.Uint(200))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"keypoolrefill","params":[200],"id":1}`,
+			unmarshalled: &KeyPoolRefillCmd{
+				NewSize: dcrjson.Uint(200),
+			},
+		},
+		{
+			name: "listaccounts",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listaccounts")
+			},
+			staticCmd: func() interface{} {
+				return NewListAccountsCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listaccounts","params":[],"id":1}`,
+			unmarshalled: &ListAccountsCmd{
+				MinConf: dcrjson.Int(1),
+			},
+		},
+		{
+			name: "listaccounts optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listaccounts", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewListAccountsCmd(dcrjson.Int(6))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listaccounts","params":[6],"id":1}`,
+			unmarshalled: &ListAccountsCmd{
+				MinConf: dcrjson.Int(6),
+			},
+		},
+		{
+			name: "listlockunspent",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listlockunspent")
+			},
+			staticCmd: func() interface{} {
+				return NewListLockUnspentCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"listlockunspent","params":[],"id":1}`,
+			unmarshalled: &ListLockUnspentCmd{},
+		},
+		{
+			name: "listreceivedbyaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaccount")
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAccountCmd(nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaccount","params":[],"id":1}`,
+			unmarshalled: &ListReceivedByAccountCmd{
+				MinConf:          dcrjson.Int(1),
+				IncludeEmpty:     dcrjson.Bool(false),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaccount optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaccount", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAccountCmd(dcrjson.Int(6), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaccount","params":[6],"id":1}`,
+			unmarshalled: &ListReceivedByAccountCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(false),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaccount optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaccount", 6, true)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAccountCmd(dcrjson.Int(6), dcrjson.Bool(true), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaccount","params":[6,true],"id":1}`,
+			unmarshalled: &ListReceivedByAccountCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(true),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaccount optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaccount", 6, true, false)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAccountCmd(dcrjson.Int(6), dcrjson.Bool(true), dcrjson.Bool(false))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaccount","params":[6,true,false],"id":1}`,
+			unmarshalled: &ListReceivedByAccountCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(true),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaddress")
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAddressCmd(nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaddress","params":[],"id":1}`,
+			unmarshalled: &ListReceivedByAddressCmd{
+				MinConf:          dcrjson.Int(1),
+				IncludeEmpty:     dcrjson.Bool(false),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaddress optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaddress", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAddressCmd(dcrjson.Int(6), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaddress","params":[6],"id":1}`,
+			unmarshalled: &ListReceivedByAddressCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(false),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaddress optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaddress", 6, true)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAddressCmd(dcrjson.Int(6), dcrjson.Bool(true), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaddress","params":[6,true],"id":1}`,
+			unmarshalled: &ListReceivedByAddressCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(true),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listreceivedbyaddress optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listreceivedbyaddress", 6, true, false)
+			},
+			staticCmd: func() interface{} {
+				return NewListReceivedByAddressCmd(dcrjson.Int(6), dcrjson.Bool(true), dcrjson.Bool(false))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listreceivedbyaddress","params":[6,true,false],"id":1}`,
+			unmarshalled: &ListReceivedByAddressCmd{
+				MinConf:          dcrjson.Int(6),
+				IncludeEmpty:     dcrjson.Bool(true),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listsinceblock",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listsinceblock")
+			},
+			staticCmd: func() interface{} {
+				return NewListSinceBlockCmd(nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listsinceblock","params":[],"id":1}`,
+			unmarshalled: &ListSinceBlockCmd{
+				BlockHash:           nil,
+				TargetConfirmations: dcrjson.Int(1),
+				IncludeWatchOnly:    dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listsinceblock optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listsinceblock", "123")
+			},
+			staticCmd: func() interface{} {
+				return NewListSinceBlockCmd(dcrjson.String("123"), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listsinceblock","params":["123"],"id":1}`,
+			unmarshalled: &ListSinceBlockCmd{
+				BlockHash:           dcrjson.String("123"),
+				TargetConfirmations: dcrjson.Int(1),
+				IncludeWatchOnly:    dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listsinceblock optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listsinceblock", "123", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewListSinceBlockCmd(dcrjson.String("123"), dcrjson.Int(6), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listsinceblock","params":["123",6],"id":1}`,
+			unmarshalled: &ListSinceBlockCmd{
+				BlockHash:           dcrjson.String("123"),
+				TargetConfirmations: dcrjson.Int(6),
+				IncludeWatchOnly:    dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listsinceblock optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listsinceblock", "123", 6, true)
+			},
+			staticCmd: func() interface{} {
+				return NewListSinceBlockCmd(dcrjson.String("123"), dcrjson.Int(6), dcrjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listsinceblock","params":["123",6,true],"id":1}`,
+			unmarshalled: &ListSinceBlockCmd{
+				BlockHash:           dcrjson.String("123"),
+				TargetConfirmations: dcrjson.Int(6),
+				IncludeWatchOnly:    dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "listtransactions",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listtransactions")
+			},
+			staticCmd: func() interface{} {
+				return NewListTransactionsCmd(nil, nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":[],"id":1}`,
+			unmarshalled: &ListTransactionsCmd{
+				Account:          nil,
+				Count:            dcrjson.Int(10),
+				From:             dcrjson.Int(0),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listtransactions optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listtransactions", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewListTransactionsCmd(dcrjson.String("acct"), nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":["acct"],"id":1}`,
+			unmarshalled: &ListTransactionsCmd{
+				Account:          dcrjson.String("acct"),
+				Count:            dcrjson.Int(10),
+				From:             dcrjson.Int(0),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listtransactions optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listtransactions", "acct", 20)
+			},
+			staticCmd: func() interface{} {
+				return NewListTransactionsCmd(dcrjson.String("acct"), dcrjson.Int(20), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":["acct",20],"id":1}`,
+			unmarshalled: &ListTransactionsCmd{
+				Account:          dcrjson.String("acct"),
+				Count:            dcrjson.Int(20),
+				From:             dcrjson.Int(0),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listtransactions optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listtransactions", "acct", 20, 1)
+			},
+			staticCmd: func() interface{} {
+				return NewListTransactionsCmd(dcrjson.String("acct"), dcrjson.Int(20),
+					dcrjson.Int(1), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":["acct",20,1],"id":1}`,
+			unmarshalled: &ListTransactionsCmd{
+				Account:          dcrjson.String("acct"),
+				Count:            dcrjson.Int(20),
+				From:             dcrjson.Int(1),
+				IncludeWatchOnly: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "listtransactions optional4",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listtransactions", "acct", 20, 1, true)
+			},
+			staticCmd: func() interface{} {
+				return NewListTransactionsCmd(dcrjson.String("acct"), dcrjson.Int(20),
+					dcrjson.Int(1), dcrjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listtransactions","params":["acct",20,1,true],"id":1}`,
+			unmarshalled: &ListTransactionsCmd{
+				Account:          dcrjson.String("acct"),
+				Count:            dcrjson.Int(20),
+				From:             dcrjson.Int(1),
+				IncludeWatchOnly: dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "listunspent",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listunspent")
+			},
+			staticCmd: func() interface{} {
+				return NewListUnspentCmd(nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listunspent","params":[],"id":1}`,
+			unmarshalled: &ListUnspentCmd{
+				MinConf:   dcrjson.Int(1),
+				MaxConf:   dcrjson.Int(9999999),
+				Addresses: nil,
+			},
+		},
+		{
+			name: "listunspent optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listunspent", 6)
+			},
+			staticCmd: func() interface{} {
+				return NewListUnspentCmd(dcrjson.Int(6), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listunspent","params":[6],"id":1}`,
+			unmarshalled: &ListUnspentCmd{
+				MinConf:   dcrjson.Int(6),
+				MaxConf:   dcrjson.Int(9999999),
+				Addresses: nil,
+			},
+		},
+		{
+			name: "listunspent optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listunspent", 6, 100)
+			},
+			staticCmd: func() interface{} {
+				return NewListUnspentCmd(dcrjson.Int(6), dcrjson.Int(100), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listunspent","params":[6,100],"id":1}`,
+			unmarshalled: &ListUnspentCmd{
+				MinConf:   dcrjson.Int(6),
+				MaxConf:   dcrjson.Int(100),
+				Addresses: nil,
+			},
+		},
+		{
+			name: "listunspent optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listunspent", 6, 100, []string{"1Address", "1Address2"})
+			},
+			staticCmd: func() interface{} {
+				return NewListUnspentCmd(dcrjson.Int(6), dcrjson.Int(100),
+					&[]string{"1Address", "1Address2"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listunspent","params":[6,100,["1Address","1Address2"]],"id":1}`,
+			unmarshalled: &ListUnspentCmd{
+				MinConf:   dcrjson.Int(6),
+				MaxConf:   dcrjson.Int(100),
+				Addresses: &[]string{"1Address", "1Address2"},
+			},
+		},
+		{
+			name: "lockunspent",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("lockunspent", true, `[{"txid":"123","vout":1}]`)
+			},
+			staticCmd: func() interface{} {
+				txInputs := []dcrjson.TransactionInput{
+					{Txid: "123", Vout: 1},
+				}
+				return NewLockUnspentCmd(true, txInputs)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"lockunspent","params":[true,[{"txid":"123","vout":1,"tree":0}]],"id":1}`,
+			unmarshalled: &LockUnspentCmd{
+				Unlock: true,
+				Transactions: []dcrjson.TransactionInput{
+					{Txid: "123", Vout: 1},
+				},
+			},
+		},
+		{
+			name: "renameaccount",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("renameaccount", "oldacct", "newacct")
+			},
+			staticCmd: func() interface{} {
+				return NewRenameAccountCmd("oldacct", "newacct")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"renameaccount","params":["oldacct","newacct"],"id":1}`,
+			unmarshalled: &RenameAccountCmd{
+				OldAccount: "oldacct",
+				NewAccount: "newacct",
+			},
+		},
+		{
+			name: "sendfrom",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendfrom", "from", "1Address", 0.5)
+			},
+			staticCmd: func() interface{} {
+				return NewSendFromCmd("from", "1Address", 0.5, nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5],"id":1}`,
+			unmarshalled: &SendFromCmd{
+				FromAccount: "from",
+				ToAddress:   "1Address",
+				Amount:      0.5,
+				MinConf:     dcrjson.Int(1),
+				Comment:     nil,
+				CommentTo:   nil,
+			},
+		},
+		{
+			name: "sendfrom optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6)
+			},
+			staticCmd: func() interface{} {
+				return NewSendFromCmd("from", "1Address", 0.5, dcrjson.Int(6), nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6],"id":1}`,
+			unmarshalled: &SendFromCmd{
+				FromAccount: "from",
+				ToAddress:   "1Address",
+				Amount:      0.5,
+				MinConf:     dcrjson.Int(6),
+				Comment:     nil,
+				CommentTo:   nil,
+			},
+		},
+		{
+			name: "sendfrom optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "comment")
+			},
+			staticCmd: func() interface{} {
+				return NewSendFromCmd("from", "1Address", 0.5, dcrjson.Int(6),
+					dcrjson.String("comment"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"comment"],"id":1}`,
+			unmarshalled: &SendFromCmd{
+				FromAccount: "from",
+				ToAddress:   "1Address",
+				Amount:      0.5,
+				MinConf:     dcrjson.Int(6),
+				Comment:     dcrjson.String("comment"),
+				CommentTo:   nil,
+			},
+		},
+		{
+			name: "sendfrom optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendfrom", "from", "1Address", 0.5, 6, "comment", "commentto")
+			},
+			staticCmd: func() interface{} {
+				return NewSendFromCmd("from", "1Address", 0.5, dcrjson.Int(6),
+					dcrjson.String("comment"), dcrjson.String("commentto"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendfrom","params":["from","1Address",0.5,6,"comment","commentto"],"id":1}`,
+			unmarshalled: &SendFromCmd{
+				FromAccount: "from",
+				ToAddress:   "1Address",
+				Amount:      0.5,
+				MinConf:     dcrjson.Int(6),
+				Comment:     dcrjson.String("comment"),
+				CommentTo:   dcrjson.String("commentto"),
+			},
+		},
+		{
+			name: "sendmany",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendmany", "from", `{"1Address":0.5}`)
+			},
+			staticCmd: func() interface{} {
+				amounts := map[string]float64{"1Address": 0.5}
+				return NewSendManyCmd("from", amounts, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5}],"id":1}`,
+			unmarshalled: &SendManyCmd{
+				FromAccount: "from",
+				Amounts:     map[string]float64{"1Address": 0.5},
+				MinConf:     dcrjson.Int(1),
+				Comment:     nil,
+			},
+		},
+		{
+			name: "sendmany optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendmany", "from", `{"1Address":0.5}`, 6)
+			},
+			staticCmd: func() interface{} {
+				amounts := map[string]float64{"1Address": 0.5}
+				return NewSendManyCmd("from", amounts, dcrjson.Int(6), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6],"id":1}`,
+			unmarshalled: &SendManyCmd{
+				FromAccount: "from",
+				Amounts:     map[string]float64{"1Address": 0.5},
+				MinConf:     dcrjson.Int(6),
+				Comment:     nil,
+			},
+		},
+		{
+			name: "sendmany optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendmany", "from", `{"1Address":0.5}`, 6, "comment")
+			},
+			staticCmd: func() interface{} {
+				amounts := map[string]float64{"1Address": 0.5}
+				return NewSendManyCmd("from", amounts, dcrjson.Int(6), dcrjson.String("comment"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendmany","params":["from",{"1Address":0.5},6,"comment"],"id":1}`,
+			unmarshalled: &SendManyCmd{
+				FromAccount: "from",
+				Amounts:     map[string]float64{"1Address": 0.5},
+				MinConf:     dcrjson.Int(6),
+				Comment:     dcrjson.String("comment"),
+			},
+		},
+		{
+			name: "sendtoaddress",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendtoaddress", "1Address", 0.5)
+			},
+			staticCmd: func() interface{} {
+				return NewSendToAddressCmd("1Address", 0.5, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5],"id":1}`,
+			unmarshalled: &SendToAddressCmd{
+				Address:   "1Address",
+				Amount:    0.5,
+				Comment:   nil,
+				CommentTo: nil,
+			},
+		},
+		{
+			name: "sendtoaddress optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sendtoaddress", "1Address", 0.5, "comment", "commentto")
+			},
+			staticCmd: func() interface{} {
+				return NewSendToAddressCmd("1Address", 0.5, dcrjson.String("comment"),
+					dcrjson.String("commentto"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sendtoaddress","params":["1Address",0.5,"comment","commentto"],"id":1}`,
+			unmarshalled: &SendToAddressCmd{
+				Address:   "1Address",
+				Amount:    0.5,
+				Comment:   dcrjson.String("comment"),
+				CommentTo: dcrjson.String("commentto"),
+			},
+		},
+		{
+			name: "settxfee",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("settxfee", 0.0001)
+			},
+			staticCmd: func() interface{} {
+				return NewSetTxFeeCmd(0.0001)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"settxfee","params":[0.0001],"id":1}`,
+			unmarshalled: &SetTxFeeCmd{
+				Amount: 0.0001,
+			},
+		},
+		{
+			name: "signmessage",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("signmessage", "1Address", "message")
+			},
+			staticCmd: func() interface{} {
+				return NewSignMessageCmd("1Address", "message")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signmessage","params":["1Address","message"],"id":1}`,
+			unmarshalled: &SignMessageCmd{
+				Address: "1Address",
+				Message: "message",
+			},
+		},
+		{
+			name: "signrawtransaction",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("signrawtransaction", "001122")
+			},
+			staticCmd: func() interface{} {
+				return NewSignRawTransactionCmd("001122", nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122"],"id":1}`,
+			unmarshalled: &SignRawTransactionCmd{
+				RawTx:    "001122",
+				Inputs:   nil,
+				PrivKeys: nil,
+				Flags:    dcrjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransaction optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("signrawtransaction", "001122", `[{"txid":"123","vout":1,"tree":0,"scriptPubKey":"00","redeemScript":"01"}]`)
+			},
+			staticCmd: func() interface{} {
+				txInputs := []RawTxInput{
+					{
+						Txid:         "123",
+						Vout:         1,
+						ScriptPubKey: "00",
+						RedeemScript: "01",
+					},
+				}
+
+				return NewSignRawTransactionCmd("001122", &txInputs, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122",[{"txid":"123","vout":1,"tree":0,"scriptPubKey":"00","redeemScript":"01"}]],"id":1}`,
+			unmarshalled: &SignRawTransactionCmd{
+				RawTx: "001122",
+				Inputs: &[]RawTxInput{
+					{
+						Txid:         "123",
+						Vout:         1,
+						ScriptPubKey: "00",
+						RedeemScript: "01",
+					},
+				},
+				PrivKeys: nil,
+				Flags:    dcrjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransaction optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("signrawtransaction", "001122", `[]`, `["abc"]`)
+			},
+			staticCmd: func() interface{} {
+				txInputs := []RawTxInput{}
+				privKeys := []string{"abc"}
+				return NewSignRawTransactionCmd("001122", &txInputs, &privKeys, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122",[],["abc"]],"id":1}`,
+			unmarshalled: &SignRawTransactionCmd{
+				RawTx:    "001122",
+				Inputs:   &[]RawTxInput{},
+				PrivKeys: &[]string{"abc"},
+				Flags:    dcrjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransaction optional3",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("signrawtransaction", "001122", `[]`, `[]`, "ALL")
+			},
+			staticCmd: func() interface{} {
+				txInputs := []RawTxInput{}
+				privKeys := []string{}
+				return NewSignRawTransactionCmd("001122", &txInputs, &privKeys,
+					dcrjson.String("ALL"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransaction","params":["001122",[],[],"ALL"],"id":1}`,
+			unmarshalled: &SignRawTransactionCmd{
+				RawTx:    "001122",
+				Inputs:   &[]RawTxInput{},
+				PrivKeys: &[]string{},
+				Flags:    dcrjson.String("ALL"),
+			},
+		},
+		{
+			name: "sweepaccount - optionals provided",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sweepaccount", "default", "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu", 6, 0.05)
+			},
+			staticCmd: func() interface{} {
+				return NewSweepAccountCmd("default", "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+					func(i uint32) *uint32 { return &i }(6),
+					func(i float64) *float64 { return &i }(0.05))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sweepaccount","params":["default","DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",6,0.05],"id":1}`,
+			unmarshalled: &SweepAccountCmd{
+				SourceAccount:         "default",
+				DestinationAddress:    "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+				RequiredConfirmations: func(i uint32) *uint32 { return &i }(6),
+				FeePerKb:              func(i float64) *float64 { return &i }(0.05),
+			},
+		},
+		{
+			name: "sweepaccount - optionals omitted",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("sweepaccount", "default", "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu")
+			},
+			staticCmd: func() interface{} {
+				return NewSweepAccountCmd("default", "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu", nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"sweepaccount","params":["default","DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu"],"id":1}`,
+			unmarshalled: &SweepAccountCmd{
+				SourceAccount:      "default",
+				DestinationAddress: "DsUZxxoHJSty8DCfwfartwTYbuhmVct7tJu",
+			},
+		},
+		{
+			name: "verifyseed",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("verifyseed", "abc")
+			},
+			staticCmd: func() interface{} {
+				return NewVerifySeedCmd("abc", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"verifyseed","params":["abc"],"id":1}`,
+			unmarshalled: &VerifySeedCmd{
+				Seed:    "abc",
+				Account: nil,
+			},
+		},
+		{
+			name: "verifyseed optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("verifyseed", "abc", 5)
+			},
+			staticCmd: func() interface{} {
+				account := dcrjson.Uint32(5)
+				return NewVerifySeedCmd("abc", account)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"verifyseed","params":["abc",5],"id":1}`,
+			unmarshalled: &VerifySeedCmd{
+				Seed:    "abc",
+				Account: dcrjson.Uint32(5),
+			},
+		},
+		{
+			name: "walletlock",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("walletlock")
+			},
+			staticCmd: func() interface{} {
+				return NewWalletLockCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"walletlock","params":[],"id":1}`,
+			unmarshalled: &WalletLockCmd{},
+		},
+		{
+			name: "walletpassphrase",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("walletpassphrase", "pass", 60)
+			},
+			staticCmd: func() interface{} {
+				return NewWalletPassphraseCmd("pass", 60)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"walletpassphrase","params":["pass",60],"id":1}`,
+			unmarshalled: &WalletPassphraseCmd{
+				Passphrase: "pass",
+				Timeout:    60,
+			},
+		},
+		{
+			name: "walletpassphrasechange",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("walletpassphrasechange", "old", "new")
+			},
+			staticCmd: func() interface{} {
+				return NewWalletPassphraseChangeCmd("old", "new")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"walletpassphrasechange","params":["old","new"],"id":1}`,
+			unmarshalled: &WalletPassphraseChangeCmd{
+				OldPassphrase: "old",
+				NewPassphrase: "new",
+			},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Marshal the command as created by the new static command
+		// creation function.
+		marshalled, err := dcrjson.MarshalCmd("1.0", testID, test.staticCmd())
+		if err != nil {
+			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		// Ensure the command is created without error via the generic
+		// new command creation function.
+		cmd, err := test.newCmd()
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected dcrjson.NewCmd error: %v ",
+				i, test.name, err)
+		}
+
+		// Marshal the command as created by the generic new command
+		// creation function.
+		marshalled, err = dcrjson.MarshalCmd("1.0", testID, cmd)
+		if err != nil {
+			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		var request dcrjson.Request
+		if err := json.Unmarshal(marshalled, &request); err != nil {
+			t.Errorf("Test #%d (%s) unexpected error while "+
+				"unmarshalling JSON-RPC request: %v", i,
+				test.name, err)
+			continue
+		}
+
+		cmd, err = dcrjson.UnmarshalCmd(&request)
+		if err != nil {
+			t.Errorf("UnmarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(cmd, test.unmarshalled) {
+			t.Errorf("Test #%d (%s) unexpected unmarshalled command "+
+				"- got %s, want %s", i, test.name,
+				fmt.Sprintf("(%T) %+[1]v", cmd),
+				fmt.Sprintf("(%T) %+[1]v\n", test.unmarshalled))
+			continue
+		}
+	}
+}

--- a/rpc/jsonrpc/types/walletsvrresults.go
+++ b/rpc/jsonrpc/types/walletsvrresults.go
@@ -1,0 +1,421 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+// FundRawTransactionResult models the data from the fundrawtransaction command.
+type FundRawTransactionResult struct {
+	Hex string  `json:"hex"`
+	Fee float64 `json:"fee"`
+}
+
+// GenerateVoteResult models the data from the generatevote command.
+type GenerateVoteResult struct {
+	Hex string `json:"hex"`
+}
+
+// GetAccountBalanceResult models the account data from the getbalance command.
+type GetAccountBalanceResult struct {
+	AccountName             string  `json:"accountname"`
+	ImmatureCoinbaseRewards float64 `json:"immaturecoinbaserewards"`
+	ImmatureStakeGeneration float64 `json:"immaturestakegeneration"`
+	LockedByTickets         float64 `json:"lockedbytickets"`
+	Spendable               float64 `json:"spendable"`
+	Total                   float64 `json:"total"`
+	Unconfirmed             float64 `json:"unconfirmed"`
+	VotingAuthority         float64 `json:"votingauthority"`
+}
+
+// GetBalanceResult models the data from the getbalance command.
+type GetBalanceResult struct {
+	Balances                     []GetAccountBalanceResult `json:"balances"`
+	BlockHash                    string                    `json:"blockhash"`
+	TotalImmatureCoinbaseRewards float64                   `json:"totalimmaturecoinbaserewards,omitempty"`
+	TotalImmatureStakeGeneration float64                   `json:"totalimmaturestakegeneration,omitempty"`
+	TotalLockedByTickets         float64                   `json:"totallockedbytickets,omitempty"`
+	TotalSpendable               float64                   `json:"totalspendable,omitempty"`
+	CumulativeTotal              float64                   `json:"cumulativetotal,omitempty"`
+	TotalUnconfirmed             float64                   `json:"totalunconfirmed,omitempty"`
+	TotalVotingAuthority         float64                   `json:"totalvotingauthority,omitempty"`
+}
+
+// GetContractHashResult models the data from the getcontracthash command.
+type GetContractHashResult struct {
+	ContractHash string `json:"contracthash"`
+}
+
+// GetMultisigOutInfoResult models the data returned from the getmultisigoutinfo
+// command.
+type GetMultisigOutInfoResult struct {
+	Address      string   `json:"address"`
+	RedeemScript string   `json:"redeemscript"`
+	M            uint8    `json:"m"`
+	N            uint8    `json:"n"`
+	Pubkeys      []string `json:"pubkeys"`
+	TxHash       string   `json:"txhash"`
+	BlockHeight  uint32   `json:"blockheight"`
+	BlockHash    string   `json:"blockhash"`
+	Spent        bool     `json:"spent"`
+	SpentBy      string   `json:"spentby"`
+	SpentByIndex uint32   `json:"spentbyindex"`
+	Amount       float64  `json:"amount"`
+}
+
+// GetPayToContractHashResult models the data returned from the getpaytocontracthash
+// command.
+type GetPayToContractHashResult struct {
+	Address string `json:"address"`
+}
+
+// GetStakeInfoResult models the data returned from the getstakeinfo
+// command.
+type GetStakeInfoResult struct {
+	BlockHeight  int64   `json:"blockheight"`
+	Difficulty   float64 `json:"difficulty"`
+	TotalSubsidy float64 `json:"totalsubsidy"`
+
+	OwnMempoolTix  uint32 `json:"ownmempooltix"`
+	Immature       uint32 `json:"immature"`
+	Unspent        uint32 `json:"unspent"`
+	Voted          uint32 `json:"voted"`
+	Revoked        uint32 `json:"revoked"`
+	UnspentExpired uint32 `json:"unspentexpired"`
+
+	// Not available to SPV wallets
+	PoolSize         uint32  `json:"poolsize,omitempty"`
+	AllMempoolTix    uint32  `json:"allmempooltix,omitempty"`
+	Live             uint32  `json:"live,omitempty"`
+	ProportionLive   float64 `json:"proportionlive,omitempty"`
+	Missed           uint32  `json:"missed,omitempty"`
+	ProportionMissed float64 `json:"proportionmissed,omitempty"`
+	Expired          uint32  `json:"expired,omitempty"`
+}
+
+// GetTicketsResult models the data returned from the gettickets
+// command.
+type GetTicketsResult struct {
+	Hashes []string `json:"hashes"`
+}
+
+// GetTransactionDetailsResult models the details data from the gettransaction command.
+//
+// This models the "short" version of the ListTransactionsResult type, which
+// excludes fields common to the transaction.  These common fields are instead
+// part of the GetTransactionResult.
+type GetTransactionDetailsResult struct {
+	Account           string   `json:"account"`
+	Address           string   `json:"address,omitempty"`
+	Amount            float64  `json:"amount"`
+	Category          string   `json:"category"`
+	InvolvesWatchOnly bool     `json:"involveswatchonly,omitempty"`
+	Fee               *float64 `json:"fee,omitempty"`
+	Vout              uint32   `json:"vout"`
+}
+
+// GetTransactionResult models the data from the gettransaction command.
+type GetTransactionResult struct {
+	Amount          float64                       `json:"amount"`
+	Fee             float64                       `json:"fee,omitempty"`
+	Confirmations   int64                         `json:"confirmations"`
+	BlockHash       string                        `json:"blockhash"`
+	BlockIndex      int64                         `json:"blockindex"`
+	BlockTime       int64                         `json:"blocktime"`
+	TxID            string                        `json:"txid"`
+	WalletConflicts []string                      `json:"walletconflicts"`
+	Time            int64                         `json:"time"`
+	TimeReceived    int64                         `json:"timereceived"`
+	Details         []GetTransactionDetailsResult `json:"details"`
+	Hex             string                        `json:"hex"`
+	Type            string                        `json:"type"`
+	TicketStatus    string                        `json:"ticketstatus,omitempty"`
+}
+
+// VoteChoice models the data for a vote choice in the getvotechoices result.
+type VoteChoice struct {
+	AgendaID          string `json:"agendaid"`
+	AgendaDescription string `json:"agendadescription"`
+	ChoiceID          string `json:"choiceid"`
+	ChoiceDescription string `json:"choicedescription"`
+}
+
+// GetVoteChoicesResult models the data returned by the getvotechoices command.
+type GetVoteChoicesResult struct {
+	Version uint32       `json:"version"`
+	Choices []VoteChoice `json:"choices"`
+}
+
+// InfoWalletResult models the data returned by the wallet server getinfo
+// command.
+type InfoWalletResult struct {
+	Version         int32   `json:"version"`
+	ProtocolVersion int32   `json:"protocolversion"`
+	WalletVersion   int32   `json:"walletversion"`
+	Balance         float64 `json:"balance"`
+	Blocks          int32   `json:"blocks"`
+	TimeOffset      int64   `json:"timeoffset"`
+	Connections     int32   `json:"connections"`
+	Proxy           string  `json:"proxy"`
+	Difficulty      float64 `json:"difficulty"`
+	TestNet         bool    `json:"testnet"`
+	KeypoolOldest   int64   `json:"keypoololdest"`
+	KeypoolSize     int32   `json:"keypoolsize"`
+	UnlockedUntil   int64   `json:"unlocked_until"`
+	PaytxFee        float64 `json:"paytxfee"`
+	RelayFee        float64 `json:"relayfee"`
+	Errors          string  `json:"errors"`
+}
+
+// ScriptInfo is the structure representing a redeem script, its hash,
+// and its address.
+type ScriptInfo struct {
+	Hash160      string `json:"hash160"`
+	Address      string `json:"address"`
+	RedeemScript string `json:"redeemscript"`
+}
+
+// ListScriptsResult models the data returned from the listscripts
+// command.
+type ListScriptsResult struct {
+	Scripts []ScriptInfo `json:"scripts"`
+}
+
+// ListTicketsTransactionSummaryInput defines the type used in the listtickets JSON-RPC
+// result for the MyInputs field of Ticket and Spender command field.
+type ListTicketsTransactionSummaryInput struct {
+	Index           uint32  `json:"index"`
+	PreviousAccount string  `json:"previousaccount"`
+	PreviousAmount  float64 `json:"previousamount"`
+}
+
+// ListTicketsTransactionSummaryOutput defines the type used in the listtickets JSON-RPC
+// result for the MyOutputs field of Ticket and Spender command field.
+type ListTicketsTransactionSummaryOutput struct {
+	Index        uint32  `json:"index"`
+	Account      string  `json:"account"`
+	Internal     bool    `json:"internal"`
+	Amount       float64 `json:"amount"`
+	Address      string  `json:"address"`
+	OutputScript string  `json:"outputscript"`
+}
+
+// ListTicketsTransactionSummary defines the type used in the listtickets JSON-RPC
+// result for the Ticket and Spender command fields.
+type ListTicketsTransactionSummary struct {
+	Hash        string                                `json:"hash"`
+	Transaction string                                `json:"transaction"`
+	MyInputs    []ListTicketsTransactionSummaryInput  `json:"myinputs"`
+	MyOutputs   []ListTicketsTransactionSummaryOutput `json:"myoutputs"`
+	Fee         float64                               `json:"fee"`
+	Timestamp   int64                                 `json:"timestamp"`
+	Type        string                                `json:"type"`
+}
+
+// ListTicketsResult models the data from the listtickets command.
+type ListTicketsResult struct {
+	Ticket  *ListTicketsTransactionSummary `json:"ticket"`
+	Spender *ListTicketsTransactionSummary `json:"spender"`
+	Status  string                         `json:"status"`
+}
+
+// ListTransactionsTxType defines the type used in the listtransactions JSON-RPC
+// result for the TxType command field.
+type ListTransactionsTxType string
+
+const (
+	// LTTTRegular indicates a regular transaction.
+	LTTTRegular ListTransactionsTxType = "regular"
+
+	// LTTTTicket indicates a ticket.
+	LTTTTicket ListTransactionsTxType = "ticket"
+
+	// LTTTVote indicates a vote.
+	LTTTVote ListTransactionsTxType = "vote"
+
+	// LTTTRevocation indicates a revocation.
+	LTTTRevocation ListTransactionsTxType = "revocation"
+)
+
+// ListTransactionsResult models the data from the listtransactions command.
+type ListTransactionsResult struct {
+	Account           string                  `json:"account"`
+	Address           string                  `json:"address,omitempty"`
+	Amount            float64                 `json:"amount"`
+	BlockHash         string                  `json:"blockhash,omitempty"`
+	BlockIndex        *int64                  `json:"blockindex,omitempty"`
+	BlockTime         int64                   `json:"blocktime,omitempty"`
+	Category          string                  `json:"category"`
+	Confirmations     int64                   `json:"confirmations"`
+	Fee               *float64                `json:"fee,omitempty"`
+	Generated         bool                    `json:"generated,omitempty"`
+	InvolvesWatchOnly bool                    `json:"involveswatchonly,omitempty"`
+	Time              int64                   `json:"time"`
+	TimeReceived      int64                   `json:"timereceived"`
+	TxID              string                  `json:"txid"`
+	TxType            *ListTransactionsTxType `json:"txtype,omitempty"`
+	Vout              uint32                  `json:"vout"`
+	WalletConflicts   []string                `json:"walletconflicts"`
+	Comment           string                  `json:"comment,omitempty"`
+	OtherAccount      string                  `json:"otheraccount,omitempty"`
+}
+
+// ListReceivedByAccountResult models the data from the listreceivedbyaccount
+// command.
+type ListReceivedByAccountResult struct {
+	Account       string  `json:"account"`
+	Amount        float64 `json:"amount"`
+	Confirmations uint64  `json:"confirmations"`
+}
+
+// ListReceivedByAddressResult models the data from the listreceivedbyaddress
+// command.
+type ListReceivedByAddressResult struct {
+	Account           string   `json:"account"`
+	Address           string   `json:"address"`
+	Amount            float64  `json:"amount"`
+	Confirmations     uint64   `json:"confirmations"`
+	TxIDs             []string `json:"txids,omitempty"`
+	InvolvesWatchonly bool     `json:"involvesWatchonly,omitempty"`
+}
+
+// ListSinceBlockResult models the data from the listsinceblock command.
+type ListSinceBlockResult struct {
+	Transactions []ListTransactionsResult `json:"transactions"`
+	LastBlock    string                   `json:"lastblock"`
+}
+
+// ListUnspentResult models a successful response from the listunspent request.
+// Contains Decred additions.
+type ListUnspentResult struct {
+	TxID          string  `json:"txid"`
+	Vout          uint32  `json:"vout"`
+	Tree          int8    `json:"tree"`
+	TxType        int     `json:"txtype"`
+	Address       string  `json:"address"`
+	Account       string  `json:"account"`
+	ScriptPubKey  string  `json:"scriptPubKey"`
+	RedeemScript  string  `json:"redeemScript,omitempty"`
+	Amount        float64 `json:"amount"`
+	Confirmations int64   `json:"confirmations"`
+	Spendable     bool    `json:"spendable"`
+}
+
+// RedeemMultiSigOutResult models the data returned from the redeemmultisigout
+// command.
+type RedeemMultiSigOutResult struct {
+	Hex      string                    `json:"hex"`
+	Complete bool                      `json:"complete"`
+	Errors   []SignRawTransactionError `json:"errors,omitempty"`
+}
+
+// RedeemMultiSigOutsResult models the data returned from the redeemmultisigouts
+// command.
+type RedeemMultiSigOutsResult struct {
+	Results []RedeemMultiSigOutResult `json:"results"`
+}
+
+// SendToMultiSigResult models the data returned from the sendtomultisig
+// command.
+type SendToMultiSigResult struct {
+	TxHash       string `json:"txhash"`
+	Address      string `json:"address"`
+	RedeemScript string `json:"redeemscript"`
+}
+
+// SignRawTransactionError models the data that contains script verification
+// errors from the signrawtransaction request.
+type SignRawTransactionError struct {
+	TxID      string `json:"txid"`
+	Vout      uint32 `json:"vout"`
+	ScriptSig string `json:"scriptSig"`
+	Sequence  uint32 `json:"sequence"`
+	Error     string `json:"error"`
+}
+
+// SignRawTransactionResult models the data from the signrawtransaction
+// command.
+type SignRawTransactionResult struct {
+	Hex      string                    `json:"hex"`
+	Complete bool                      `json:"complete"`
+	Errors   []SignRawTransactionError `json:"errors,omitempty"`
+}
+
+// SignedTransaction is a signed transaction resulting from a signrawtransactions
+// command.
+type SignedTransaction struct {
+	SigningResult SignRawTransactionResult `json:"signingresult"`
+	Sent          bool                     `json:"sent"`
+	TxHash        *string                  `json:"txhash,omitempty"`
+}
+
+// SignRawTransactionsResult models the data returned from the signrawtransactions
+// command.
+type SignRawTransactionsResult struct {
+	Results []SignedTransaction `json:"results"`
+}
+
+// PoolUserTicket is the JSON struct corresponding to a stake pool user ticket
+// object.
+type PoolUserTicket struct {
+	Status        string `json:"status"`
+	Ticket        string `json:"ticket"`
+	TicketHeight  uint32 `json:"ticketheight"`
+	SpentBy       string `json:"spentby"`
+	SpentByHeight uint32 `json:"spentbyheight"`
+}
+
+// StakePoolUserInfoResult models the data returned from the stakepooluserinfo
+// command.
+type StakePoolUserInfoResult struct {
+	Tickets        []PoolUserTicket `json:"tickets"`
+	InvalidTickets []string         `json:"invalid"`
+}
+
+// SweepAccountResult models the data returned from the sweepaccount
+// command.
+type SweepAccountResult struct {
+	UnsignedTransaction       string  `json:"unsignedtransaction"`
+	TotalPreviousOutputAmount float64 `json:"totalpreviousoutputamount"`
+	TotalOutputAmount         float64 `json:"totaloutputamount"`
+	EstimatedSignedSize       uint32  `json:"estimatedsignedsize"`
+}
+
+// ValidateAddressWalletResult models the data returned by the wallet server
+// validateaddress command.
+type ValidateAddressWalletResult struct {
+	IsValid      bool     `json:"isvalid"`
+	Address      string   `json:"address,omitempty"`
+	IsMine       bool     `json:"ismine,omitempty"`
+	IsWatchOnly  bool     `json:"iswatchonly,omitempty"`
+	IsScript     bool     `json:"isscript,omitempty"`
+	PubKeyAddr   string   `json:"pubkeyaddr,omitempty"`
+	PubKey       string   `json:"pubkey,omitempty"`
+	IsCompressed bool     `json:"iscompressed,omitempty"`
+	Account      string   `json:"account,omitempty"`
+	Addresses    []string `json:"addresses,omitempty"`
+	Hex          string   `json:"hex,omitempty"`
+	Script       string   `json:"script,omitempty"`
+	SigsRequired int32    `json:"sigsrequired,omitempty"`
+}
+
+// VerifySeedResult models the data returned by the wallet server verify
+// seed command.
+type VerifySeedResult struct {
+	Result   bool   `json:"keyresult"`
+	CoinType uint32 `json:"cointype"`
+}
+
+// WalletInfoResult models the data returned from the walletinfo command.
+type WalletInfoResult struct {
+	DaemonConnected  bool    `json:"daemonconnected"`
+	Unlocked         bool    `json:"unlocked"`
+	CoinType         uint32  `json:"cointype,omitempty"`
+	TxFee            float64 `json:"txfee"`
+	TicketFee        float64 `json:"ticketfee"`
+	TicketPurchasing bool    `json:"ticketpurchasing"`
+	VoteBits         uint16  `json:"votebits"`
+	VoteBitsExtended string  `json:"votebitsextended"`
+	VoteVersion      uint32  `json:"voteversion"`
+	Voting           bool    `json:"voting"`
+}

--- a/rpc/jsonrpc/types/walletsvrwscmds.go
+++ b/rpc/jsonrpc/types/walletsvrwscmds.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+import "github.com/decred/dcrd/dcrjson/v2"
+
+// NOTE: This file is intended to house the RPC commands that are supported by
+// a wallet server, but are only available via websockets.
+
+// CreateEncryptedWalletCmd defines the createencryptedwallet JSON-RPC command.
+type CreateEncryptedWalletCmd struct {
+	Passphrase string
+}
+
+// NewCreateEncryptedWalletCmd returns a new instance which can be used to issue
+// a createencryptedwallet JSON-RPC command.
+func NewCreateEncryptedWalletCmd(passphrase string) *CreateEncryptedWalletCmd {
+	return &CreateEncryptedWalletCmd{
+		Passphrase: passphrase,
+	}
+}
+
+// ExportWatchingWalletCmd defines the exportwatchingwallet JSON-RPC command.
+type ExportWatchingWalletCmd struct {
+	Account  *string
+	Download *bool `jsonrpcdefault:"false"`
+}
+
+// NewExportWatchingWalletCmd returns a new instance which can be used to issue
+// a exportwatchingwallet JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewExportWatchingWalletCmd(account *string, download *bool) *ExportWatchingWalletCmd {
+	return &ExportWatchingWalletCmd{
+		Account:  account,
+		Download: download,
+	}
+}
+
+// GetUnconfirmedBalanceCmd defines the getunconfirmedbalance JSON-RPC command.
+type GetUnconfirmedBalanceCmd struct {
+	Account *string
+}
+
+// NewGetUnconfirmedBalanceCmd returns a new instance which can be used to issue
+// a getunconfirmedbalance JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetUnconfirmedBalanceCmd(account *string) *GetUnconfirmedBalanceCmd {
+	return &GetUnconfirmedBalanceCmd{
+		Account: account,
+	}
+}
+
+// ListAddressTransactionsCmd defines the listaddresstransactions JSON-RPC
+// command.
+type ListAddressTransactionsCmd struct {
+	Addresses []string
+	Account   *string
+}
+
+// NewListAddressTransactionsCmd returns a new instance which can be used to
+// issue a listaddresstransactions JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListAddressTransactionsCmd(addresses []string, account *string) *ListAddressTransactionsCmd {
+	return &ListAddressTransactionsCmd{
+		Addresses: addresses,
+		Account:   account,
+	}
+}
+
+// ListAllTransactionsCmd defines the listalltransactions JSON-RPC command.
+type ListAllTransactionsCmd struct {
+	Account *string
+}
+
+// NewListAllTransactionsCmd returns a new instance which can be used to issue a
+// listalltransactions JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewListAllTransactionsCmd(account *string) *ListAllTransactionsCmd {
+	return &ListAllTransactionsCmd{
+		Account: account,
+	}
+}
+
+// RecoverAddressesCmd defines the recoveraddresses JSON-RPC command.
+type RecoverAddressesCmd struct {
+	Account string
+	N       int
+}
+
+// NewRecoverAddressesCmd returns a new instance which can be used to issue a
+// recoveraddresses JSON-RPC command.
+func NewRecoverAddressesCmd(account string, n int) *RecoverAddressesCmd {
+	return &RecoverAddressesCmd{
+		Account: account,
+		N:       n,
+	}
+}
+
+// WalletIsLockedCmd defines the walletislocked JSON-RPC command.
+type WalletIsLockedCmd struct{}
+
+// NewWalletIsLockedCmd returns a new instance which can be used to issue a
+// walletislocked JSON-RPC command.
+func NewWalletIsLockedCmd() *WalletIsLockedCmd {
+	return &WalletIsLockedCmd{}
+}
+
+func init() {
+	// The commands in this file are only usable with a wallet server via
+	// websockets.
+	flags := dcrjson.UFWalletOnly | dcrjson.UFWebsocketOnly
+
+	dcrjson.MustRegisterCmd("createencryptedwallet", (*CreateEncryptedWalletCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("exportwatchingwallet", (*ExportWatchingWalletCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("getunconfirmedbalance", (*GetUnconfirmedBalanceCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listaddresstransactions", (*ListAddressTransactionsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("listalltransactions", (*ListAllTransactionsCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("recoveraddresses", (*RecoverAddressesCmd)(nil), flags)
+	dcrjson.MustRegisterCmd("walletislocked", (*WalletIsLockedCmd)(nil), flags)
+}

--- a/rpc/jsonrpc/types/walletsvrwscmds_test.go
+++ b/rpc/jsonrpc/types/walletsvrwscmds_test.go
@@ -1,0 +1,260 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/dcrjson/v2"
+)
+
+// TestWalletSvrWsCmds tests all of the wallet server websocket-specific
+// commands marshal and unmarshal into valid results include handling of
+// optional fields being omitted in the marshalled command, while optional
+// fields with defaults have the default assigned on unmarshalled commands.
+func TestWalletSvrWsCmds(t *testing.T) {
+	t.Parallel()
+
+	testID := int(1)
+	tests := []struct {
+		name         string
+		newCmd       func() (interface{}, error)
+		staticCmd    func() interface{}
+		marshalled   string
+		unmarshalled interface{}
+	}{
+		{
+			name: "createencryptedwallet",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("createencryptedwallet", "pass")
+			},
+			staticCmd: func() interface{} {
+				return NewCreateEncryptedWalletCmd("pass")
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"createencryptedwallet","params":["pass"],"id":1}`,
+			unmarshalled: &CreateEncryptedWalletCmd{Passphrase: "pass"},
+		},
+		{
+			name: "exportwatchingwallet",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("exportwatchingwallet")
+			},
+			staticCmd: func() interface{} {
+				return NewExportWatchingWalletCmd(nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"exportwatchingwallet","params":[],"id":1}`,
+			unmarshalled: &ExportWatchingWalletCmd{
+				Account:  nil,
+				Download: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "exportwatchingwallet optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("exportwatchingwallet", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewExportWatchingWalletCmd(dcrjson.String("acct"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"exportwatchingwallet","params":["acct"],"id":1}`,
+			unmarshalled: &ExportWatchingWalletCmd{
+				Account:  dcrjson.String("acct"),
+				Download: dcrjson.Bool(false),
+			},
+		},
+		{
+			name: "exportwatchingwallet optional2",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("exportwatchingwallet", "acct", true)
+			},
+			staticCmd: func() interface{} {
+				return NewExportWatchingWalletCmd(dcrjson.String("acct"),
+					dcrjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"exportwatchingwallet","params":["acct",true],"id":1}`,
+			unmarshalled: &ExportWatchingWalletCmd{
+				Account:  dcrjson.String("acct"),
+				Download: dcrjson.Bool(true),
+			},
+		},
+		{
+			name: "getunconfirmedbalance",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getunconfirmedbalance")
+			},
+			staticCmd: func() interface{} {
+				return NewGetUnconfirmedBalanceCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getunconfirmedbalance","params":[],"id":1}`,
+			unmarshalled: &GetUnconfirmedBalanceCmd{
+				Account: nil,
+			},
+		},
+		{
+			name: "getunconfirmedbalance optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("getunconfirmedbalance", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewGetUnconfirmedBalanceCmd(dcrjson.String("acct"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getunconfirmedbalance","params":["acct"],"id":1}`,
+			unmarshalled: &GetUnconfirmedBalanceCmd{
+				Account: dcrjson.String("acct"),
+			},
+		},
+		{
+			name: "listaddresstransactions",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listaddresstransactions", `["1Address"]`)
+			},
+			staticCmd: func() interface{} {
+				return NewListAddressTransactionsCmd([]string{"1Address"}, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listaddresstransactions","params":[["1Address"]],"id":1}`,
+			unmarshalled: &ListAddressTransactionsCmd{
+				Addresses: []string{"1Address"},
+				Account:   nil,
+			},
+		},
+		{
+			name: "listaddresstransactions optional1",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listaddresstransactions", `["1Address"]`, "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewListAddressTransactionsCmd([]string{"1Address"},
+					dcrjson.String("acct"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listaddresstransactions","params":[["1Address"],"acct"],"id":1}`,
+			unmarshalled: &ListAddressTransactionsCmd{
+				Addresses: []string{"1Address"},
+				Account:   dcrjson.String("acct"),
+			},
+		},
+		{
+			name: "listalltransactions",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listalltransactions")
+			},
+			staticCmd: func() interface{} {
+				return NewListAllTransactionsCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listalltransactions","params":[],"id":1}`,
+			unmarshalled: &ListAllTransactionsCmd{
+				Account: nil,
+			},
+		},
+		{
+			name: "listalltransactions optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("listalltransactions", "acct")
+			},
+			staticCmd: func() interface{} {
+				return NewListAllTransactionsCmd(dcrjson.String("acct"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"listalltransactions","params":["acct"],"id":1}`,
+			unmarshalled: &ListAllTransactionsCmd{
+				Account: dcrjson.String("acct"),
+			},
+		},
+		{
+			name: "recoveraddresses",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("recoveraddresses", "acct", 10)
+			},
+			staticCmd: func() interface{} {
+				return NewRecoverAddressesCmd("acct", 10)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"recoveraddresses","params":["acct",10],"id":1}`,
+			unmarshalled: &RecoverAddressesCmd{
+				Account: "acct",
+				N:       10,
+			},
+		},
+		{
+			name: "walletislocked",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd("walletislocked")
+			},
+			staticCmd: func() interface{} {
+				return NewWalletIsLockedCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"walletislocked","params":[],"id":1}`,
+			unmarshalled: &WalletIsLockedCmd{},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Marshal the command as created by the new static command
+		// creation function.
+		marshalled, err := dcrjson.MarshalCmd("1.0", testID, test.staticCmd())
+		if err != nil {
+			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		// Ensure the command is created without error via the generic
+		// new command creation function.
+		cmd, err := test.newCmd()
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected NewCmd error: %v ",
+				i, test.name, err)
+		}
+
+		// Marshal the command as created by the generic new command
+		// creation function.
+		marshalled, err = dcrjson.MarshalCmd("1.0", testID, cmd)
+		if err != nil {
+			t.Errorf("MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		var request dcrjson.Request
+		if err := json.Unmarshal(marshalled, &request); err != nil {
+			t.Errorf("Test #%d (%s) unexpected error while "+
+				"unmarshalling JSON-RPC request: %v", i,
+				test.name, err)
+			continue
+		}
+
+		cmd, err = dcrjson.UnmarshalCmd(&request)
+		if err != nil {
+			t.Errorf("UnmarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(cmd, test.unmarshalled) {
+			t.Errorf("Test #%d (%s) unexpected unmarshalled command "+
+				"- got %s, want %s", i, test.name,
+				fmt.Sprintf("(%T) %+[1]v", cmd),
+				fmt.Sprintf("(%T) %+[1]v\n", test.unmarshalled))
+			continue
+		}
+	}
+}

--- a/rpc/jsonrpc/types/walletsvrwsntfns.go
+++ b/rpc/jsonrpc/types/walletsvrwsntfns.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// NOTE: This file is intended to house the RPC websocket notifications that are
+// supported by a wallet server.
+
+package types
+
+import "github.com/decred/dcrd/dcrjson/v2"
+
+const (
+	// AccountBalanceNtfnMethod is the method used for account balance
+	// notifications.
+	AccountBalanceNtfnMethod = "accountbalance"
+
+	// DcrdConnectedNtfnMethod is the method used for notifications when
+	// a wallet server is connected to a chain server.
+	DcrdConnectedNtfnMethod = "dcrdconnected"
+
+	// NewTicketsNtfnMethod is the method of the daemon
+	// newtickets notification.
+	NewTicketsNtfnMethod = "newtickets"
+
+	// NewTxNtfnMethod is the method used to notify that a wallet server has
+	// added a new transaction to the transaction store.
+	NewTxNtfnMethod = "newtx"
+
+	// RevocationCreatedNtfnMethod is the method of the dcrwallet
+	// revocationcreated notification.
+	RevocationCreatedNtfnMethod = "revocationcreated"
+
+	// TicketPurchasedNtfnMethod is the method of the dcrwallet
+	// ticketpurchased notification.
+	TicketPurchasedNtfnMethod = "ticketpurchased"
+
+	// VoteCreatedNtfnMethod is the method of the dcrwallet
+	// votecreated notification.
+	VoteCreatedNtfnMethod = "votecreated"
+
+	// WinningTicketsNtfnMethod is the method of the daemon
+	// winningtickets notification.
+	WinningTicketsNtfnMethod = "winningtickets"
+
+	// WalletLockStateNtfnMethod is the method used to notify the lock state
+	// of a wallet has changed.
+	WalletLockStateNtfnMethod = "walletlockstate"
+)
+
+// AccountBalanceNtfn defines the accountbalance JSON-RPC notification.
+type AccountBalanceNtfn struct {
+	Account   string
+	Balance   float64 // In DCR
+	Confirmed bool    // Whether Balance is confirmed or unconfirmed.
+}
+
+// NewAccountBalanceNtfn returns a new instance which can be used to issue an
+// accountbalance JSON-RPC notification.
+func NewAccountBalanceNtfn(account string, balance float64, confirmed bool) *AccountBalanceNtfn {
+	return &AccountBalanceNtfn{
+		Account:   account,
+		Balance:   balance,
+		Confirmed: confirmed,
+	}
+}
+
+// DcrdConnectedNtfn defines the dcrddconnected JSON-RPC notification.
+type DcrdConnectedNtfn struct {
+	Connected bool
+}
+
+// NewDcrdConnectedNtfn returns a new instance which can be used to issue a
+// dcrddconnected JSON-RPC notification.
+func NewDcrdConnectedNtfn(connected bool) *DcrdConnectedNtfn {
+	return &DcrdConnectedNtfn{
+		Connected: connected,
+	}
+}
+
+// NewTxNtfn defines the newtx JSON-RPC notification.
+type NewTxNtfn struct {
+	Account string
+	Details ListTransactionsResult
+}
+
+// NewNewTxNtfn returns a new instance which can be used to issue a newtx
+// JSON-RPC notification.
+func NewNewTxNtfn(account string, details ListTransactionsResult) *NewTxNtfn {
+	return &NewTxNtfn{
+		Account: account,
+		Details: details,
+	}
+}
+
+// TicketPurchasedNtfn is a type handling custom marshaling and
+// unmarshaling of ticketpurchased JSON websocket notifications.
+type TicketPurchasedNtfn struct {
+	TxHash string
+	Amount int64 // SStx only
+}
+
+// NewTicketPurchasedNtfn creates a new TicketPurchasedNtfn.
+func NewTicketPurchasedNtfn(txHash string, amount int64) *TicketPurchasedNtfn {
+	return &TicketPurchasedNtfn{
+		TxHash: txHash,
+		Amount: amount,
+	}
+}
+
+// RevocationCreatedNtfn is a type handling custom marshaling and
+// unmarshaling of ticketpurchased JSON websocket notifications.
+type RevocationCreatedNtfn struct {
+	TxHash string
+	SStxIn string
+}
+
+// NewRevocationCreatedNtfn creates a new RevocationCreatedNtfn.
+func NewRevocationCreatedNtfn(txHash string, sstxIn string) *RevocationCreatedNtfn {
+	return &RevocationCreatedNtfn{
+		TxHash: txHash,
+		SStxIn: sstxIn,
+	}
+}
+
+// VoteCreatedNtfn is a type handling custom marshaling and
+// unmarshaling of ticketpurchased JSON websocket notifications.
+type VoteCreatedNtfn struct {
+	TxHash    string
+	BlockHash string
+	Height    int32
+	SStxIn    string
+	VoteBits  uint16
+}
+
+// NewVoteCreatedNtfn creates a new VoteCreatedNtfn.
+func NewVoteCreatedNtfn(txHash string, blockHash string, height int32, sstxIn string, voteBits uint16) *VoteCreatedNtfn {
+	return &VoteCreatedNtfn{
+		TxHash:    txHash,
+		BlockHash: blockHash,
+		Height:    height,
+		SStxIn:    sstxIn,
+		VoteBits:  voteBits,
+	}
+}
+
+// WalletLockStateNtfn defines the walletlockstate JSON-RPC notification.
+type WalletLockStateNtfn struct {
+	Locked bool
+}
+
+// NewWalletLockStateNtfn returns a new instance which can be used to issue a
+// walletlockstate JSON-RPC notification.
+func NewWalletLockStateNtfn(locked bool) *WalletLockStateNtfn {
+	return &WalletLockStateNtfn{
+		Locked: locked,
+	}
+}
+
+func init() {
+	// The commands in this file are only usable with a wallet server via
+	// websockets and are notifications.
+	flags := dcrjson.UFWalletOnly | dcrjson.UFWebsocketOnly | dcrjson.UFNotification
+
+	dcrjson.MustRegisterCmd(AccountBalanceNtfnMethod, (*AccountBalanceNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(DcrdConnectedNtfnMethod, (*DcrdConnectedNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(NewTxNtfnMethod, (*NewTxNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(TicketPurchasedNtfnMethod, (*TicketPurchasedNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(RevocationCreatedNtfnMethod, (*RevocationCreatedNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(VoteCreatedNtfnMethod, (*VoteCreatedNtfn)(nil), flags)
+	dcrjson.MustRegisterCmd(WalletLockStateNtfnMethod, (*WalletLockStateNtfn)(nil), flags)
+}

--- a/rpc/jsonrpc/types/walletsvrwsntfns_test.go
+++ b/rpc/jsonrpc/types/walletsvrwsntfns_test.go
@@ -1,0 +1,227 @@
+// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2015-2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package types
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/decred/dcrd/dcrjson/v2"
+)
+
+// TestWalletSvrWsNtfns tests all of the chain server websocket-specific
+// notifications marshal and unmarshal into valid results include handling of
+// optional fields being omitted in the marshalled command, while optional
+// fields with defaults have the default assigned on unmarshalled commands.
+func TestWalletSvrWsNtfns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		newNtfn      func() (interface{}, error)
+		staticNtfn   func() interface{}
+		marshalled   string
+		unmarshalled interface{}
+	}{
+		{
+			name: "accountbalance",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("accountbalance", "acct", 1.25, true)
+			},
+			staticNtfn: func() interface{} {
+				return NewAccountBalanceNtfn("acct", 1.25, true)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"accountbalance","params":["acct",1.25,true],"id":null}`,
+			unmarshalled: &AccountBalanceNtfn{
+				Account:   "acct",
+				Balance:   1.25,
+				Confirmed: true,
+			},
+		},
+		{
+			name: "dcrdconnected",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("dcrdconnected", true)
+			},
+			staticNtfn: func() interface{} {
+				return NewDcrdConnectedNtfn(true)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"dcrdconnected","params":[true],"id":null}`,
+			unmarshalled: &DcrdConnectedNtfn{
+				Connected: true,
+			},
+		},
+		{
+			name: "newtx",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("newtx", "acct", `{"account":"acct","address":"1Address","category":"send","amount":1.5,"fee":0.0001,"confirmations":1,"txid":"456","walletconflicts":[],"time":12345678,"timereceived":12345876,"vout":789,"otheraccount":"otheracct"}`)
+			},
+			staticNtfn: func() interface{} {
+				result := ListTransactionsResult{
+					Account:         "acct",
+					Address:         "1Address",
+					Category:        "send",
+					Amount:          1.5,
+					Fee:             dcrjson.Float64(0.0001),
+					Confirmations:   1,
+					TxID:            "456",
+					WalletConflicts: []string{},
+					Time:            12345678,
+					TimeReceived:    12345876,
+					Vout:            789,
+					OtherAccount:    "otheracct",
+				}
+				return NewNewTxNtfn("acct", result)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"newtx","params":["acct",{"account":"acct","address":"1Address","amount":1.5,"category":"send","confirmations":1,"fee":0.0001,"time":12345678,"timereceived":12345876,"txid":"456","vout":789,"walletconflicts":[],"otheraccount":"otheracct"}],"id":null}`,
+			unmarshalled: &NewTxNtfn{
+				Account: "acct",
+				Details: ListTransactionsResult{
+					Account:         "acct",
+					Address:         "1Address",
+					Category:        "send",
+					Amount:          1.5,
+					Fee:             dcrjson.Float64(0.0001),
+					Confirmations:   1,
+					TxID:            "456",
+					WalletConflicts: []string{},
+					Time:            12345678,
+					TimeReceived:    12345876,
+					Vout:            789,
+					OtherAccount:    "otheracct",
+				},
+			},
+		},
+		{
+			name: "revocationcreated",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("revocationcreated", "123", "1234")
+			},
+			staticNtfn: func() interface{} {
+				return NewRevocationCreatedNtfn("123", "1234")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"revocationcreated","params":["123","1234"],"id":null}`,
+			unmarshalled: &RevocationCreatedNtfn{
+				TxHash: "123",
+				SStxIn: "1234",
+			},
+		},
+		{
+			name: "ticketpurchase",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("ticketpurchased", "123", 5)
+			},
+			staticNtfn: func() interface{} {
+				return NewTicketPurchasedNtfn("123", 5)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"ticketpurchased","params":["123",5],"id":null}`,
+			unmarshalled: &TicketPurchasedNtfn{
+				TxHash: "123",
+				Amount: 5,
+			},
+		},
+		{
+			name: "votecreated",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("votecreated", "123", "1234", 100, "12345", 1)
+			},
+			staticNtfn: func() interface{} {
+				return NewVoteCreatedNtfn("123", "1234", 100, "12345", 1)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"votecreated","params":["123","1234",100,"12345",1],"id":null}`,
+			unmarshalled: &VoteCreatedNtfn{
+				TxHash:    "123",
+				BlockHash: "1234",
+				Height:    100,
+				SStxIn:    "12345",
+				VoteBits:  1,
+			},
+		},
+		{
+			name: "walletlockstate",
+			newNtfn: func() (interface{}, error) {
+				return dcrjson.NewCmd("walletlockstate", true)
+			},
+			staticNtfn: func() interface{} {
+				return NewWalletLockStateNtfn(true)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"walletlockstate","params":[true],"id":null}`,
+			unmarshalled: &WalletLockStateNtfn{
+				Locked: true,
+			},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		// Marshal the notification as created by the new static
+		// creation function.  The ID is nil for notifications.
+		marshalled, err := dcrjson.MarshalCmd("1.0", nil, test.staticNtfn())
+		if err != nil {
+			t.Errorf("dcrjson.MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		// Ensure the notification is created without error via the
+		// generic new notification creation function.
+		cmd, err := test.newNtfn()
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected NewCmd error: %v ",
+				i, test.name, err)
+		}
+
+		// Marshal the notification as created by the generic new
+		// notification creation function.    The ID is nil for
+		// notifications.
+		marshalled, err = dcrjson.MarshalCmd("1.0", nil, cmd)
+		if err != nil {
+			t.Errorf("dcrjson.MarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !bytes.Equal(marshalled, []byte(test.marshalled)) {
+			t.Errorf("Test #%d (%s) unexpected marshalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.marshalled)
+			continue
+		}
+
+		var request dcrjson.Request
+		if err := json.Unmarshal(marshalled, &request); err != nil {
+			t.Errorf("Test #%d (%s) unexpected error while "+
+				"unmarshalling JSON-RPC request: %v", i,
+				test.name, err)
+			continue
+		}
+
+		cmd, err = dcrjson.UnmarshalCmd(&request)
+		if err != nil {
+			t.Errorf("dcrjson.dcrjson.UnmarshalCmd #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(cmd, test.unmarshalled) {
+			t.Errorf("Test #%d (%s) unexpected unmarshalled command "+
+				"- got %s, want %s", i, test.name,
+				fmt.Sprintf("(%T) %+[1]v", cmd),
+				fmt.Sprintf("(%T) %+[1]v\n", test.unmarshalled))
+			continue
+		}
+	}
+}


### PR DESCRIPTION
**This requires decred/dcrd#1607**.

~**DO NOT MERGE -- This currently contains an override in the `go.mod` to use the required pull request so CI will build.  It will need to be updated once the upstream PR is merged and tagged.**~

This moves all of the types specific to `dcrwallet` from the `dcrjson` module into a new module at `rpc/jsonrpc/types` so wallet is able to independently modify them as necessary without needing to submit the changes to `dcrd` directly or requiring new `dcrjson` tags.

It provides full package documentation and also ported all tests over so there is comprehensive test coverage.