### PR TITLE
Return early with context error from spv rescan.

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -197,6 +197,9 @@ FilterLoop:
 			var rp *p2p.RemotePeer
 		PickPeer:
 			for {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
 				if rp == nil {
 					var err error
 					rp, err = s.pickRemote(pickAny)


### PR DESCRIPTION
Previously, it was spinning a CPU due to the error handling attempting to pick a
different peer.