### PR TITLE
Use errors.Is instead of error value equality

### DIFF
--- a/cmd/sweepaccount/main.go
+++ b/cmd/sweepaccount/main.go
@@ -393,7 +393,7 @@ func sweep() error {
 		}
 
 		if err != nil {
-			if err != (noInputValue{}) {
+			if !errors.Is(err, (noInputValue{})) {
 				reportError("Failed to create unsigned transaction: %v", err)
 			}
 			continue

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -49,7 +49,7 @@ func main() {
 	go shutdownListener()
 
 	// Run the wallet until permanent failure or shutdown is requested.
-	if err := run(ctx); err != nil && err != context.Canceled {
+	if err := run(ctx); err != nil && !errors.Is(err, context.Canceled) {
 		os.Exit(1)
 	}
 }
@@ -258,7 +258,7 @@ func run(ctx context.Context) error {
 			tbdone := make(chan struct{})
 			go func() {
 				err := tb.Run(ctx, passphrase)
-				if err != nil && err != context.Canceled {
+				if err != nil && !errors.Is(err, context.Canceled) {
 					log.Errorf("Ticket buying ended: %v", err)
 				}
 				tbdone <- struct{}{}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -15,6 +15,7 @@ import (
 	"unicode"
 
 	"github.com/decred/dcrd/hdkeychain/v2"
+	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/walletseed"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -128,7 +129,7 @@ func PassPrompt(reader *bufio.Reader, prefix string, confirm bool) ([]byte, erro
 			pass, err = terminal.ReadPassword(fd)
 		} else {
 			pass, err = reader.ReadBytes('\n')
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = nil
 			}
 		}

--- a/internal/rpc/jsonrpc/server.go
+++ b/internal/rpc/jsonrpc/server.go
@@ -325,7 +325,7 @@ func (s *Server) websocketClientRead(ctx context.Context, wsc *websocketClient) 
 	for {
 		_, request, err := wsc.conn.ReadMessage()
 		if err != nil {
-			if err != io.EOF && err != io.ErrUnexpectedEOF {
+			if !errors.Is(err, io.EOF) && !errors.Is(err, io.ErrUnexpectedEOF) {
 				log.Warnf("Websocket receive failed from client %s: %v",
 					remoteAddr(ctx), err)
 			}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -2139,7 +2139,7 @@ func (s *walletServer) ConfirmationNotifications(svr pb.WalletService_Confirmati
 	case <-svr.Context().Done():
 		return nil
 	case err := <-errOut:
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 		if _, ok := status.FromError(err); ok {
@@ -2647,9 +2647,9 @@ func (s *loaderServer) SpvSync(req *pb.SpvSyncRequest, svr pb.WalletLoaderServic
 
 	err := syncer.Run(svr.Context())
 	if err != nil {
-		if err == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return status.Errorf(codes.Canceled, "SPV synchronization canceled: %v", err)
-		} else if err == context.DeadlineExceeded {
+		} else if errors.Is(err, context.DeadlineExceeded) {
 			return status.Errorf(codes.DeadlineExceeded, "SPV synchronization deadline exceeded: %v", err)
 		}
 		return translateError(err)

--- a/ipc.go
+++ b/ipc.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/decred/dcrwallet/errors/v2"
 )
 
 // Messages sent over a pipe are encoded using a simple binary message format:
@@ -46,7 +48,7 @@ func serviceControlPipeRx(fd uintptr) {
 	r := bufio.NewReader(pipe)
 	for {
 		_, err := r.Discard(1024)
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -469,7 +469,7 @@ func (w *Wallet) nextAddress(ctx context.Context, op errors.Op, persist persistR
 				account, branch))
 		}
 		child, err := alb.branchXpub.Child(childIndex)
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			alb.cursor++
 			continue
 		}
@@ -830,7 +830,7 @@ func deriveChildAddresses(key *hdkeychain.ExtendedKey, startIndex, count uint32,
 	addresses := make([]dcrutil.Address, 0, count)
 	for i := uint32(0); i < count; i++ {
 		child, err := key.Child(startIndex + i)
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			continue
 		}
 		if err != nil {
@@ -870,7 +870,7 @@ func appendChildAddrsRange(addrs *[]dcrutil.Address, key *hdkeychain.ExtendedKey
 
 	for ; a < b && a < hdkeychain.HardenedKeyStart; a++ {
 		addr, err := deriveChildAddress(key, a, params)
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			continue
 		}
 		if err != nil {

--- a/wallet/internal/bdb/interface_test.go
+++ b/wallet/internal/bdb/interface_test.go
@@ -492,7 +492,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -520,8 +520,8 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		// Return an error to force a rollback.
 		return forceRollbackError
 	})
-	if err != forceRollbackError {
-		if err == errSubTestFail {
+	if !errors.Is(err, forceRollbackError) {
+		if errors.Is(err, errSubTestFail) {
 			return false
 		}
 
@@ -545,7 +545,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -565,7 +565,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -585,7 +585,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -605,7 +605,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -650,7 +650,7 @@ func testAdditionalErrors(tc *testContext) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -1630,7 +1630,7 @@ func (m *Manager) syncAccountToAddrIndex(ns walletdb.ReadWriteBucket, account ui
 	// been created.
 	for child := syncToIndex; ; child-- {
 		xpubChild, err := xpubBranch.Child(child)
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			continue
 		}
 		if err != nil {
@@ -2325,7 +2325,7 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 	if err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 
@@ -2335,7 +2335,7 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 	if err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 
@@ -2347,7 +2347,7 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 	if err := checkBranchKeys(acctKeyLegacyPriv); err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 
@@ -2356,7 +2356,7 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 	if err := checkBranchKeys(acctKeySLIP0044Priv); err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 
@@ -2580,7 +2580,7 @@ func createWatchOnly(ns walletdb.ReadWriteBucket, hdPubKey string, pubPassphrase
 	if err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 
@@ -2592,7 +2592,7 @@ func createWatchOnly(ns walletdb.ReadWriteBucket, hdPubKey string, pubPassphrase
 	if err := checkBranchKeys(acctKeyPub); err != nil {
 		// The seed is unusable if the any of the children in the
 		// required hierarchy can't be derived due to invalid child.
-		if err == hdkeychain.ErrInvalidChild {
+		if errors.Is(err, hdkeychain.ErrInvalidChild) {
 			return errors.E(errors.Seed, hdkeychain.ErrUnusableSeed)
 		}
 

--- a/wallet/udb/stakedb.go
+++ b/wallet/udb/stakedb.go
@@ -125,7 +125,7 @@ func deserializeSStxRecord(serializedSStxRecord []byte, dbVersion uint32) (*sstx
 		msgTx := new(wire.MsgTx)
 		err := msgTx.Deserialize(buf)
 		if err != nil {
-			if err == io.EOF {
+			if errors.Is(err, io.EOF) {
 				err = io.ErrUnexpectedEOF
 			}
 			return nil, err

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -221,7 +221,7 @@ func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byt
 		lastUsedIntIndex := ^uint32(0)
 		for child := uint32(0); child < hdkeychain.HardenedKeyStart; child++ {
 			xpubChild, err := xpubExtBranch.Child(child)
-			if err == hdkeychain.ErrInvalidChild {
+			if errors.Is(err, hdkeychain.ErrInvalidChild) {
 				continue
 			}
 			if err != nil {
@@ -244,7 +244,7 @@ func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byt
 		for child := uint32(0); child < hdkeychain.HardenedKeyStart; child++ {
 			// Same as above but search the internal branch.
 			xpubChild, err := xpubIntBranch.Child(child)
-			if err == hdkeychain.ErrInvalidChild {
+			if errors.Is(err, hdkeychain.ErrInvalidChild) {
 				continue
 			}
 			if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -494,7 +494,7 @@ func (w *Wallet) loadActiveAddrs(ctx context.Context, dbtx walletdb.ReadTx, nb N
 				stop := minUint32(n+1, child+step)
 				for ; child < stop; child++ {
 					addr, err := deriveChildAddress(branchKey, child, w.chainParams)
-					if err == hdkeychain.ErrInvalidChild {
+					if errors.Is(err, hdkeychain.ErrInvalidChild) {
 						continue
 					}
 					if err != nil {
@@ -4226,7 +4226,7 @@ func (w *Wallet) NeedsAccountsSync() (bool, error) {
 			needsSync = false
 			return errBreak
 		})
-		if err == errBreak {
+		if errors.Is(err, errBreak) {
 			return nil
 		}
 		return err

--- a/wallet/walletdb/db_test.go
+++ b/wallet/walletdb/db_test.go
@@ -85,7 +85,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure creating a database with the new type fails with the expected
 	// error.
 	_, err := walletdb.Create(dbType)
-	if err != openError {
+	if !errors.Is(err, openError) {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			openError)
 		return
@@ -94,7 +94,7 @@ func TestCreateOpenFail(t *testing.T) {
 	// Ensure opening a database with the new type fails with the expected
 	// error.
 	_, err = walletdb.Open(dbType)
-	if err != openError {
+	if !errors.Is(err, openError) {
 		t.Errorf("expected error not received - got: %v, want %v", err,
 			openError)
 		return

--- a/wallet/walletdb/interface_test.go
+++ b/wallet/walletdb/interface_test.go
@@ -532,8 +532,8 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		// Return an error to force a rollback.
 		return forceRollbackError
 	})
-	if err != forceRollbackError {
-		if err == errSubTestFail {
+	if !errors.Is(err, forceRollbackError) {
+		if errors.Is(err, errSubTestFail) {
 			return false
 		}
 
@@ -557,7 +557,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -577,7 +577,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -597,7 +597,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -617,7 +617,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false
@@ -659,7 +659,7 @@ func testAdditionalErrors(tc *testContext) bool {
 		return nil
 	})
 	if err != nil {
-		if err != errSubTestFail {
+		if !errors.Is(err, errSubTestFail) {
 			tc.t.Errorf("%v", err)
 		}
 		return false

--- a/walletseed/go.sum
+++ b/walletseed/go.sum
@@ -27,6 +27,7 @@ github.com/decred/dcrd/hdkeychain/v2 v2.0.1/go.mod h1:qPv+vTla19liVHFuXVnQ70dMI4
 github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hng=
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
 github.com/decred/dcrwallet v1.2.2 h1:NdI13wxP+OsWKXPqjWQQ9VSGAl4VoSLBfAunzFreeJg=
+github.com/decred/dcrwallet/errors v1.0.0 h1:XjSILZ2mK5HqWYlhdBpsm+CimFDqDB+hY3tuX0Yh0Jo=
 github.com/decred/dcrwallet/errors v1.0.0/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=
 github.com/decred/dcrwallet/errors v1.0.1 h1:8EF7IY6twRlo9sqWaSfm8abfi2/rHZ1wacOiGvBy+bM=
 github.com/decred/dcrwallet/errors v1.0.1/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=
@@ -40,3 +41,5 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
This replaces all cases of err == x and err != x, where x is not nil,
with the equivalent usage of errors.Is.  Checking errors with
errors.Is correctly detects error conditions when an error wraps the
target error.

Replacements automated using gofmt -r.