### PR TITLE
Remove -race from CI test scripts

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -18,7 +18,7 @@ REPO=dcrwallet
 
 testrepo () {
     go version
-    env GORACE='halt_on_error=1' CC=gcc GOTESTFLAGS='-race -short' bash ./testmodules.sh
+    env CC=gcc GOTESTFLAGS='-short' bash ./testmodules.sh
 }
 
 DOCKER=


### PR DESCRIPTION
Race-enabled testing is an order of magnitude slower.  This causes issues for
pull requests which add more tests, due to elapsed timeouts on the CI
infrastructure, and it is more desirable to have a comprehensive test suite
running without -race than few tests with it.  Further improvements may be made
by caching the Go build cache and/or investigating other infra.

To test with -race locally, just run go test -race as usual, or (better) build
and run a race-enabled binary.