### PR TITLE
wallet: Ignore duplicate tx error when publishing

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -4316,17 +4317,33 @@ func (w *Wallet) PublishTransaction(tx *wire.MsgTx, serializedTx []byte, n Netwo
 	if err != nil {
 		// Return the error and purge relevant txs from the store only if the
 		// backend returns an error different than "already have transaction".
+		var isDuplicateTx bool
 
 		// Unwrap to access the underlying RPC error code.
+		innerErr := err
 		for {
-			if e, ok := err.(*errors.Error); ok && e.Err != nil {
-				err = e.Err
+			if e, ok := innerErr.(*dcrjson.RPCError); ok && e.Code == dcrjson.ErrRPCDuplicateTx {
+				// Found an RPCError in the error stack. Verify if the error is
+				// due to this exact same transaction already existing in the
+				// mempool, in which case we ignore it and don't purge the tx
+				// from the database.
+				//
+				// This is brittle, since it relies on checking the error
+				// message, but ErrRPCDuplicateTx can be returned in situations
+				// other than an exact copy of the tx already existing (such as
+				// the new tx being a double spend) and in such cases we _do_
+				// need to purge it.
+				dupeMsg := fmt.Sprintf("already have transaction %v",
+					tx.TxHash())
+				isDuplicateTx = strings.HasSuffix(e.Message, dupeMsg)
+				break
+			} else if e, ok := innerErr.(*errors.Error); ok && e.Err != nil {
+				innerErr = e.Err
 			} else {
 				break
 			}
 		}
-		rpcErr, ok := err.(*dcrjson.RPCError)
-		if !ok || rpcErr.Code != dcrjson.ErrRPCDuplicateTx {
+		if !isDuplicateTx {
 			if relevant {
 				if err := w.PurgeUnminedTransaction(&txHash); err != nil {
 					log.Warnf("Failed to purge added unmined transaction: %v", err)


### PR DESCRIPTION
This makes the wallet not purge unmined transactions when the underlying
error returned by the backend is a dcrjson error with ErrRPCDuplicateTx
code.

Previously, this caused wallets to purge an unmined transaction that was
republished or otherwise already existed in the network even though it
was still valid, and could cause the wallet to produce a double spend
transaction by marking the funds of the (now purged) tx as spendable.