### PR TITLE
Improve compatibility with Go 1.13 errors

### DIFF
--- a/errors/go.mod
+++ b/errors/go.mod
@@ -1,1 +1,3 @@
 module github.com/decred/dcrwallet/errors
+
+go 1.11


### PR DESCRIPTION
The dcrwallet errors package was created at a time when the stdlib
errors package did not provide any support or wrapping/unwrapping or
detection features.  These have been added beginning in Go 1.13 in the
form of the Is and As functions.

To improve the compatibility between dcrwallet's errors and the new
stdlib features, the following additions are made:

* Kind implements error.

* Error implements the Unrwap method used by stdlib errors.Is.  Unwrap
  returns the underlying error if it is not nil, falling back to
  returning the Kind error if it is nonzero.

* Error implements the Is method used by stdlib errors.Is.  If the
  target is an Error, Is returns if the errors match according to the
  rules of Match.  If the target is a Kind, Is returns whether the
  Kinds are equal and nonzero.  Otherwise Is returns false.

* Error and Kind both implement the As method used by stdlib errors.As.
  Both As methods will assign the target if it points to a *Error or
  Kind, with Kind targets only being assigned if the receiver's Kind is
  nonzero.