### PR TITLE
Add PurchaseTicketsContext for request-scoped ticket buying.

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -906,7 +906,7 @@ func makeTicket(params *chaincfg.Params, inputPool *extendedOutPoint, input *ext
 // wallet instance will be used.  Also, when the spend limit in the request is
 // greater than or equal to 0, tickets that cost more than that limit will
 // return an error that not enough funds are available.
-func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op, n NetworkBackend, req *purchaseTicketsRequest) ([]*chainhash.Hash, error) {
+func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op, n NetworkBackend, req *PurchaseTicketsRequest) ([]*chainhash.Hash, error) {
 	// Ensure the minimum number of required confirmations is positive.
 	if req.MinConf < 0 {
 		return nil, errors.E(op, errors.Invalid, "negative minconf")

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1156,6 +1156,8 @@ func (w *Wallet) CreateMultisigTx(account uint32, amount dcrutil.Amount, pubkeys
 
 // PurchaseTickets purchases tickets, returning the hashes of all ticket
 // purchase transactions.
+//
+// Deprecated: Use PurchaseTicketsContext for solo buying.
 func (w *Wallet) PurchaseTickets(minBalance, spendLimit dcrutil.Amount, minConf int32, votingAddr dcrutil.Address, account uint32, count int, poolAddress dcrutil.Address,
 	poolFees float64, expiry int32, txFee dcrutil.Amount, ticketFee dcrutil.Amount) ([]*chainhash.Hash, error) {
 
@@ -1166,7 +1168,7 @@ func (w *Wallet) PurchaseTickets(minBalance, spendLimit dcrutil.Amount, minConf 
 		return nil, errors.E(op, err)
 	}
 
-	req := &purchaseTicketsRequest{
+	req := &PurchaseTicketsRequest{
 		Count:         count,
 		SourceAccount: account,
 		VotingAddress: votingAddr,
@@ -1190,8 +1192,8 @@ func (w *Wallet) PurchaseTickets(minBalance, spendLimit dcrutil.Amount, minConf 
 	return w.purchaseTickets(context.Background(), op, n, req)
 }
 
-// purchaseTicketsRequest describes the parameters for purchasing tickets.
-type purchaseTicketsRequest struct {
+// PurchaseTicketsRequest describes the parameters for purchasing tickets.
+type PurchaseTicketsRequest struct {
 	Count         int
 	SourceAccount uint32
 	VotingAddress dcrutil.Address
@@ -1205,6 +1207,20 @@ type purchaseTicketsRequest struct {
 	poolFees    float64
 	txFee       dcrutil.Amount
 	ticketFee   dcrutil.Amount
+}
+
+// PurchaseTicketsContext purchases tickets, returning the hashes of all ticket
+// purchase transactions.
+func (w *Wallet) PurchaseTicketsContext(ctx context.Context, n NetworkBackend, req *PurchaseTicketsRequest) ([]*chainhash.Hash, error) {
+	const op errors.Op = "wallet.PurchaseTicketsContext"
+
+	heldUnlock, err := w.holdUnlock()
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+	defer heldUnlock.release()
+
+	return w.purchaseTickets(ctx, op, n, req)
 }
 
 type (


### PR DESCRIPTION
Currently only supports solo buying.

This is intended to be used by the auto ticketbuyer and cancelable RPC methods
to terminate ticket purchasing early if the request should be canceled, either
due to RPC client disconnection or new blocks attached to the main chain.