### PR TITLE
Remove direct usage of txscript.PayToAddrScript

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/decred/dcrd/txscript v1.0.2
 	github.com/decred/dcrd/wire v1.2.0
 	github.com/decred/dcrwallet/chain/v2 v2.0.0
-	github.com/decred/dcrwallet/errors v1.0.1
+	github.com/decred/dcrwallet/errors v1.1.0
 	github.com/decred/dcrwallet/internal/helpers v1.0.1
 	github.com/decred/dcrwallet/internal/zero v1.0.1
 	github.com/decred/dcrwallet/p2p v1.0.1
@@ -27,7 +27,7 @@ require (
 	github.com/decred/dcrwallet/spv/v2 v2.0.0
 	github.com/decred/dcrwallet/ticketbuyer/v3 v3.0.0
 	github.com/decred/dcrwallet/version v1.0.1
-	github.com/decred/dcrwallet/wallet/v2 v2.0.0
+	github.com/decred/dcrwallet/wallet/v2 v2.1.0
 	github.com/decred/dcrwallet/walletseed v1.0.1
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.4.0

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -100,8 +100,14 @@ func (s *Syncer) LoadTxFilter(ctx context.Context, reload bool, addrs []dcrutil.
 		s.filterData = nil
 	}
 	for _, addr := range addrs {
-		pkScript, err := txscript.PayToAddrScript(addr)
-		if err == nil {
+		var pkScript []byte
+		switch addr := addr.(type) {
+		case wallet.V0Scripter:
+			pkScript = addr.ScriptV0()
+		default:
+			pkScript, _ = txscript.PayToAddrScript(addr)
+		}
+		if pkScript != nil {
 			s.rescanFilter.AddAddress(addr)
 			s.filterData.AddRegularPkScript(pkScript)
 		}

--- a/spv/go.mod
+++ b/spv/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/decred/dcrd/gcs v1.0.2
 	github.com/decred/dcrd/txscript v1.0.2
 	github.com/decred/dcrd/wire v1.2.0
-	github.com/decred/dcrwallet/errors v1.0.1
+	github.com/decred/dcrwallet/errors v1.1.0
 	github.com/decred/dcrwallet/lru v1.0.0
 	github.com/decred/dcrwallet/p2p v1.0.1
 	github.com/decred/dcrwallet/validate v1.0.2
-	github.com/decred/dcrwallet/wallet/v2 v2.0.0
+	github.com/decred/dcrwallet/wallet/v2 v2.1.0
 	github.com/decred/slog v1.0.0
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
 )

--- a/spv/go.sum
+++ b/spv/go.sum
@@ -38,6 +38,8 @@ github.com/decred/dcrd/chaincfg v1.2.0 h1:Vj0xr85wmqOdQDxKLkpP9TqwK1RykqY2eC0fWc
 github.com/decred/dcrd/chaincfg v1.2.0/go.mod h1:kpoGTMIriKn5hHRSu5b65+Q9LlGUdbQcMzGujac1BVs=
 github.com/decred/dcrd/chaincfg v1.3.0 h1:DEysyX1/kxlWbY97PTIPpGbMOp3+n2iixi3m9d27A6c=
 github.com/decred/dcrd/chaincfg v1.3.0/go.mod h1:kpoGTMIriKn5hHRSu5b65+Q9LlGUdbQcMzGujac1BVs=
+github.com/decred/dcrd/chaincfg v1.4.0 h1:dIJhXQooiVW5AVZ0c4brylsiwkc8KSawpZ3NPq+LxWY=
+github.com/decred/dcrd/chaincfg v1.4.0/go.mod h1:ypuM30F+XgZmZTFfAkWHWd0lwwkWWAOAQYNRkRDlYLc=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1 h1:0vG7U9+dSjSCaHQKdoSKURK2pOb47+b+8FK5q4+Je7M=
 github.com/decred/dcrd/chaincfg/chainhash v1.0.1/go.mod h1:OVfvaOsNLS/A1y4Eod0Ip/Lf8qga7VXCQjUQLbkY0Go=
 github.com/decred/dcrd/connmgr v1.0.2 h1:ipHJBV9fmhLi8ZZCtsNpG+kLY2c+yu59/8oOkA8BNJY=
@@ -81,8 +83,12 @@ github.com/decred/dcrd/gcs v1.0.2 h1:wZjxeC9WPBoRApaAQpBrzvN9NA0iS2KWrTJa9IiDgc8
 github.com/decred/dcrd/gcs v1.0.2/go.mod h1:eLCvrzUsWro48TlTyrmFcZAZqnllYFz0vEv5VZtufF4=
 github.com/decred/dcrd/hdkeychain v1.1.1 h1:6+BwOmPfEyw/Krm+91RXysc76F1jqCta3m45DyD5+s4=
 github.com/decred/dcrd/hdkeychain v1.1.1/go.mod h1:CLBVXLoO63fIiqkv38KR23zXGSgrfiAWOybOKTneLhA=
+github.com/decred/dcrd/hdkeychain/v2 v2.0.0 h1:b6GklXT+LeDumc0bDqMHkss+p2Bu+mgiUDhjAX01LOc=
+github.com/decred/dcrd/hdkeychain/v2 v2.0.0/go.mod h1:tG+VpXfloIkNGHGd6NeoTElHWA68Wf1aP87zegXDGEw=
 github.com/decred/dcrd/mempool v1.1.1 h1:ysFIS3HzEIJ88B1Y4OfL6wjzBurlChbKkzq54hPglGo=
 github.com/decred/dcrd/mempool v1.1.1/go.mod h1:u1I2KRv9UHhx2crlbZXYoLDabWyQ8VnnHDSG53UdhCA=
+github.com/decred/dcrd/mempool/v2 v2.0.0 h1:QoQC5Lri311unqCr/PejBEwNERWMSWtnSa7bpBFZjbQ=
+github.com/decred/dcrd/mempool/v2 v2.0.0/go.mod h1:/AH0mFOKCglSdEDubF3oRDbWUmDj26gwnrIlFsr+lbM=
 github.com/decred/dcrd/mining v1.1.0 h1:9Wtla+i+pEjfYsNCfixsipmyyoB26DgL4LSXWAin/zw=
 github.com/decred/dcrd/mining v1.1.0/go.mod h1:NQEtX604XgNwKcPFId1hVTTiBqmVQDlnqV1yNqGl4oU=
 github.com/decred/dcrd/rpcclient/v2 v2.0.0 h1:Zy9twdEaOGUdCj/89LAs/IrStm6FcabxzBve4UsA73A=
@@ -99,6 +105,8 @@ github.com/decred/dcrwallet/deployments v1.1.0 h1:83arg+7ct7PS1H2IYhuePnrBK2rkVp
 github.com/decred/dcrwallet/deployments v1.1.0/go.mod h1:8Sasryu8SX23Jvqr6maZ7MoS7wFIGXupWzbsVtcZsUg=
 github.com/decred/dcrwallet/errors v1.0.1 h1:8EF7IY6twRlo9sqWaSfm8abfi2/rHZ1wacOiGvBy+bM=
 github.com/decred/dcrwallet/errors v1.0.1/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=
+github.com/decred/dcrwallet/errors v1.1.0 h1:xDzE4l8AGLcL1CGigPR9vYHP/rBmMm34ZatolleOS9A=
+github.com/decred/dcrwallet/errors v1.1.0/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=
 github.com/decred/dcrwallet/internal/helpers v1.0.1 h1:oEqfJPs1uI7QI0Aejx2MUWq/yD609cc9Z8P7vQ6cDz8=
 github.com/decred/dcrwallet/internal/helpers v1.0.1/go.mod h1:qIXcze8VZ+A3sEgZou7PTOe4Vsnmks54SGTSGZ6084g=
 github.com/decred/dcrwallet/internal/zero v1.0.1 h1:hO7orPk13AFp7pFTL739CbVLKImSNorI2J9/tiucNQY=
@@ -115,6 +123,8 @@ github.com/decred/dcrwallet/version v1.0.1 h1:gAz1lDkcJ+oAbg0tOn/J0KwZBVWIlhWmHh
 github.com/decred/dcrwallet/version v1.0.1/go.mod h1:rXeMsUaI03WtlQrSol7Q7sJ8HBOB+tZvT7YQRXD5Y7M=
 github.com/decred/dcrwallet/wallet/v2 v2.0.0 h1:ppSLjwu3DHmRWdnRbN53fu9AFjY0MqK40jzbZQAouG8=
 github.com/decred/dcrwallet/wallet/v2 v2.0.0/go.mod h1:uDSN0GRTH583eSnPyPiTXNcZ9DrQ2tBqdm/tjp5rjwY=
+github.com/decred/dcrwallet/wallet/v2 v2.1.0 h1:RYegu/aqRGb+iuTKmsVHIMpKVGLTxDucwRuft+EQceM=
+github.com/decred/dcrwallet/wallet/v2 v2.1.0/go.mod h1:k4dPFhvoucYlY2NVblPAFzJL/TnuUCIoBRb00pZJv/I=
 github.com/decred/slog v1.0.0 h1:Dl+W8O6/JH6n2xIFN2p3DNjCmjYwvrXsjlSJTQQ4MhE=
 github.com/decred/slog v1.0.0/go.mod h1:zR98rEZHSnbZ4WHZtO0iqmSZjDLKhkXfrPTZQKtAonQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -143,6 +153,7 @@ github.com/onsi/gomega v1.4.1 h1:PZSj/UFNaVp3KxrzHOcS7oyuWA7LoOY/77yCTEFu21U=
 github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f h1:lRy+hhwk7YT7MsKejxuz0C5Q1gk6p/QoPQYEmKmGFb8=
 golang.org/x/crypto v0.0.0-20180718160520-a2144134853f/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -17,7 +17,6 @@ import (
 	"github.com/decred/dcrd/gcs/blockcf"
 	hd "github.com/decred/dcrd/hdkeychain"
 	rpc "github.com/decred/dcrd/rpcclient/v2"
-	"github.com/decred/dcrd/txscript"
 	"github.com/decred/dcrd/wire"
 	"github.com/decred/dcrwallet/errors"
 	"github.com/decred/dcrwallet/validate"
@@ -199,9 +198,9 @@ func (a *addrFinder) find(ctx context.Context, start *chainhash.Hash, p Peer) er
 				return err
 			}
 			for i, addr := range addrs {
-				scr, err := txscript.PayToAddrScript(addr)
+				scr, _, err := addressScript(addr)
 				if err != nil {
-					log.Errorf("PayToAddrScript(%v): %v", addr, err)
+					log.Errorf("addressScript(%v): %v", addr, err)
 					continue
 				}
 				data = append(data, scr)
@@ -448,7 +447,7 @@ func (w *Wallet) findLastUsedAccount(ctx context.Context, p Peer, blockCache blo
 				return 0, err
 			}
 			for _, a := range addrs {
-				script, err := txscript.PayToAddrScript(a)
+				script, _, err := addressScript(a)
 				if err != nil {
 					log.Warnf("Failed to create output script for address %v: %v", a, err)
 					continue
@@ -461,7 +460,7 @@ func (w *Wallet) findLastUsedAccount(ctx context.Context, p Peer, blockCache blo
 				return 0, err
 			}
 			for _, a := range addrs {
-				script, err := txscript.PayToAddrScript(a)
+				script, _, err := addressScript(a)
 				if err != nil {
 					log.Warnf("Failed to create output script for address %v: %v", a, err)
 					continue


### PR DESCRIPTION
Each instance is replaced with additional logic to first check for
implementations of the wallet.V0Scripter interface.  This allows
internal wallet types which txscript does not recognize to return
their own scripts (with script versions implied by the method name).

Fixes #1483.