### PR TITLE
main: enable --createtemp for all nets

### DIFF
--- a/config.go
+++ b/config.go
@@ -73,6 +73,7 @@ type config struct {
 	AppDataDir         *cfgutil.ExplicitString `short:"A" long:"appdata" description:"Application data directory for wallet config, databases and logs"`
 	TestNet            bool                    `long:"testnet" description:"Use the test network"`
 	SimNet             bool                    `long:"simnet" description:"Use the simulation test network"`
+	RegNet             bool                    `long:"regnet" description:"Use the regression test network"`
 	NoInitialLoad      bool                    `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
 	DebugLevel         string                  `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LogDir             *cfgutil.ExplicitString `long:"logdir" description:"Directory to log output."`
@@ -408,6 +409,10 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		activeNet = &netparams.SimNetParams
 		numNets++
 	}
+	if cfg.RegNet {
+		activeNet = &netparams.RegNetParams
+		numNets++
+	}
 	if numNets > 1 {
 		str := "%s: The testnet and simnet params can't be used " +
 			"together -- choose one"
@@ -498,11 +503,10 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		os.Exit(0)
 	}
 
-	// Exit if you try to use a simulation wallet on anything other than
-	// simnet or testnet.
-	if !cfg.SimNet && cfg.CreateTemp {
+	// Exit if you try to use a simulation wallet on mainnet
+	if !(cfg.SimNet || cfg.TestNet || cfg.RegNet) && cfg.CreateTemp {
 		fmt.Fprintln(os.Stderr, "Tried to create a temporary simulation "+
-			"wallet for network other than simnet!")
+			"wallet for mainnet!")
 		os.Exit(0)
 	}
 

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -382,13 +382,13 @@ func startPromptPass(ctx context.Context, w *wallet.Wallet) []byte {
 
 	// We need to rescan accounts for the initial sync. Unlock the
 	// wallet after prompting for the passphrase. The special case
-	// of a --createtemp simnet wallet is handled by first
+	// of a --createtemp wallet is handled by first
 	// attempting to automatically open it with the default
 	// passphrase. The wallet should also request to be unlocked
 	// if stake mining is currently on, so users with this flag
 	// are prompted here as well.
 	for {
-		if w.ChainParams().Net == wire.SimNet {
+		if w.ChainParams().Net != wire.MainNet {
 			err := w.Unlock(wallet.SimulationPassphrase, nil)
 			if err == nil {
 				// Unlock success with the default password.

--- a/internal/netparams/params.go
+++ b/internal/netparams/params.go
@@ -42,3 +42,12 @@ var SimNetParams = Params{
 	JSONRPCServerPort: "19557",
 	GRPCServerPort:    "19558",
 }
+
+// RegNetParams contains parameters specific to the regression test network
+// (wire.RegNet).
+var RegNetParams = Params{
+	Params:            chaincfg.RegNetParams(),
+	JSONRPCClientPort: "19556",
+	JSONRPCServerPort: "19557",
+	GRPCServerPort:    "19558",
+}

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,6 +3,7 @@
 set -ex
 
 go version
+go clean -testcache
 
 GOTESTFLAGS='-short'
 ROOTPATH=$(go list -m -f {{.Dir}} 2>/dev/null)


### PR DESCRIPTION
Enables creation of a temporary wallet for all networks but MainNet