### PR TITLE
chain: Close RPC conn on bad server version.

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -246,6 +246,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 	s.rpc = dcrd.New(client)
 
 	// Verify that the server is running on the expected network.


### PR DESCRIPTION
Closes #1542 

We may need further changes in this Run() function to close the client in other places where an error is returned.