### PR TITLE
Generate new block locators after announced blocks.

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1015,7 +1015,7 @@ func (s *Syncer) getHeaders(ctx context.Context, rp *p2p.RemotePeer) error {
 	s.locatorMu.Lock()
 	locators = s.currentLocators
 	generation = s.locatorGeneration
-	if locators == nil {
+	if len(locators) == 0 {
 		locators, err = s.wallet.BlockLocators(nil)
 		if err != nil {
 			s.locatorMu.Unlock()
@@ -1090,7 +1090,8 @@ func (s *Syncer) getHeaders(ctx context.Context, rp *p2p.RemotePeer) error {
 			s.locatorMu.Lock()
 			if s.locatorGeneration > generation {
 				locators = s.currentLocators
-			} else {
+			}
+			if len(locators) == 0 {
 				locators, err = s.wallet.BlockLocators(nil)
 				if err != nil {
 					s.locatorMu.Unlock()


### PR DESCRIPTION
When a block is announced and it is attached to and becomes the new
best chain, the previous block locators saved by the SPV syncer are
cleared.  This could cause an slice out-of-bounds panic in getHeaders
since that method required that the locators be at least length 1 at
all times.  This change protects against that logic race by always
checking whether a new locator generation has zero length and if so,
new locators are generated and saved.