### PR TITLE
Remove non-main module replacement that snuck in.

### DIFF
--- a/ticketbuyer/go.mod
+++ b/ticketbuyer/go.mod
@@ -7,5 +7,3 @@ require (
 	github.com/decred/dcrwallet/wallet/v2 v2.0.0
 	github.com/decred/slog v1.0.0
 )
-
-replace github.com/decred/dcrwallet/wallet/v2 => ../wallet


### PR DESCRIPTION
This was added during an attempt to perform both submodule major bumps and main
module updates in a single change.  The attempt failed and this replacement
should have been removed at that time.