### PR TITLE
Add go 1.11 directive to main module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/decred/dcrwallet
 
+go 1.11
+
 require (
 	github.com/decred/dcrd/addrmgr v1.0.2
 	github.com/decred/dcrd/blockchain v1.1.1


### PR DESCRIPTION
The go directive describes the minimum target Go version of the module.  If
building with an older version of Go than described by the module, a note will
be emitted if the build fails.