### PR TITLE
Display OS/arch with -V

### DIFF
--- a/config.go
+++ b/config.go
@@ -344,7 +344,8 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 	usageMessage := fmt.Sprintf("Use %s -h to show usage", appName)
 	if preCfg.ShowVersion {
-		fmt.Printf("%s version %s (Go version %s)\n", appName, version.String(), runtime.Version())
+		fmt.Printf("%s version %s (Go version %s %s/%s)\n", appName,
+			version.String(), runtime.Version(), runtime.GOOS, runtime.GOARCH)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
The OS and arch were already being logged by dcrwallet at startup but this adds
the details to the -V output for consistency with the log and with dcrd.