### PR TITLE
Remove additional legacy references to JSON-RPC server

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ the following features are disabled or unavailable to SPV wallets:
 
 Wallet clients interact with the wallet using one of two RPC servers:
 
-  1. A legacy JSON-RPC server inspired by the Bitcoin Core rpc server
+  1. A JSON-RPC server inspired by the Bitcoin Core rpc server
 
      The JSON-RPC server exists to ease the migration of wallet applications
      from Core, but complete compatibility is not guaranteed.  Some portions of
@@ -62,7 +62,7 @@ Wallet clients interact with the wallet using one of two RPC servers:
      The gRPC server uses a new API built for dcrwallet, but the API is not
      stabilized.  This server is enabled by default and may be disabled with
      the config option `--nogrpc`.  If you don't mind applications breaking
-     due to API changes, don't want to deal with issues of the legacy API, or
+     due to API changes, don't want to deal with issues of the JSON-RPC API, or
      need notifications for changes to the wallet, this is the RPC server to
      use. The gRPC server is documented [here](./rpc/documentation/README.md).
 

--- a/ipc.go
+++ b/ipc.go
@@ -112,10 +112,10 @@ func drainOutgoingPipeMessages() {
 }
 
 // The jsonrpcListenerEvent is used to notify the listener addresses used for
-// the legacy JSON-RPC server.  The message type is "jsonrpclistener".  This
-// event is most notably useful when parent processes start the wallet with
-// listener addresses bound on port 0 to cause the operating system to select an
-// unused port.
+// the JSON-RPC server.  The message type is "jsonrpclistener".  This event is
+// most notably useful when parent processes start the wallet with listener
+// addresses bound on port 0 to cause the operating system to select an unused
+// port.
 //
 // The payload is the UTF8 bytes of the listener address, and the payload size
 // is the byte length of the string.

--- a/rpc/jsonrpc/config.go
+++ b/rpc/jsonrpc/config.go
@@ -4,7 +4,7 @@
 
 package jsonrpc
 
-// Options contains the required options for running the legacy RPC server.
+// Options contains the required options for running the JSON-RPC server.
 type Options struct {
 	Username string
 	Password string

--- a/rpc/jsonrpc/server.go
+++ b/rpc/jsonrpc/server.go
@@ -90,7 +90,7 @@ func jsonAuthFail(w http.ResponseWriter) {
 	http.Error(w, "401 Unauthorized.", http.StatusUnauthorized)
 }
 
-// NewServer creates a new server for serving legacy RPC client connections,
+// NewServer creates a new server for serving JSON-RPC client connections,
 // both HTTP POST and websocket.
 func NewServer(opts *Options, activeNet *chaincfg.Params, walletLoader *loader.Loader, listeners []net.Listener) *Server {
 	serveMux := http.NewServeMux()
@@ -192,7 +192,7 @@ func httpBasicAuth(username, password string) []byte {
 	return output
 }
 
-// serve serves HTTP POST and websocket RPC for the legacy JSON-RPC RPC server.
+// serve serves HTTP POST and websocket RPC for the JSON-RPC RPC server.
 // This function does not block on lis.Accept.
 func (s *Server) serve(lis net.Listener) {
 	s.wg.Add(1)

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -90,10 +90,10 @@
 ; specific reason to do otherwise.
 ;
 ; These option semantics apply to both the rpclisten and grpclisten options.
-; rpclisten sets the listeners for the legacy JSON-RPC server while grpclisten
+; rpclisten sets the listeners for the JSON-RPC server while grpclisten
 ; modifies the listeners for the gRPC server.
 ;
-; By default, the legacy JSON-RPC server listens on localhost addresses on port
+; By default, the JSON-RPC server listens on localhost addresses on port
 ; 9110, and the gRPC server listens on localhost addresses on port 9111.
 ;
 ; rpclisten=                ; all interfaces on default port
@@ -109,15 +109,15 @@
 ; rpclisten=0.0.0.0:18337   ; all ipv4 interfaces on non-standard port 18337
 ; rpclisten=[::]:18337      ; all ipv6 interfaces on non-standard port 18337
 
-; Disable the legacy (JSON-RPC) server or gRPC servers
-; nolegacyrpc=0
+; Disable the JSON-RPC server or gRPC servers
+; nolegacyrpc=0 ; JSON-RPC
 ; nogrpc=0
 
-; Legacy (Bitcoin Core-compatible) RPC listener addresses.  Addresses without a
+; JSON-RPC (Bitcoin Core-compatible) RPC listener addresses.  Addresses without a
 ; port specified use the same default port as the new server.  Listeners cannot
 ; be shared between both RPC servers.
 ;
-; Adding any legacy RPC listen addresses disable all default rpclisten options.
+; Adding any JSON-RPC listen addresses disable all default rpclisten options.
 ; If both servers must run, all listen addresses must be manually specified for
 ; each.
 ; legacyrpclisten=


### PR DESCRIPTION
The package implementing the server was already renamed to reflect the
decision that the server is neither legacy nor unmaintained.  The only
remaining references to the server being legacy are in dcrwallet
command line and config flags, which can't be changed without
deprecating them in at least one release cycle.