### PR TITLE
Add wallet address interfaces.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -481,18 +481,19 @@ func (s *walletServer) NextAddress(ctx context.Context, req *pb.NextAddressReque
 		return nil, translateError(err)
 	}
 
-	pubKey, err := s.wallet.PubKeyForAddress(addr)
-	if err != nil {
-		return nil, translateError(err)
-	}
-	pubKeyAddr, err := dcrutil.NewAddressSecpPubKey(pubKey.Serialize(), s.wallet.ChainParams())
-	if err != nil {
-		return nil, translateError(err)
+	var pubKeyAddrString string
+	if secp, ok := addr.(wallet.SecpPubKeyer); ok {
+		pubKey := secp.SecpPubKey().Serialize()
+		pubKeyAddr, err := dcrutil.NewAddressSecpPubKey(pubKey, s.wallet.ChainParams())
+		if err != nil {
+			return nil, translateError(err)
+		}
+		pubKeyAddrString = pubKeyAddr.String()
 	}
 
 	return &pb.NextAddressResponse{
 		Address:   addr.EncodeAddress(),
-		PublicKey: pubKeyAddr.String(),
+		PublicKey: pubKeyAddrString,
 	}, nil
 }
 

--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -835,12 +835,14 @@ func (w *Wallet) DiscoverActiveAddresses(ctx context.Context, p Peer, startBlock
 			for acct := lastRecorded + 1; acct <= lastUsed; acct++ {
 				_, ok := w.addressBuffers[acct]
 				if !ok {
-					extKey, intKey, err := deriveBranches(acctXpubs[acct])
+					xpub := acctXpubs[acct]
+					extKey, intKey, err := deriveBranches(xpub)
 					if err != nil {
 						w.addressBuffersMu.Unlock()
 						return errors.E(op, err)
 					}
 					w.addressBuffers[acct] = &bip0044AccountData{
+						xpub:        hd1to2(xpub, w.chainParams),
 						albExternal: addressBuffer{branchXpub: extKey},
 						albInternal: addressBuffer{branchXpub: intKey},
 					}

--- a/wallet/hdkeychain.go
+++ b/wallet/hdkeychain.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2019 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	hdkeychain1 "github.com/decred/dcrd/hdkeychain"
+	hdkeychain2 "github.com/decred/dcrd/hdkeychain/v2"
+)
+
+// hd2to1 converts a hdkeychain/v2 extended key to the v1 API.
+// An error check during string conversion is intentionally dropped for brevity.
+func hd2to1(k2 *hdkeychain2.ExtendedKey) *hdkeychain1.ExtendedKey {
+	k, _ := hdkeychain1.NewKeyFromString(k2.String())
+	return k
+}
+
+// hd1to2 converts a v1 extended key to the v2 API.
+// An error check during string conversion is intentionally dropped for brevity.
+func hd1to2(k *hdkeychain1.ExtendedKey, params hdkeychain2.NetworkParams) *hdkeychain2.ExtendedKey {
+	k2, _ := hdkeychain2.NewKeyFromString(k.String(), params)
+	return k2
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1701,6 +1701,7 @@ func (w *Wallet) NextAccount(name string) (uint32, error) {
 	}
 	w.addressBuffersMu.Lock()
 	w.addressBuffers[account] = &bip0044AccountData{
+		xpub:        hd1to2(xpub, w.chainParams),
 		albExternal: addressBuffer{branchXpub: extKey, lastUsed: ^uint32(0)},
 		albInternal: addressBuffer{branchXpub: intKey, lastUsed: ^uint32(0)},
 	}
@@ -4429,6 +4430,7 @@ func Open(cfg *Config) (*Wallet, error) {
 				return err
 			}
 			w.addressBuffers[acct] = &bip0044AccountData{
+				xpub: hd1to2(xpub, w.chainParams),
 				albExternal: addressBuffer{
 					branchXpub: extKey,
 					lastUsed:   props.LastUsedExternalIndex,


### PR DESCRIPTION
The following new interfaces are introduced:

- V0Scripter: for addresses used to create version 0 scripts
- SecpPubKeyHasher: for addresses created from a secp256k1 pubkey hash
- SecpPubKeyer: for addresses with a known secp256k1 pubkey
- SecpPubKeyHash160er: for addresses paying to a secp256k1 pubkey HASH160
- BIP44AccountXpubPather: for BIP0044 addresses derived from an account xpub
- AddressP2PKHv0: a union interface for v0 P2PKH addrs
- BIP44XpubP2PKHv0: a union interface for v0 P2PKH addrs with known xpubs

These interfaces describe the behavior and features of an address and allow
callers to operate on their distinctive capabilities without switching on a
concrete type.  More interfaces are planned to be introduced in the future as
address and script usage evolves.

The wallet methods NewExternalAddress, NewInternalAddress, and NewChangeAddress
have been modified to return addresses implementing all of the new interfaces.