### PR TITLE
legacyrpc: prevent leak of cancel

### DIFF
--- a/config.go
+++ b/config.go
@@ -49,8 +49,6 @@ const (
 	defaultDisableCoinTypeUpgrades = false
 
 	// ticket buyer options
-	defaultMaxFee                    dcrutil.Amount = 1e6
-	defaultMinFee                    dcrutil.Amount = 1e5
 	defaultBalanceToMaintainAbsolute                = 0
 
 	walletDbName = "wallet.db"

--- a/rpc/legacyrpc/server.go
+++ b/rpc/legacyrpc/server.go
@@ -136,8 +136,6 @@ func NewServer(opts *Options, activeNet *chaincfg.Params, walletLoader *loader.L
 
 	serveMux.Handle("/ws", throttledFn(opts.MaxWebsocketClients,
 		func(w http.ResponseWriter, r *http.Request) {
-			ctx := withRemoteAddr(r.Context(), r.RemoteAddr)
-			ctx, cancel := context.WithCancel(ctx)
 			authenticated := false
 			switch server.checkAuthHeader(r) {
 			case nil:
@@ -159,6 +157,8 @@ func NewServer(opts *Options, activeNet *chaincfg.Params, walletLoader *loader.L
 					r.RemoteAddr, err)
 				return
 			}
+			ctx := withRemoteAddr(r.Context(), r.RemoteAddr)
+			ctx, cancel := context.WithCancel(ctx)
 			wsc := newWebsocketClient(conn, cancel, authenticated)
 			server.websocketClientRPC(ctx, wsc)
 		}))


### PR DESCRIPTION
also remove two unused ticketbuyer constants.