### PR TITLE
Fix cursor indexes to derive next address.

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -390,11 +390,11 @@ func (w *Wallet) watchFutureAddresses(dbtx walletdb.ReadTx) error {
 		// used and last returned indexes retreived from the db.
 		if endExt > startExt {
 			a.albExternal.lastUsed = dbLastUsed.external
-			a.albExternal.cursor -= minUint32(a.albExternal.cursor, endExt-startExt)
+			a.albExternal.cursor = dbLastRet.external - dbLastUsed.external
 		}
 		if endInt > startInt {
 			a.albInternal.lastUsed = dbLastUsed.internal
-			a.albInternal.cursor -= minUint32(a.albInternal.cursor, endInt-startInt)
+			a.albInternal.cursor = dbLastRet.internal - dbLastUsed.internal
 		}
 
 		go func() {

--- a/wallet/network_test.go
+++ b/wallet/network_test.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/dcrutil"
+	"github.com/decred/dcrd/gcs"
+	"github.com/decred/dcrd/wire"
+)
+
+// mockNetwork implements all methods of NetworkBackend, returning zero values
+// without error.  It may be embedded in a struct to create another
+// NetworkBackend which dispatches to particular implementations of the methods.
+type mockNetwork struct{}
+
+func (mockNetwork) GetBlocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error) {
+	return nil, nil
+}
+func (mockNetwork) GetCFilters(ctx context.Context, blockHashes []*chainhash.Hash) ([]*gcs.Filter, error) {
+	return nil, nil
+}
+func (mockNetwork) GetHeaders(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error) {
+	return nil, nil
+}
+func (mockNetwork) PublishTransactions(ctx context.Context, txs ...*wire.MsgTx) error { return nil }
+func (mockNetwork) LoadTxFilter(ctx context.Context, reload bool, addrs []dcrutil.Address, outpoints []wire.OutPoint) error {
+	return nil
+}
+func (mockNetwork) Rescan(ctx context.Context, blocks []chainhash.Hash, r RescanSaver) error {
+	return nil
+}
+func (mockNetwork) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error) { return 0, nil }


### PR DESCRIPTION
The cursor index was not being set to the correct value, causing addresses to be
returned multiple times after any block or unmined transaction was received.
This has been fixed and tests have been added to ensure the behavior remains
correct, as this is not the first time address reuse has become a problem.

Fixes #1445.