### PR TITLE
Add a trace region for all db views and updates

### DIFF
--- a/config.go
+++ b/config.go
@@ -543,7 +543,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 
 		if !tempWalletExists {
 			// Perform the initial wallet creation wizard.
-			if err := createSimulationWallet(&cfg); err != nil {
+			if err := createSimulationWallet(ctx, &cfg); err != nil {
 				fmt.Fprintln(os.Stderr, "Unable to create wallet:", err)
 				return loadConfigError(err)
 			}
@@ -567,7 +567,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		// Perform the initial wallet creation wizard.
 		os.Stdout.Sync()
 		if cfg.CreateWatchingOnly {
-			err = createWatchingOnlyWallet(&cfg)
+			err = createWatchingOnlyWallet(ctx, &cfg)
 		} else {
 			err = createWallet(ctx, &cfg)
 		}

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -196,7 +196,7 @@ func run(ctx context.Context) error {
 		errc := make(chan error, 1)
 		go func() {
 			var err error
-			w, err = loader.OpenExistingWallet(walletPass)
+			w, err = loader.OpenExistingWallet(ctx, walletPass)
 			if err != nil {
 				log.Errorf("Failed to open wallet: %v", err)
 				if errors.Is(err, errors.Passphrase) {
@@ -228,7 +228,7 @@ func run(ctx context.Context) error {
 		// the wallet only over RPC, disable this feature for them.
 		if cfg.Pass != "" {
 			passphrase = []byte(cfg.Pass)
-			err = w.Unlock(passphrase, nil)
+			err = w.Unlock(ctx, passphrase, nil)
 			if err != nil {
 				log.Errorf("Incorrect passphrase in pass config setting.")
 				return err
@@ -239,7 +239,7 @@ func run(ctx context.Context) error {
 
 		// Start a ticket buyer.
 		if cfg.EnableTicketBuyer {
-			acct, err := w.AccountNumber(cfg.PurchaseAccount)
+			acct, err := w.AccountNumber(ctx, cfg.PurchaseAccount)
 			if err != nil {
 				log.Errorf("Purchase account %q does not exist", cfg.PurchaseAccount)
 				return err
@@ -359,7 +359,7 @@ func startPromptPass(ctx context.Context, w *wallet.Wallet) []byte {
 	// The wallet is totally desynced, so we need to resync accounts.
 	// Prompt for the password. Then, set the flag it wallet so it
 	// knows which address functions to call when resyncing.
-	needSync, err := w.NeedsAccountsSync()
+	needSync, err := w.NeedsAccountsSync(ctx)
 	if err != nil {
 		log.Errorf("Error determining whether an accounts sync is necessary: %v", err)
 	}
@@ -389,7 +389,7 @@ func startPromptPass(ctx context.Context, w *wallet.Wallet) []byte {
 	// are prompted here as well.
 	for {
 		if w.ChainParams().Net == wire.SimNet {
-			err := w.Unlock(wallet.SimulationPassphrase, nil)
+			err := w.Unlock(ctx, wallet.SimulationPassphrase, nil)
 			if err == nil {
 				// Unlock success with the default password.
 				return wallet.SimulationPassphrase
@@ -401,7 +401,7 @@ func startPromptPass(ctx context.Context, w *wallet.Wallet) []byte {
 			return nil
 		}
 
-		err = w.Unlock(passphrase, nil)
+		err = w.Unlock(ctx, passphrase, nil)
 		if err != nil {
 			fmt.Println("Incorrect password entered. Please " +
 				"try again.")

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -6,6 +6,7 @@
 package loader
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -102,7 +103,7 @@ func (l *Loader) RunAfterLoad(fn func(*wallet.Wallet)) {
 
 // CreateWatchingOnlyWallet creates a new watch-only wallet using the provided
 // extended public key and public passphrase.
-func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte) (w *wallet.Wallet, err error) {
+func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey string, pubPass []byte) (w *wallet.Wallet, err error) {
 	const op errors.Op = "loader.CreateWatchingOnlyWallet"
 
 	defer l.mu.Unlock()
@@ -157,7 +158,7 @@ func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte)
 	}
 
 	// Initialize the watch-only database for the wallet before opening.
-	err = wallet.CreateWatchOnly(db, extendedPubKey, pubPass, l.chainParams)
+	err = wallet.CreateWatchOnly(ctx, db, extendedPubKey, pubPass, l.chainParams)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -181,7 +182,7 @@ func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte)
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
 	}
-	w, err = wallet.Open(cfg)
+	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -193,7 +194,7 @@ func (l *Loader) CreateWatchingOnlyWallet(extendedPubKey string, pubPass []byte)
 // CreateNewWallet creates a new wallet using the provided public and private
 // passphrases.  The seed is optional.  If non-nil, addresses are derived from
 // this seed.  If nil, a secure random seed is generated.
-func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w *wallet.Wallet, err error) {
+func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphrase, seed []byte) (w *wallet.Wallet, err error) {
 	const op errors.Op = "loader.CreateNewWallet"
 
 	defer l.mu.Unlock()
@@ -248,7 +249,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 	}
 
 	// Initialize the newly created database for the wallet before opening.
-	err = wallet.Create(db, pubPassphrase, privPassphrase, seed, l.chainParams)
+	err = wallet.Create(ctx, db, pubPassphrase, privPassphrase, seed, l.chainParams)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -272,7 +273,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
 	}
-	w, err = wallet.Open(cfg)
+	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
@@ -285,7 +286,7 @@ func (l *Loader) CreateNewWallet(pubPassphrase, privPassphrase, seed []byte) (w 
 // and the public passphrase.  If the loader is being called by a context where
 // standard input prompts may be used during wallet upgrades, setting
 // canConsolePrompt will enable these prompts.
-func (l *Loader) OpenExistingWallet(pubPassphrase []byte) (w *wallet.Wallet, rerr error) {
+func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (w *wallet.Wallet, rerr error) {
 	const op errors.Op = "loader.OpenExistingWallet"
 
 	defer l.mu.Unlock()
@@ -333,7 +334,7 @@ func (l *Loader) OpenExistingWallet(pubPassphrase []byte) (w *wallet.Wallet, rer
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
 	}
-	w, err = wallet.Open(cfg)
+	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
 		return nil, errors.E(op, err)
 	}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -292,7 +292,7 @@ func (s *walletServer) Network(ctx context.Context, req *pb.NetworkRequest) (
 }
 
 func (s *walletServer) CoinType(ctx context.Context, req *pb.CoinTypeRequest) (*pb.CoinTypeResponse, error) {
-	coinType, err := s.wallet.CoinType()
+	coinType, err := s.wallet.CoinType(ctx)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -302,7 +302,7 @@ func (s *walletServer) CoinType(ctx context.Context, req *pb.CoinTypeRequest) (*
 func (s *walletServer) AccountNumber(ctx context.Context, req *pb.AccountNumberRequest) (
 	*pb.AccountNumberResponse, error) {
 
-	accountNum, err := s.wallet.AccountNumber(req.AccountName)
+	accountNum, err := s.wallet.AccountNumber(ctx, req.AccountName)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -311,7 +311,7 @@ func (s *walletServer) AccountNumber(ctx context.Context, req *pb.AccountNumberR
 }
 
 func (s *walletServer) Accounts(ctx context.Context, req *pb.AccountsRequest) (*pb.AccountsResponse, error) {
-	resp, err := s.wallet.Accounts()
+	resp, err := s.wallet.Accounts(ctx, )
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -337,7 +337,7 @@ func (s *walletServer) Accounts(ctx context.Context, req *pb.AccountsRequest) (*
 func (s *walletServer) RenameAccount(ctx context.Context, req *pb.RenameAccountRequest) (
 	*pb.RenameAccountResponse, error) {
 
-	err := s.wallet.RenameAccount(req.AccountNumber, req.NewName)
+	err := s.wallet.RenameAccount(ctx, req.AccountNumber, req.NewName)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -381,7 +381,7 @@ func (s *walletServer) Rescan(req *pb.RescanRequest, svr pb.WalletService_Rescan
 		blockID = wallet.NewBlockIdentifierFromHeight(req.BeginHeight)
 	}
 
-	b, err := s.wallet.BlockInfo(blockID)
+	b, err := s.wallet.BlockInfo(svr.Context(), blockID)
 	if err != nil {
 		return translateError(err)
 	}
@@ -427,7 +427,7 @@ func (s *walletServer) NextAccount(ctx context.Context, req *pb.NextAccountReque
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err := s.wallet.Unlock(req.Passphrase, lock)
+	err := s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -509,7 +509,7 @@ func (s *walletServer) ImportPrivateKey(ctx context.Context, req *pb.ImportPriva
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err = s.wallet.Unlock(req.Passphrase, lock)
+	err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -563,7 +563,7 @@ func (s *walletServer) ImportScript(ctx context.Context,
 	}
 	ownAddrs := 0
 	for _, a := range addrs {
-		haveAddr, err := s.wallet.HaveAddress(a)
+		haveAddr, err := s.wallet.HaveAddress(ctx, a)
 		if err != nil {
 			return nil, translateError(err)
 		}
@@ -582,7 +582,7 @@ func (s *walletServer) ImportScript(ctx context.Context,
 		defer func() {
 			lock <- time.Time{} // send matters, not the value
 		}()
-		err = s.wallet.Unlock(req.Passphrase, lock)
+		err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 		if err != nil {
 			return nil, translateError(err)
 		}
@@ -625,7 +625,7 @@ func (s *walletServer) Balance(ctx context.Context, req *pb.BalanceRequest) (
 
 	account := req.AccountNumber
 	reqConfs := req.RequiredConfirmations
-	bals, err := s.wallet.CalculateAccountBalance(account, reqConfs)
+	bals, err := s.wallet.CalculateAccountBalance(ctx, account, reqConfs)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -645,11 +645,11 @@ func (s *walletServer) Balance(ctx context.Context, req *pb.BalanceRequest) (
 }
 
 func (s *walletServer) TicketPrice(ctx context.Context, req *pb.TicketPriceRequest) (*pb.TicketPriceResponse, error) {
-	sdiff, err := s.wallet.NextStakeDifficulty()
+	sdiff, err := s.wallet.NextStakeDifficulty(ctx, )
 	if err != nil {
 		return nil, translateError(err)
 	}
-	_, tipHeight := s.wallet.MainChainTip()
+	_, tipHeight := s.wallet.MainChainTip(ctx, )
 	resp := &pb.TicketPriceResponse{
 		TicketPrice: int64(sdiff),
 		Height:      tipHeight,
@@ -668,7 +668,7 @@ func (s *walletServer) StakeInfo(ctx context.Context, req *pb.StakeInfoRequest) 
 	if rpc != nil {
 		si, err = s.wallet.StakeInfoPrecise(ctx, rpc)
 	} else {
-		si, err = s.wallet.StakeInfo()
+		si, err = s.wallet.StakeInfo(ctx, )
 	}
 	if err != nil {
 		return nil, translateError(err)
@@ -762,7 +762,7 @@ func (s *walletServer) SweepAccount(ctx context.Context, req *pb.SweepAccountReq
 		}
 	}
 
-	account, err := s.wallet.AccountNumber(req.SourceAccount)
+	account, err := s.wallet.AccountNumber(ctx, req.SourceAccount)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -772,7 +772,7 @@ func (s *walletServer) SweepAccount(ctx context.Context, req *pb.SweepAccountReq
 		return nil, translateError(err)
 	}
 
-	tx, err := s.wallet.NewUnsignedTransaction(nil, feePerKb, account,
+	tx, err := s.wallet.NewUnsignedTransaction(ctx, nil, feePerKb, account,
 		int32(req.RequiredConfirmations), wallet.OutputSelectionAlgorithmAll,
 		changeSource)
 	if err != nil {
@@ -811,7 +811,7 @@ func (s *walletServer) BlockInfo(ctx context.Context, req *pb.BlockInfoRequest) 
 		blockID = wallet.NewBlockIdentifierFromHeight(req.BlockHeight)
 	}
 
-	b, err := s.wallet.BlockInfo(blockID)
+	b, err := s.wallet.BlockInfo(ctx, blockID)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -838,7 +838,7 @@ func (s *walletServer) UnspentOutputs(req *pb.UnspentOutputsRequest, svr pb.Wall
 		Account:               req.Account,
 		RequiredConfirmations: req.RequiredConfirmations,
 	}
-	inputDetail, err := s.wallet.SelectInputs(dcrutil.Amount(req.TargetAmount), policy)
+	inputDetail, err := s.wallet.SelectInputs(svr.Context(), dcrutil.Amount(req.TargetAmount), policy)
 	// Do not return errors to caller when there was insufficient spendable
 	// outputs available for the target amount.
 	if err != nil && !errors.Is(err, errors.InsufficientBalance) {
@@ -851,7 +851,7 @@ func (s *walletServer) UnspentOutputs(req *pb.UnspentOutputsRequest, svr pb.Wall
 		case <-svr.Context().Done():
 			return status.Errorf(codes.Canceled, "unspentoutputs cancelled")
 		default:
-			outputInfo, err := s.wallet.OutputInfo(&input.PreviousOutPoint)
+			outputInfo, err := s.wallet.OutputInfo(svr.Context(), &input.PreviousOutPoint)
 			if err != nil {
 				return translateError(err)
 			}
@@ -884,7 +884,7 @@ func (s *walletServer) FundTransaction(ctx context.Context, req *pb.FundTransact
 		Account:               req.Account,
 		RequiredConfirmations: req.RequiredConfirmations,
 	}
-	inputDetail, err := s.wallet.SelectInputs(dcrutil.Amount(req.TargetAmount), policy)
+	inputDetail, err := s.wallet.SelectInputs(ctx, dcrutil.Amount(req.TargetAmount), policy)
 	// Do not return errors to caller when there was insufficient spendable
 	// outputs available for the target amount.
 	if err != nil && !errors.Is(err, errors.InsufficientBalance) {
@@ -893,7 +893,7 @@ func (s *walletServer) FundTransaction(ctx context.Context, req *pb.FundTransact
 
 	selectedOutputs := make([]*pb.FundTransactionResponse_PreviousOutput, len(inputDetail.Inputs))
 	for i, input := range inputDetail.Inputs {
-		outputInfo, err := s.wallet.OutputInfo(&input.PreviousOutPoint)
+		outputInfo, err := s.wallet.OutputInfo(ctx, &input.PreviousOutPoint)
 		if err != nil {
 			return nil, translateError(err)
 		}
@@ -1028,7 +1028,7 @@ func (s *walletServer) ConstructTransaction(ctx context.Context, req *pb.Constru
 		}
 	}
 
-	tx, err := s.wallet.NewUnsignedTransaction(outputs, feePerKb, req.SourceAccount,
+	tx, err := s.wallet.NewUnsignedTransaction(ctx, outputs, feePerKb, req.SourceAccount,
 		req.RequiredConfirmations, algo, changeSource)
 	if err != nil {
 		return nil, translateError(err)
@@ -1056,7 +1056,7 @@ func (s *walletServer) ConstructTransaction(ctx context.Context, req *pb.Constru
 }
 
 func (s *walletServer) GetAccountExtendedPubKey(ctx context.Context, req *pb.GetAccountExtendedPubKeyRequest) (*pb.GetAccountExtendedPubKeyResponse, error) {
-	accExtendedPubKey, err := s.wallet.MasterPubKey(req.AccountNumber)
+	accExtendedPubKey, err := s.wallet.MasterPubKey(ctx, req.AccountNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -1073,13 +1073,13 @@ func (s *walletServer) GetAccountExtendedPrivKey(ctx context.Context, req *pb.Ge
 		zero(req.Passphrase)
 	}
 
-	err := s.wallet.Unlock(req.Passphrase, lock)
+	err := s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
 	defer lockWallet()
 
-	accExtendedPrivKey, err := s.wallet.MasterPrivKey(req.AccountNumber)
+	accExtendedPrivKey, err := s.wallet.MasterPrivKey(ctx, req.AccountNumber)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1095,7 +1095,7 @@ func (s *walletServer) GetTransaction(ctx context.Context, req *pb.GetTransactio
 		return nil, status.Errorf(codes.InvalidArgument, "transaction_hash has invalid length")
 	}
 
-	txSummary, confs, blockHash, err := s.wallet.TransactionSummary(txHash)
+	txSummary, confs, blockHash, err := s.wallet.TransactionSummary(ctx, txHash)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1188,7 +1188,7 @@ func (s *walletServer) GetTransactions(req *pb.GetTransactionsRequest,
 		}
 	}
 
-	err := s.wallet.GetTransactions(rangeFn, startBlock, endBlock)
+	err := s.wallet.GetTransactions(ctx, rangeFn, startBlock, endBlock)
 	if err != nil {
 		return translateError(err)
 	}
@@ -1211,7 +1211,7 @@ func (s *walletServer) GetTicket(ctx context.Context, req *pb.GetTicketRequest) 
 	var ticketSummary *wallet.TicketSummary
 	var blockHeader *wire.BlockHeader
 	if rpc == nil {
-		ticketSummary, blockHeader, err = s.wallet.GetTicketInfo(ticketHash)
+		ticketSummary, blockHeader, err = s.wallet.GetTicketInfo(ctx, ticketHash)
 	} else {
 		ticketSummary, blockHeader, err =
 			s.wallet.GetTicketInfoPrecise(ctx, rpc, ticketHash)
@@ -1295,7 +1295,7 @@ func (s *walletServer) GetTickets(req *pb.GetTicketsRequest,
 	if rpc, ok := n.(*dcrd.RPC); ok {
 		err = s.wallet.GetTicketsPrecise(ctx, rpc, rangeFn, startBlock, endBlock)
 	} else {
-		err = s.wallet.GetTickets(rangeFn, startBlock, endBlock)
+		err = s.wallet.GetTickets(ctx, rangeFn, startBlock, endBlock)
 	}
 	if err != nil {
 		return translateError(err)
@@ -1320,7 +1320,7 @@ func (s *walletServer) ChangePassphrase(ctx context.Context, req *pb.ChangePassp
 	var err error
 	switch req.Key {
 	case pb.ChangePassphraseRequest_PRIVATE:
-		err = s.wallet.ChangePrivatePassphrase(oldPass, newPass)
+		err = s.wallet.ChangePrivatePassphrase(ctx, oldPass, newPass)
 	case pb.ChangePassphraseRequest_PUBLIC:
 		if len(oldPass) == 0 {
 			oldPass = []byte(wallet.InsecurePubPassphrase)
@@ -1328,7 +1328,7 @@ func (s *walletServer) ChangePassphrase(ctx context.Context, req *pb.ChangePassp
 		if len(newPass) == 0 {
 			newPass = []byte(wallet.InsecurePubPassphrase)
 		}
-		err = s.wallet.ChangePublicPassphrase(oldPass, newPass)
+		err = s.wallet.ChangePublicPassphrase(ctx, oldPass, newPass)
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "Unknown key type (%d)", req.Key)
 	}
@@ -1354,7 +1354,7 @@ func (s *walletServer) SignTransaction(ctx context.Context, req *pb.SignTransact
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err = s.wallet.Unlock(req.Passphrase, lock)
+	err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1375,7 +1375,7 @@ func (s *walletServer) SignTransaction(ctx context.Context, req *pb.SignTransact
 		}
 	}
 
-	invalidSigs, err := s.wallet.SignTransaction(&tx, txscript.SigHashAll, additionalPkScripts, nil, nil)
+	invalidSigs, err := s.wallet.SignTransaction(ctx, &tx, txscript.SigHashAll, additionalPkScripts, nil, nil)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1407,7 +1407,7 @@ func (s *walletServer) SignTransactions(ctx context.Context, req *pb.SignTransac
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err := s.wallet.Unlock(req.Passphrase, lock)
+	err := s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1438,7 +1438,7 @@ func (s *walletServer) SignTransactions(ctx context.Context, req *pb.SignTransac
 				"Bytes do not represent a valid raw transaction: %v", err)
 		}
 
-		invalidSigs, err := s.wallet.SignTransaction(&tx, txscript.SigHashAll, additionalPkScripts, nil, nil)
+		invalidSigs, err := s.wallet.SignTransaction(ctx, &tx, txscript.SigHashAll, additionalPkScripts, nil, nil)
 		if err != nil {
 			return nil, translateError(err)
 		}
@@ -1485,7 +1485,7 @@ func (s *walletServer) CreateSignature(ctx context.Context, req *pb.CreateSignat
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err = s.wallet.Unlock(req.Passphrase, lock)
+	err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1496,7 +1496,7 @@ func (s *walletServer) CreateSignature(ctx context.Context, req *pb.CreateSignat
 	}
 
 	hashType := txscript.SigHashType(req.HashType)
-	sig, pubkey, err := s.wallet.CreateSignature(&tx, req.InputIndex, addr, hashType, req.PreviousPkScript)
+	sig, pubkey, err := s.wallet.CreateSignature(ctx, &tx, req.InputIndex, addr, hashType, req.PreviousPkScript)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1598,7 +1598,7 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err = s.wallet.Unlock(req.Passphrase, lock)
+	err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1626,7 +1626,7 @@ func (s *walletServer) RevokeTickets(ctx context.Context, req *pb.RevokeTicketsR
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err = s.wallet.Unlock(req.Passphrase, lock)
+	err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1683,7 +1683,7 @@ func (s *walletServer) CommittedTickets(ctx context.Context, req *pb.CommittedTi
 	}
 
 	// Figure out which tickets we own
-	out, outAddr, err := s.wallet.CommittedTickets(in)
+	out, outAddr, err := s.wallet.CommittedTickets(ctx, in)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1709,7 +1709,7 @@ func (s *walletServer) CommittedTickets(ctx context.Context, req *pb.CommittedTi
 	return ctr, nil
 }
 
-func (s *walletServer) signMessage(address, message string) ([]byte, error) {
+func (s *walletServer) signMessage(ctx context.Context, address, message string) ([]byte, error) {
 	addr, err := decodeAddress(address, s.wallet.ChainParams())
 	if err != nil {
 		return nil, err
@@ -1728,7 +1728,7 @@ func (s *walletServer) signMessage(address, message string) ([]byte, error) {
 		goto WrongAddrKind
 	}
 
-	sig, err = s.wallet.SignMessage(message, addr)
+	sig, err = s.wallet.SignMessage(ctx, message, addr)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1739,17 +1739,17 @@ WrongAddrKind:
 		"address must be secp256k1 P2PK or P2PKH")
 }
 
-func (s *walletServer) SignMessage(cts context.Context, req *pb.SignMessageRequest) (*pb.SignMessageResponse, error) {
+func (s *walletServer) SignMessage(ctx context.Context, req *pb.SignMessageRequest) (*pb.SignMessageResponse, error) {
 	lock := make(chan time.Time, 1)
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err := s.wallet.Unlock(req.Passphrase, lock)
+	err := s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
 
-	sig, err := s.signMessage(req.Address, req.Message)
+	sig, err := s.signMessage(ctx, req.Address, req.Message)
 	if err != nil {
 		return nil, err
 	}
@@ -1757,12 +1757,12 @@ func (s *walletServer) SignMessage(cts context.Context, req *pb.SignMessageReque
 	return &pb.SignMessageResponse{Signature: sig}, nil
 }
 
-func (s *walletServer) SignMessages(cts context.Context, req *pb.SignMessagesRequest) (*pb.SignMessagesResponse, error) {
+func (s *walletServer) SignMessages(ctx context.Context, req *pb.SignMessagesRequest) (*pb.SignMessagesResponse, error) {
 	lock := make(chan time.Time, 1)
 	defer func() {
 		lock <- time.Time{} // send matters, not the value
 	}()
-	err := s.wallet.Unlock(req.Passphrase, lock)
+	err := s.wallet.Unlock(ctx, req.Passphrase, lock)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -1773,7 +1773,7 @@ func (s *walletServer) SignMessages(cts context.Context, req *pb.SignMessagesReq
 	}
 	for _, v := range req.Messages {
 		e := ""
-		sig, err := s.signMessage(v.Address, v.Message)
+		sig, err := s.signMessage(ctx, v.Address, v.Message)
 		if err != nil {
 			e = err.Error()
 		}
@@ -1795,7 +1795,7 @@ func (s *walletServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddr
 	}
 
 	result.IsValid = true
-	addrInfo, err := s.wallet.AddressInfo(addr)
+	addrInfo, err := s.wallet.AddressInfo(ctx, addr)
 	if err != nil {
 		if errors.Is(err, errors.NotExist) {
 			// No additional information available about the address.
@@ -1807,12 +1807,12 @@ func (s *walletServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddr
 	// The address lookup was successful which means there is further
 	// information about it available and it is "mine".
 	result.IsMine = true
-	acctName, err := s.wallet.AccountName(addrInfo.Account())
+	acctName, err := s.wallet.AccountName(ctx, addrInfo.Account())
 	if err != nil {
 		return nil, translateError(err)
 	}
 
-	acctNumber, err := s.wallet.AccountNumber(acctName)
+	acctNumber, err := s.wallet.AccountNumber(ctx, acctName)
 	if err != nil {
 		return nil, err
 	}
@@ -1835,7 +1835,7 @@ func (s *walletServer) ValidateAddress(ctx context.Context, req *pb.ValidateAddr
 
 		// The script is only available if the manager is unlocked, so
 		// just break out now if there is an error.
-		script, err := s.wallet.RedeemScriptCopy(addr)
+		script, err := s.wallet.RedeemScriptCopy(ctx, addr)
 		if err != nil {
 			break
 		}
@@ -2208,7 +2208,7 @@ func (t *ticketbuyerV2Server) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr 
 		zero(req.Passphrase)
 	}
 
-	err = wallet.Unlock(req.Passphrase, lock)
+	err = wallet.Unlock(svr.Context(), req.Passphrase, lock)
 	if err != nil {
 		return translateError(err)
 	}
@@ -2248,7 +2248,7 @@ func (s *loaderServer) CreateWallet(ctx context.Context, req *pb.CreateWalletReq
 		return nil, status.Errorf(codes.InvalidArgument, "seed is a required parameter")
 	}
 
-	_, err := s.loader.CreateNewWallet(pubPassphrase, req.PrivatePassphrase, req.Seed)
+	_, err := s.loader.CreateNewWallet(ctx, pubPassphrase, req.PrivatePassphrase, req.Seed)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -2265,7 +2265,7 @@ func (s *loaderServer) CreateWatchingOnlyWallet(ctx context.Context, req *pb.Cre
 		pubPassphrase = []byte(wallet.InsecurePubPassphrase)
 	}
 
-	_, err := s.loader.CreateWatchingOnlyWallet(req.ExtendedPubKey, pubPassphrase)
+	_, err := s.loader.CreateWatchingOnlyWallet(ctx, req.ExtendedPubKey, pubPassphrase)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -2282,7 +2282,7 @@ func (s *loaderServer) OpenWallet(ctx context.Context, req *pb.OpenWalletRequest
 		pubPassphrase = []byte(wallet.InsecurePubPassphrase)
 	}
 
-	w, err := s.loader.OpenExistingWallet(pubPassphrase)
+	w, err := s.loader.OpenExistingWallet(ctx, pubPassphrase)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -2354,7 +2354,7 @@ func (s *loaderServer) RpcSync(req *pb.RpcSyncRequest, svr pb.WalletLoaderServic
 			zero(req.PrivatePassphrase)
 		}
 		defer lockWallet()
-		err := wallet.Unlock(req.PrivatePassphrase, lock)
+		err := wallet.Unlock(svr.Context(), req.PrivatePassphrase, lock)
 		if err != nil {
 			return translateError(err)
 		}
@@ -2496,7 +2496,7 @@ func (s *loaderServer) SpvSync(req *pb.SpvSyncRequest, svr pb.WalletLoaderServic
 			zero(req.PrivatePassphrase)
 		}
 		defer lockWallet()
-		err := wallet.Unlock(req.PrivatePassphrase, lock)
+		err := wallet.Unlock(svr.Context(), req.PrivatePassphrase, lock)
 		if err != nil {
 			return translateError(err)
 		}
@@ -2652,7 +2652,7 @@ func (s *loaderServer) RescanPoint(ctx context.Context, req *pb.RescanPointReque
 	if !ok {
 		return nil, status.Errorf(codes.FailedPrecondition, "Wallet has not been loaded")
 	}
-	rescanPoint, err := wallet.RescanPoint()
+	rescanPoint, err := wallet.RescanPoint(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.FailedPrecondition, "Rescan point failed to be requested %v", err)
 	}
@@ -2752,7 +2752,7 @@ func (s *votingServer) checkReady() bool {
 
 func (s *votingServer) VoteChoices(ctx context.Context, req *pb.VoteChoicesRequest) (*pb.VoteChoicesResponse, error) {
 	version, agendas := wallet.CurrentAgendas(s.wallet.ChainParams())
-	choices, voteBits, err := s.wallet.AgendaChoices()
+	choices, voteBits, err := s.wallet.AgendaChoices(ctx, )
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -2787,7 +2787,7 @@ func (s *votingServer) SetVoteChoices(ctx context.Context, req *pb.SetVoteChoice
 			ChoiceID: c.ChoiceId,
 		}
 	}
-	voteBits, err := s.wallet.SetAgendaChoices(choices...)
+	voteBits, err := s.wallet.SetAgendaChoices(ctx, choices...)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -2957,7 +2957,7 @@ func (s *decodeMessageServer) DecodeRawTransaction(ctx context.Context, req *pb.
 }
 
 func (s *walletServer) BestBlock(ctx context.Context, req *pb.BestBlockRequest) (*pb.BestBlockResponse, error) {
-	hash, height := s.wallet.MainChainTip()
+	hash, height := s.wallet.MainChainTip(ctx, )
 	resp := &pb.BestBlockResponse{
 		Hash:   hash[:],
 		Height: uint32(height),

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -145,7 +145,7 @@ func (s *Syncer) Rescan(ctx context.Context, blockHashes []chainhash.Hash, save 
 
 	cfilters := make([]*gcs.Filter, 0, len(blockHashes))
 	for i := 0; i < len(blockHashes); i++ {
-		f, err := s.wallet.CFilter(&blockHashes[i])
+		f, err := s.wallet.CFilter(ctx, &blockHashes[i])
 		if err != nil {
 			return err
 		}

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -59,7 +59,7 @@ func New(w *wallet.Wallet) *TB {
 // ever becomes incorrect due to a wallet passphrase change, Run exits with an
 // errors.Passphrase error.
 func (tb *TB) Run(ctx context.Context, passphrase []byte) error {
-	err := tb.wallet.Unlock(passphrase, nil)
+	err := tb.wallet.Unlock(ctx, passphrase, nil)
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *chainhash.Hash) e
 
 	// Don't buy tickets for this attached block when transactions are not
 	// synced through the tip block.
-	rp, err := w.RescanPoint()
+	rp, err := w.RescanPoint(ctx)
 	if err != nil {
 		return err
 	}
@@ -131,12 +131,12 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *chainhash.Hash) e
 	// Ensure wallet is unlocked with the current passphrase.  If the passphase
 	// is changed, the Run exits and TB must be restarted with the new
 	// passphrase.
-	err = w.Unlock(passphrase, nil)
+	err = w.Unlock(ctx, passphrase, nil)
 	if err != nil {
 		return err
 	}
 
-	header, err := w.BlockHeader(tip)
+	header, err := w.BlockHeader(ctx, tip)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *chainhash.Hash) e
 	tb.mu.Unlock()
 
 	// Determine how many tickets to buy
-	bal, err := w.CalculateAccountBalance(account, minconf)
+	bal, err := w.CalculateAccountBalance(ctx, account, minconf)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *chainhash.Hash) e
 		return nil
 	}
 	spendable -= maintain
-	sdiff, err := w.NextStakeDifficultyAfterHeader(header)
+	sdiff, err := w.NextStakeDifficultyAfterHeader(ctx, header)
 	if err != nil {
 		return err
 	}

--- a/wallet/cointype.go
+++ b/wallet/cointype.go
@@ -5,6 +5,8 @@
 package wallet
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/hdkeychain/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/wallet/v3/udb"
@@ -18,12 +20,12 @@ import (
 // This function does not register addresses from the new account 0 with the
 // wallet's network backend.  This is intentional as it allows offline
 // activities, such as wallet creation, to perform this upgrade.
-func (w *Wallet) UpgradeToSLIP0044CoinType() error {
+func (w *Wallet) UpgradeToSLIP0044CoinType(ctx context.Context) error {
 	const op errors.Op = "wallet.UpgradeToSLIP0044CoinType"
 
 	var acctXpub, extBranchXpub, intBranchXpub *hdkeychain.ExtendedKey
 
-	err := walletdb.Update(w.db, func(dbtx walletdb.ReadWriteTx) error {
+	err := walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 		err := w.Manager.UpgradeToSLIP0044CoinType(dbtx)
 		if err != nil {
 			return err

--- a/wallet/internal/bdb/driver_test.go
+++ b/wallet/internal/bdb/driver_test.go
@@ -8,6 +8,7 @@ package bdb_test
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"testing"
 
@@ -89,6 +90,7 @@ func TestCreateOpenFail(t *testing.T) {
 // TestPersistence ensures that values stored are still valid after closing and
 // reopening the database.
 func TestPersistence(t *testing.T) {
+	ctx := context.Background()
 	// Create a new database to run tests against.
 	dbPath := "persistencetest.db"
 	db, err := walletdb.Create(dbType, dbPath)
@@ -108,7 +110,7 @@ func TestPersistence(t *testing.T) {
 	}
 	ns1Key := []byte("ns1")
 
-	walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+	walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		ns1Bkt, err := tx.CreateTopLevelBucket(ns1Key)
 		if err != nil {
 			return errors.E(errors.IO, err)
@@ -138,7 +140,7 @@ func TestPersistence(t *testing.T) {
 
 	// Ensure the values previously stored in the bucket still exist
 	// and are correct.
-	walletdb.View(db, func(tx walletdb.ReadTx) error {
+	walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns1Bkt := tx.ReadBucket(ns1Key)
 		for k, v := range storeValues {
 			val := ns1Bkt.Get([]byte(k))

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -351,7 +351,7 @@ func (s *NotificationServer) notifyAttachedBlock(dbtx walletdb.ReadTx, block *wi
 	}
 }
 
-func (s *NotificationServer) sendAttachedBlockNotification() {
+func (s *NotificationServer) sendAttachedBlockNotification(ctx context.Context) {
 	// Avoid work if possible
 	s.mu.Lock()
 	if len(s.transactions) == 0 {
@@ -375,7 +375,7 @@ func (s *NotificationServer) sendAttachedBlockNotification() {
 		bals          = make(map[uint32]dcrutil.Amount)
 		unminedHashes []*chainhash.Hash
 	)
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		var err error
 		unminedHashes, err = w.TxStore.UnminedTxHashes(txmgrNs)
@@ -834,7 +834,7 @@ type ConfirmationNotification struct {
 func (c *ConfirmationNotificationsClient) Watch(txHashes []*chainhash.Hash, stopAfter int32) {
 	w := c.s.wallet
 	r := make([]ConfirmationNotification, 0, len(c.watched))
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(c.ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		_, tipHeight := w.TxStore.MainChainTip(txmgrNs)
 		// cannot range here, txHashes may be modified
@@ -930,7 +930,7 @@ func (c *ConfirmationNotificationsClient) process(tipHeight int32) {
 		result: make([]ConfirmationNotification, 0, len(c.watched)),
 	}
 	var unwatch []*chainhash.Hash
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(c.ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		for txHash, stopAfter := range c.watched {
 			txHash := txHash // copy

--- a/wallet/reorg_test.go
+++ b/wallet/reorg_test.go
@@ -74,7 +74,8 @@ func mustAddBlockNode(t *testing.T, forest *SidechainForest, n *BlockNode) {
 }
 
 func (tw *tw) evaluateBestChain(forest *SidechainForest, expectedBranchLen int, expectedTip *chainhash.Hash) []*BlockNode {
-	bestChain, err := tw.EvaluateBestChain(forest)
+	ctx := context.Background()
+	bestChain, err := tw.EvaluateBestChain(ctx, forest)
 	if err != nil {
 		tw.Fatal(err)
 	}
@@ -92,6 +93,7 @@ func (tw *tw) assertNoBetterChain(forest *SidechainForest) {
 }
 
 func (tw *tw) chainSwitch(forest *SidechainForest, chain []*BlockNode) {
+	ctx := context.Background()
 	prevChain, err := tw.ChainSwitch(context.Background(), forest, chain, nil)
 	if err != nil {
 		tw.Fatal(err)
@@ -99,14 +101,15 @@ func (tw *tw) chainSwitch(forest *SidechainForest, chain []*BlockNode) {
 	for _, n := range prevChain {
 		forest.AddBlockNode(n)
 	}
-	tip, _ := tw.MainChainTip()
+	tip, _ := tw.MainChainTip(ctx)
 	if tip != *chain[len(chain)-1].Hash {
 		tw.Fatalf("expected tip %v, got %v", chain[len(chain)-1].Hash, &tip)
 	}
 }
 
 func (tw *tw) expectBlockInMainChain(hash *chainhash.Hash, have, invalidated bool) {
-	haveBlock, isInvalidated, err := tw.BlockInMainChain(hash)
+	ctx := context.Background()
+	haveBlock, isInvalidated, err := tw.BlockInMainChain(ctx, hash)
 	if err != nil {
 		tw.Fatal(err)
 	}

--- a/wallet/setup_test.go
+++ b/wallet/setup_test.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -23,6 +24,7 @@ var basicWalletConfig = Config{
 }
 
 func testWallet(t *testing.T, cfg *Config) (w *Wallet, teardown func()) {
+	ctx := context.Background()
 	f, err := ioutil.TempFile("", "dcrwallet.testdb")
 	if err != nil {
 		t.Fatal(err)
@@ -36,13 +38,13 @@ func testWallet(t *testing.T, cfg *Config) (w *Wallet, teardown func()) {
 		db.Close()
 		os.Remove(f.Name())
 	}
-	err = Create(opaqueDB{db}, []byte(InsecurePubPassphrase), []byte("private"), nil, cfg.Params)
+	err = Create(ctx, opaqueDB{db}, []byte(InsecurePubPassphrase), []byte("private"), nil, cfg.Params)
 	if err != nil {
 		rm()
 		t.Fatal(err)
 	}
 	cfg.DB = opaqueDB{db}
-	w, err = Open(cfg)
+	w, err = Open(ctx, cfg)
 	if err != nil {
 		rm()
 		t.Fatal(err)

--- a/wallet/sidechains.go
+++ b/wallet/sidechains.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"context"
 	"math/big"
 	"sort"
 
@@ -243,10 +244,10 @@ func (f *SidechainForest) PruneTree(root *chainhash.Hash) {
 // EvaluateBestChain returns block nodes to create the best main chain.  These
 // may extend the main chain or require a reorg.  An empty slice indicates there
 // is no better chain.
-func (w *Wallet) EvaluateBestChain(f *SidechainForest) ([]*BlockNode, error) {
+func (w *Wallet) EvaluateBestChain(ctx context.Context, f *SidechainForest) ([]*BlockNode, error) {
 	const op errors.Op = "wallet.EvaluateBestChain"
 	var newBestChain []*BlockNode
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		ns := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		tipHash, _ := w.TxStore.MainChainTip(ns)
 		tipHeader, err := w.TxStore.GetBlockHeader(dbtx, &tipHash)

--- a/wallet/stakepool.go
+++ b/wallet/stakepool.go
@@ -5,6 +5,8 @@
 package wallet
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/wallet/v3/udb"
@@ -13,7 +15,7 @@ import (
 
 // StakePoolUserInfo returns the stake pool user information for a user
 // identified by their P2SH voting address.
-func (w *Wallet) StakePoolUserInfo(userAddress dcrutil.Address) (*udb.StakePoolUser, error) {
+func (w *Wallet) StakePoolUserInfo(ctx context.Context, userAddress dcrutil.Address) (*udb.StakePoolUser, error) {
 	const op errors.Op = "wallet.StakePoolUserInfo"
 
 	switch userAddress.(type) {
@@ -24,7 +26,7 @@ func (w *Wallet) StakePoolUserInfo(userAddress dcrutil.Address) (*udb.StakePoolU
 	}
 
 	var user *udb.StakePoolUser
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
 		stakemgrNs := tx.ReadBucket(wstakemgrNamespaceKey)
 		var err error
 		user, err = w.StakeMgr.StakePoolUserInfo(stakemgrNs, userAddress)

--- a/wallet/udb/cointype_test.go
+++ b/wallet/udb/cointype_test.go
@@ -5,6 +5,7 @@
 package udb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/decred/dcrd/chaincfg/v2"
@@ -58,17 +59,18 @@ func equalExtKeys(k0, k1 *hdkeychain.ExtendedKey) bool {
 func TestCoinTypeUpgrade(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	db, teardown := tempDB(t)
 	defer teardown()
 
 	params := chaincfg.TestNet3Params()
 
-	err := Initialize(db, params, seed, pubPass, privPassphrase)
+	err := Initialize(ctx, db, params, seed, pubPass, privPassphrase)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	m, _, _, err := Open(db, params, pubPass)
+	m, _, _, err := Open(ctx, db, params, pubPass)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +114,7 @@ func TestCoinTypeUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = walletdb.Update(db, func(dbtx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, db, func(dbtx walletdb.ReadWriteTx) error {
 		ns := dbtx.ReadWriteBucket(waddrmgrBucketKey)
 		err := m.Unlock(ns, privPassphrase)
 		if err != nil {

--- a/wallet/udb/common_test.go
+++ b/wallet/udb/common_test.go
@@ -6,6 +6,7 @@
 package udb
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -44,6 +45,7 @@ func hexToBytes(origHex string) []byte {
 
 // createEmptyDB is a helper function for creating an empty wallet db.
 func createEmptyDB() error {
+	ctx := context.Background()
 	db, err := walletdb.Create("bdb", emptyDbPath)
 	defer db.Close()
 
@@ -51,13 +53,13 @@ func createEmptyDB() error {
 		return err
 	}
 
-	err = Initialize(db, chaincfg.TestNet3Params(), seed, pubPassphrase,
+	err = Initialize(ctx, db, chaincfg.TestNet3Params(), seed, pubPassphrase,
 		privPassphrase)
 	if err != nil {
 		return err
 	}
 
-	err = Upgrade(db, pubPassphrase, chaincfg.TestNet3Params())
+	err = Upgrade(ctx, db, pubPassphrase, chaincfg.TestNet3Params())
 	if err != nil {
 		return err
 	}
@@ -68,6 +70,7 @@ func createEmptyDB() error {
 // cloneDB makes a copy of an empty wallet db. It returns a wallet db, store, a
 // stake store and a teardown function.
 func cloneDB(cloneName string) (walletdb.DB, *Manager, *Store, *StakeStore, func(), error) {
+	ctx := context.Background()
 	file, err := ioutil.ReadFile(emptyDbPath)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("unexpected error: %v", err)
@@ -83,7 +86,7 @@ func cloneDB(cloneName string) (walletdb.DB, *Manager, *Store, *StakeStore, func
 		return nil, nil, nil, nil, nil, fmt.Errorf("unexpected error: %v", err)
 	}
 
-	mgr, txStore, stkStore, err := Open(db, chaincfg.TestNet3Params(), pubPassphrase)
+	mgr, txStore, stkStore, err := Open(ctx, db, chaincfg.TestNet3Params(), pubPassphrase)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("unexpected error: %v", err)
 	}

--- a/wallet/udb/initialize.go
+++ b/wallet/udb/initialize.go
@@ -5,6 +5,8 @@
 package udb
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/wallet/v3/walletdb"
@@ -13,8 +15,8 @@ import (
 // Initialize prepares an empty database for usage by initializing all buckets
 // and key/value pairs.  The database is initialized with the latest version and
 // does not require any upgrades to use.
-func Initialize(db walletdb.DB, params *chaincfg.Params, seed, pubPass, privPass []byte) error {
-	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+func Initialize(ctx context.Context, db walletdb.DB, params *chaincfg.Params, seed, pubPass, privPass []byte) error {
+	err := walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs, err := tx.CreateTopLevelBucket(waddrmgrBucketKey)
 		if err != nil {
 			return errors.E(errors.IO, err)
@@ -53,14 +55,14 @@ func Initialize(db walletdb.DB, params *chaincfg.Params, seed, pubPass, privPass
 	if err != nil {
 		return err
 	}
-	return Upgrade(db, pubPass, params)
+	return Upgrade(ctx, db, pubPass, params)
 }
 
 // InitializeWatchOnly prepares an empty database for watching-only wallet usage
 // by initializing all buckets and key/value pairs.  The database is initialized
 // with the latest version and does not require any upgrades to use.
-func InitializeWatchOnly(db walletdb.DB, params *chaincfg.Params, hdPubKey string, pubPass []byte) error {
-	err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+func InitializeWatchOnly(ctx context.Context, db walletdb.DB, params *chaincfg.Params, hdPubKey string, pubPass []byte) error {
+	err := walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs, err := tx.CreateTopLevelBucket(waddrmgrBucketKey)
 		if err != nil {
 			return errors.E(errors.IO, err)
@@ -99,5 +101,5 @@ func InitializeWatchOnly(db walletdb.DB, params *chaincfg.Params, hdPubKey strin
 	if err != nil {
 		return err
 	}
-	return Upgrade(db, pubPass, params)
+	return Upgrade(ctx, db, pubPass, params)
 }

--- a/wallet/udb/migration.go
+++ b/wallet/udb/migration.go
@@ -5,6 +5,8 @@
 package udb
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/wallet/v3/walletdb"
@@ -20,9 +22,9 @@ var (
 
 // NeedsMigration checks whether the database needs to be converted to the
 // unified database format.
-func NeedsMigration(db walletdb.DB) (bool, error) {
+func NeedsMigration(ctx context.Context, db walletdb.DB) (bool, error) {
 	var needsMigration bool
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		needsMigration = tx.ReadBucket(unifiedDBMetadata{}.rootBucketKey()) == nil
 		return nil
 	})
@@ -33,8 +35,8 @@ func NeedsMigration(db walletdb.DB) (bool, error) {
 // format.  If any old upgrades are necessary, they are performed first.
 // Upgrades added after the migration was implemented may still need to be
 // performed.
-func Migrate(db walletdb.DB, params *chaincfg.Params) error {
-	return walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+func Migrate(ctx context.Context, db walletdb.DB, params *chaincfg.Params) error {
+	return walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrBucketKey)
 		txmgrNs := tx.ReadWriteBucket(wtxmgrBucketKey)
 		stakemgrNs := tx.ReadWriteBucket(wstakemgrBucketKey)

--- a/wallet/udb/open.go
+++ b/wallet/udb/open.go
@@ -5,6 +5,8 @@
 package udb
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/chaincfg/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/wallet/v3/walletdb"
@@ -16,8 +18,8 @@ import (
 // A NotExist error will be returned if the database has not been initialized.
 // The recorded database version must match exactly with DBVersion.  If the
 // version does not match, an Invalid error is returned.
-func Open(db walletdb.DB, params *chaincfg.Params, pubPass []byte) (addrMgr *Manager, txStore *Store, stakeStore *StakeStore, err error) {
-	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+func Open(ctx context.Context, db walletdb.DB, params *chaincfg.Params, pubPass []byte) (addrMgr *Manager, txStore *Store, stakeStore *StakeStore, err error) {
+	err = walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		// Verify the database exists and the recorded version is supported by
 		// this software version.
 		metadataBucket := tx.ReadBucket(unifiedDBMetadata{}.rootBucketKey())

--- a/wallet/udb/stakevalidation_test.go
+++ b/wallet/udb/stakevalidation_test.go
@@ -6,6 +6,7 @@ package udb
 
 import (
 	"bytes"
+	"context"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ func insertMainChainHeaders(s *Store, ns walletdb.ReadWriteBucket, addrmgrNs wal
 }
 
 func TestStakeInvalidationOfTip(t *testing.T) {
+	ctx := context.Background()
 	db, _, s, _, teardown, err := cloneDB("stake_inv_of_tip.kv")
 	defer teardown()
 	if err != nil {
@@ -71,7 +73,7 @@ func TestStakeInvalidationOfTip(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrBucketKey)
 		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 

--- a/wallet/udb/tx_test.go
+++ b/wallet/udb/tx_test.go
@@ -6,6 +6,7 @@
 package udb
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 )
 
 func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
+	ctx := context.Background()
 	db, _, s, _, teardown, err := cloneDB("inserts_credits_debits_rollbacks.kv")
 	defer teardown()
 	if err != nil {
@@ -80,7 +82,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrBucketKey)
 		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 		err = insertMainChainHeaders(s, ns, addrmgrNs, headerData, filters)
@@ -258,7 +260,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+		err := walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 			ns := tx.ReadWriteBucket(wtxmgrBucketKey)
 			addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 
@@ -356,6 +358,7 @@ func spendOutput(txHash *chainhash.Hash, index uint32, tree int8, outputValues .
 }
 
 func TestCoinbases(t *testing.T) {
+	ctx := context.Background()
 	db, _, s, _, teardown, err := cloneDB("coinbases.kv")
 	defer teardown()
 	if err != nil {
@@ -384,7 +387,7 @@ func TestCoinbases(t *testing.T) {
 	headerData := makeHeaderDataSlice(headers...)
 	filters := emptyFilters(18)
 
-	err = walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		ns := tx.ReadWriteBucket(wtxmgrBucketKey)
 		addrmgrNs := tx.ReadBucket(waddrmgrBucketKey)
 

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -5,6 +5,7 @@
 package udb
 
 import (
+	"context"
 	"crypto/sha256"
 
 	"github.com/decred/dcrd/blockchain/stake/v2"
@@ -996,9 +997,9 @@ func ticketCommitmentsUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, 
 
 // Upgrade checks whether the any upgrades are necessary before the database is
 // ready for application usage.  If any are, they are performed.
-func Upgrade(db walletdb.DB, publicPassphrase []byte, params *chaincfg.Params) error {
+func Upgrade(ctx context.Context, db walletdb.DB, publicPassphrase []byte, params *chaincfg.Params) error {
 	var version uint32
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		var err error
 		metadataBucket := tx.ReadBucket(unifiedDBMetadata{}.rootBucketKey())
 		if metadataBucket == nil {
@@ -1020,7 +1021,7 @@ func Upgrade(db walletdb.DB, publicPassphrase []byte, params *chaincfg.Params) e
 
 	log.Infof("Upgrading database from version %d to %d", version, DBVersion)
 
-	return walletdb.Update(db, func(tx walletdb.ReadWriteTx) error {
+	return walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
 		// Execute all necessary upgrades in order.
 		for _, upgrade := range upgrades[version:] {
 			err := upgrade(tx, publicPassphrase, params)

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -6,6 +6,7 @@ package udb
 
 import (
 	"bytes"
+	"context"
 	"compress/gzip"
 	"encoding/hex"
 	"fmt"
@@ -44,6 +45,7 @@ var pubPass = []byte("public")
 func TestUpgrades(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	d, err := ioutil.TempDir("", "dcrwallet_udb_TestUpgrades")
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +81,7 @@ func TestUpgrades(t *testing.T) {
 					t.Fatal(err)
 				}
 				defer db.Close()
-				err = Upgrade(db, pubPass, chaincfg.TestNet3Params())
+				err = Upgrade(ctx, db, pubPass, chaincfg.TestNet3Params())
 				if err != nil {
 					t.Fatalf("Upgrade failed: %v", err)
 				}
@@ -92,12 +94,13 @@ func TestUpgrades(t *testing.T) {
 }
 
 func verifyV2Upgrade(t *testing.T, db walletdb.DB) {
-	amgr, _, _, err := Open(db, chaincfg.TestNet3Params(), pubPass)
+	ctx := context.Background()
+	amgr, _, _, err := Open(ctx, db, chaincfg.TestNet3Params(), pubPass)
 	if err != nil {
 		t.Fatalf("Open after Upgrade failed: %v", err)
 	}
 
-	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrBucketKey)
 		nsMetaBucket := ns.NestedReadBucket(metaBucketName)
 
@@ -161,12 +164,13 @@ func verifyV2Upgrade(t *testing.T, db walletdb.DB) {
 }
 
 func verifyV3Upgrade(t *testing.T, db walletdb.DB) {
-	_, _, smgr, err := Open(db, chaincfg.TestNet3Params(), pubPass)
+	ctx := context.Background()
+	_, _, smgr, err := Open(ctx, db, chaincfg.TestNet3Params(), pubPass)
 	if err != nil {
 		t.Fatalf("Open after Upgrade failed: %v", err)
 	}
 
-	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wstakemgrBucketKey)
 
 		const (
@@ -230,7 +234,8 @@ func verifyV3Upgrade(t *testing.T, db walletdb.DB) {
 }
 
 func verifyV4Upgrade(t *testing.T, db walletdb.DB) {
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	ctx := context.Background()
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrBucketKey)
 		mainBucket := ns.NestedReadBucket(mainBucketName)
 		if mainBucket.Get(seedName) != nil {
@@ -244,7 +249,8 @@ func verifyV4Upgrade(t *testing.T, db walletdb.DB) {
 }
 
 func verifyV5Upgrade(t *testing.T, db walletdb.DB) {
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	ctx := context.Background()
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(waddrmgrBucketKey)
 
 		data := []struct {
@@ -297,7 +303,8 @@ func verifyV5Upgrade(t *testing.T, db walletdb.DB) {
 }
 
 func verifyV6Upgrade(t *testing.T, db walletdb.DB) {
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	ctx := context.Background()
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrBucketKey)
 
 		data := []*chainhash.Hash{
@@ -349,7 +356,8 @@ func verifyV6Upgrade(t *testing.T, db walletdb.DB) {
 }
 
 func verifyV8Upgrade(t *testing.T, db walletdb.DB) {
-	err := walletdb.View(db, func(tx walletdb.ReadTx) error {
+	ctx := context.Background()
+	err := walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		ns := tx.ReadBucket(wtxmgrBucketKey)
 		creditBucket := ns.NestedReadBucket(bucketCredits)
 		err := creditBucket.ForEach(func(k []byte, v []byte) error {
@@ -421,12 +429,13 @@ func verifyV8Upgrade(t *testing.T, db walletdb.DB) {
 // See the v11.db.go file for an explanation of the database layout and test
 // plan.
 func verifyV12Upgrade(t *testing.T, db walletdb.DB) {
-	_, txmgr, _, err := Open(db, chaincfg.TestNet3Params(), pubPass)
+	ctx := context.Background()
+	_, txmgr, _, err := Open(ctx, db, chaincfg.TestNet3Params(), pubPass)
 	if err != nil {
 		t.Fatalf("Open after Upgrade failed: %v", err)
 	}
 
-	err = walletdb.View(db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		txmgrns := tx.ReadBucket(wtxmgrBucketKey)
 		amgrns := tx.ReadBucket(waddrmgrBucketKey)
 

--- a/wallet/unstable.go
+++ b/wallet/unstable.go
@@ -5,6 +5,8 @@
 package wallet
 
 import (
+	"context"
+	
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrwallet/errors/v2"
@@ -24,11 +26,11 @@ type unstableAPI struct {
 func UnstableAPI(w *Wallet) unstableAPI { return unstableAPI{w} }
 
 // TxDetails calls udb.Store.TxDetails under a single database view transaction.
-func (u unstableAPI) TxDetails(txHash *chainhash.Hash) (*udb.TxDetails, error) {
+func (u unstableAPI) TxDetails(ctx context.Context, txHash *chainhash.Hash) (*udb.TxDetails, error) {
 	const op errors.Op = "wallet.TxDetails"
 
 	var details *udb.TxDetails
-	err := walletdb.View(u.w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, u.w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		var err error
 		details, err = u.w.TxStore.TxDetails(txmgrNs, txHash)
@@ -42,9 +44,9 @@ func (u unstableAPI) TxDetails(txHash *chainhash.Hash) (*udb.TxDetails, error) {
 
 // RangeTransactions calls udb.Store.RangeTransactions under a single
 // database view tranasction.
-func (u unstableAPI) RangeTransactions(begin, end int32, f func([]udb.TxDetails) (bool, error)) error {
+func (u unstableAPI) RangeTransactions(ctx context.Context, begin, end int32, f func([]udb.TxDetails) (bool, error)) error {
 	const op errors.Op = "wallet.RangeTransactions"
-	err := walletdb.View(u.w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, u.w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		return u.w.TxStore.RangeTransactions(txmgrNs, begin, end, f)
 	})
@@ -57,10 +59,10 @@ func (u unstableAPI) RangeTransactions(begin, end int32, f func([]udb.TxDetails)
 // UnspentMultisigCreditsForAddress calls
 // udb.Store.UnspentMultisigCreditsForAddress under a single database view
 // transaction.
-func (u unstableAPI) UnspentMultisigCreditsForAddress(p2shAddr *dcrutil.AddressScriptHash) ([]*udb.MultisigCredit, error) {
+func (u unstableAPI) UnspentMultisigCreditsForAddress(ctx context.Context, p2shAddr *dcrutil.AddressScriptHash) ([]*udb.MultisigCredit, error) {
 	const op errors.Op = "wallet.UnspentMultisigCreditsForAddress"
 	var multisigCredits []*udb.MultisigCredit
-	err := walletdb.View(u.w.db, func(tx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, u.w.db, func(tx walletdb.ReadTx) error {
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 		var err error
 		multisigCredits, err = u.w.TxStore.UnspentMultisigCreditsForAddress(

--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -5,6 +5,7 @@
 package wallet
 
 import (
+	"context"
 	"time"
 
 	blockchain "github.com/decred/dcrd/blockchain/standalone"
@@ -30,10 +31,10 @@ func (p *OutputSelectionPolicy) meetsRequiredConfs(txHeight, curHeight int32) bo
 
 // UnspentOutputs fetches all unspent outputs from the wallet that match rules
 // described in the passed policy.
-func (w *Wallet) UnspentOutputs(policy OutputSelectionPolicy) ([]*TransactionOutput, error) {
+func (w *Wallet) UnspentOutputs(ctx context.Context, policy OutputSelectionPolicy) ([]*TransactionOutput, error) {
 	const op errors.Op = "wallet.UnspentOutputs"
 	var outputResults []*TransactionOutput
-	err := walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 
@@ -105,9 +106,9 @@ func (w *Wallet) UnspentOutputs(policy OutputSelectionPolicy) ([]*TransactionOut
 
 // SelectInputs selects transaction inputs to redeem unspent outputs stored in
 // the wallet.  It returns an input detail summary.
-func (w *Wallet) SelectInputs(targetAmount dcrutil.Amount, policy OutputSelectionPolicy) (inputDetail *txauthor.InputDetail, err error) {
+func (w *Wallet) SelectInputs(ctx context.Context, targetAmount dcrutil.Amount, policy OutputSelectionPolicy) (inputDetail *txauthor.InputDetail, err error) {
 	const op errors.Op = "wallet.SelectInputs"
-	err = walletdb.View(w.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
 		_, tipHeight := w.TxStore.MainChainTip(txmgrNs)
@@ -144,10 +145,10 @@ type OutputInfo struct {
 
 // OutputInfo queries the wallet for additional transaction output info
 // regarding an outpoint.
-func (w *Wallet) OutputInfo(out *wire.OutPoint) (OutputInfo, error) {
+func (w *Wallet) OutputInfo(ctx context.Context, out *wire.OutPoint) (OutputInfo, error) {
 	const op errors.Op = "wallet.OutputInfo"
 	var info OutputInfo
-	err := walletdb.View(w.db, func(dbtx walletdb.ReadTx) error {
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
 
 		txDetails, err := w.TxStore.TxDetails(txmgrNs, &out.Hash)

--- a/wallet/walletdb/interface.go
+++ b/wallet/walletdb/interface.go
@@ -9,7 +9,9 @@
 package walletdb
 
 import (
+	"context"
 	"io"
+	"runtime/trace"
 
 	"github.com/decred/dcrwallet/errors/v2"
 )
@@ -195,7 +197,9 @@ type DB interface {
 // transaction passed as a parameter.  After f exits or panics, the transaction
 // is rolled back.  If f errors, its error is returned, not a rollback error (if
 // any occurred).
-func View(db DB, f func(tx ReadTx) error) error {
+func View(ctx context.Context, db DB, f func(tx ReadTx) error) error {
+	defer trace.StartRegion(ctx, "db.View").End()
+	
 	tx, err := db.BeginReadTx()
 	if err != nil {
 		return err
@@ -218,7 +222,9 @@ func View(db DB, f func(tx ReadTx) error) error {
 // error, the transaction is committed.  Otherwise, if f did error or panic, the
 // transaction is rolled back.  If a rollback fails, the original error returned
 // by f is still returned.  If the commit fails, the commit error is returned.
-func Update(db DB, f func(tx ReadWriteTx) error) (err error) {
+func Update(ctx context.Context, db DB, f func(tx ReadWriteTx) error) (err error) {
+	defer trace.StartRegion(ctx, "db.Update").End()
+	
 	tx, err := db.BeginReadWriteTx()
 	if err != nil {
 		return err

--- a/wallet/walletdb/interface_test.go
+++ b/wallet/walletdb/interface_test.go
@@ -14,6 +14,7 @@
 package walletdb_test
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -478,8 +479,9 @@ func testManualTxInterface(tc *testContext, bucketKey []byte) bool {
 // tests all facets of it interface as well as transaction and bucket
 // interfaces under it.
 func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
+	ctx := context.Background()
 	namespaceKeyBytes := []byte(namespaceKey)
-	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err := walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 		_, err := tx.CreateTopLevelBucket(namespaceKeyBytes)
 		return err
 	})
@@ -489,7 +491,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 	}
 	defer func() {
 		// Remove the namespace now that the tests are done for it.
-		err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+		err := walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 			return tx.DeleteTopLevelBucket(namespaceKeyBytes)
 		})
 		if err != nil {
@@ -514,7 +516,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 	// Also, put a series of values and force a rollback so the following
 	// code can ensure the values were not stored.
 	forceRollbackError := fmt.Errorf("force rollback")
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 		rootBucket := tx.ReadWriteBucket(namespaceKeyBytes)
 		if rootBucket == nil {
 			return fmt.Errorf("ReadWriteBucket: unexpected nil root bucket")
@@ -544,7 +546,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 
 	// Ensure the values that should have not been stored due to the forced
 	// rollback above were not actually stored.
-	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, tc.db, func(tx walletdb.ReadTx) error {
 		rootBucket := tx.ReadBucket(namespaceKeyBytes)
 		if rootBucket == nil {
 			return fmt.Errorf("ReadBucket: unexpected nil root bucket")
@@ -564,7 +566,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 	}
 
 	// Store a series of values via a managed read-write transaction.
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 		rootBucket := tx.ReadWriteBucket(namespaceKeyBytes)
 		if rootBucket == nil {
 			return fmt.Errorf("ReadWriteBucket: unexpected nil root bucket")
@@ -584,7 +586,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 	}
 
 	// Ensure the values stored above were committed as expected.
-	err = walletdb.View(tc.db, func(tx walletdb.ReadTx) error {
+	err = walletdb.View(ctx, tc.db, func(tx walletdb.ReadTx) error {
 		rootBucket := tx.ReadBucket(namespaceKeyBytes)
 		if rootBucket == nil {
 			return fmt.Errorf("ReadBucket: unexpected nil root bucket")
@@ -604,7 +606,7 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 	}
 
 	// Clean up the values stored above in a managed read-write transaction.
-	err = walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err = walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 		rootBucket := tx.ReadWriteBucket(namespaceKeyBytes)
 		if rootBucket == nil {
 			return fmt.Errorf("ReadWriteBucket: unexpected nil root bucket")
@@ -629,9 +631,10 @@ func testNamespaceAndTxInterfaces(tc *testContext, namespaceKey string) bool {
 // testAdditionalErrors performs some tests for error cases not covered
 // elsewhere in the tests and therefore improves negative test coverage.
 func testAdditionalErrors(tc *testContext) bool {
+	ctx := context.Background()
 	ns3Key := []byte("ns3")
 
-	err := walletdb.Update(tc.db, func(tx walletdb.ReadWriteTx) error {
+	err := walletdb.Update(ctx, tc.db, func(tx walletdb.ReadWriteTx) error {
 		// Create a new namespace
 		rootBucket, err := tx.CreateTopLevelBucket(ns3Key)
 		if err != nil {

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -78,13 +78,13 @@ func createWallet(ctx context.Context, cfg *config) error {
 	}
 
 	fmt.Println("Creating the wallet...")
-	w, err := loader.CreateNewWallet(pubPass, privPass, seed)
+	w, err := loader.CreateNewWallet(ctx, pubPass, privPass, seed)
 	if err != nil {
 		return err
 	}
 
 	if !imported {
-		err := w.UpgradeToSLIP0044CoinType()
+		err := w.UpgradeToSLIP0044CoinType(ctx)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 
 	// Display a mining address when creating a simnet wallet.
 	if cfg.SimNet {
-		xpub, err := w.MasterPubKey(0)
+		xpub, err := w.MasterPubKey(ctx, 0)
 		if err != nil {
 			return err
 		}
@@ -127,7 +127,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 
 // createSimulationWallet is intended to be called from the rpcclient
 // and used to create a wallet for actors involved in simulations.
-func createSimulationWallet(cfg *config) error {
+func createSimulationWallet(ctx context.Context, cfg *config) error {
 	// Simulation wallet password is 'password'.
 	privPass := wallet.SimulationPassphrase
 
@@ -162,7 +162,7 @@ func createSimulationWallet(cfg *config) error {
 	defer db.Close()
 
 	// Create the wallet.
-	err = wallet.Create(db, pubPass, privPass, seed, activeNet.Params)
+	err = wallet.Create(ctx, db, pubPass, privPass, seed, activeNet.Params)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func promptHDPublicKey(reader *bufio.Reader) (string, error) {
 
 // createWatchingOnlyWallet creates a watching only wallet using the passed
 // extended public key.
-func createWatchingOnlyWallet(cfg *config) error {
+func createWatchingOnlyWallet(ctx context.Context, cfg *config) error {
 	// Get the public key.
 	reader := bufio.NewReader(os.Stdin)
 	pubKeyString, err := promptHDPublicKey(reader)
@@ -216,7 +216,7 @@ func createWatchingOnlyWallet(cfg *config) error {
 	}
 	defer db.Close()
 
-	err = wallet.CreateWatchOnly(db, pubKeyString, pubPass, activeNet.Params)
+	err = wallet.CreateWatchOnly(ctx, db, pubKeyString, pubPass, activeNet.Params)
 	if err != nil {
 		errOS := os.Remove(dbPath)
 		if errOS != nil {


### PR DESCRIPTION
This requires plumbing context through many more APIs and is the bulk
if this commit, since trace tasks are passed around using a context.