### PR TITLE
multi: prevent multiple imports of the same script.

### DIFF
--- a/rpc/rpcserver/server.go
+++ b/rpc/rpcserver/server.go
@@ -610,7 +610,13 @@ func (s *walletServer) ImportScript(ctx context.Context,
 
 	err = s.wallet.ImportScript(req.Script)
 	if err != nil {
-		return nil, translateError(err)
+		switch {
+		case errors.Is(errors.Exist, err):
+			// Do not return duplicate script errors to the client.
+			return nil, nil
+		default:
+			return nil, translateError(err)
+		}
 	}
 
 	if req.Rescan {

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -558,7 +558,6 @@ func (w *Wallet) processTransactionRecord(dbtx walletdb.ReadWriteTx, rec *udb.Tx
 				}
 				mscriptaddr, err := w.Manager.ImportScript(addrmgrNs, rs)
 				switch {
-				case errors.Is(errors.Exist, err): // Don't care if it's already there.
 				case errors.Is(errors.Locked, err):
 					log.Warnf("failed to attempt script importation "+
 						"of incoming tx script %x because addrmgr "+

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -3595,8 +3595,15 @@ func (s *Store) AccountBalances(ns, addrmgrNs walletdb.ReadBucket, minConf int32
 	return s.balanceFullScan(ns, addrmgrNs, minConf, syncHeight)
 }
 
-// InsertTxScript inserts a transaction script into the database.
+// InsertTxScript inserts a transaction script into the database if it does not 
+// already exist.
 func (s *Store) InsertTxScript(ns walletdb.ReadWriteBucket, script []byte) error {
+	hash := keyTxScript(script)
+	v := existsTxScript(ns, hash)
+	if v != nil {
+		return errors.E(errors.Exist, errors.Errorf("script for hash %x already exists", hash))
+	}
+
 	return putTxScript(ns, script)
 }
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3132,9 +3132,6 @@ func (w *Wallet) ImportScript(rs []byte) error {
 		mscriptaddr, err := w.Manager.ImportScript(addrmgrNs, rs)
 		if err != nil {
 			switch {
-			// Don't care if it's already there.
-			case errors.Is(errors.Exist, err):
-				return nil
 			case errors.Is(errors.Locked, err):
 				log.Debugf("failed to attempt script importation " +
 					"of incoming tx because addrmgr was locked")


### PR DESCRIPTION
This updates script imports to prevent multiple imports of the same script for the tx store. This also prevents a rescan trigger if the script already exists.

fixes #1412