### PR TITLE
Prevent ChainSwitch from erroring with NoPeers

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -193,7 +193,7 @@ func (w *Wallet) ChainSwitch(forest *SidechainForest, chain []*BlockNode, releva
 	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
 		return w.watchFutureAddresses(tx)
 	})
-	if err != nil {
+	if err != nil && !errors.Is(errors.NoPeers, err) {
 		return nil, err
 	}
 


### PR DESCRIPTION
ChainSwitch will attempt to watch for new addresses when the wallet is
associated with a network backend, but it should be successful in the case where
the wallet is offline or disconnected from the Decred network as well.