### PR TITLE
Run go fmt on the wallet module

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -10,8 +10,8 @@ import (
 	"math/big"
 	"time"
 
-	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/blockchain/stake/v2"
+	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrjson/v3"
 	"github.com/decred/dcrd/dcrutil/v2"

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 	"time"
 
-	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/blockchain/stake/v2"
+	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/chaincfg/v2/chainec"

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -10,8 +10,8 @@ import (
 	"context"
 	"sync"
 
-	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/blockchain/stake/v2"
+	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrd/hdkeychain/v2"

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -17,8 +17,8 @@ import (
 	"sync"
 	"time"
 
-	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/blockchain/stake/v2"
+	blockchain "github.com/decred/dcrd/blockchain/standalone"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrd/chaincfg/v2/chainec"


### PR DESCRIPTION
It appears that go fmt ./... from the main module doesn't format
dependency modules contained in the same file tree.