### PR TITLE
Remove macOS runners from Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,18 +16,6 @@ matrix:
         directories:
           - $HOME/.cache/go-build
           - $HOME/go/pkg/mod
-    - os: osx
-      go: 1.12.x
-      cache:
-        directories:
-          - $HOME/.cache/go-build
-          - $HOME/go/pkg/mod
-    - os: osx
-      go: 1.11.x
-      cache:
-        directories:
-          - $HOME/Library/Caches/go-build
-          - $HOME/go/pkg/mod
 script:
   - env GO111MODULE=on go build ./...
   - env GO111MODULE=on ./run_tests.sh


### PR DESCRIPTION
These runners are very slow to start and don't provide a tangible
benefit to the project due to the lack of any platform-specific code
that needs to be tested.