### PR TITLE
Run correct JSON-RPC method generator

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -1637,7 +1637,7 @@ func (s *Server) getWalletFee(ctx context.Context, icmd interface{}) (interface{
 // separated by newlines.  It is set during init.  These usages are used for all
 // locales.
 //
-//go:generate go run ../../internal/rpchelp/genrpcserverhelp.go jsonrpc
+//go:generate go run ../../rpchelp/genrpcserverhelp.go jsonrpc
 //go:generate gofmt -w rpcserverhelp.go
 
 var helpDescs map[string]string


### PR DESCRIPTION
The relative path changed when the jsonrpc package moved under the
internal directory structure.  This fixes the go:generate directive to
point to the correct relative location of the file.