### PR TITLE
new account type for vsp purpose key derivation

### DIFF
--- a/wallet/udb/addressdb.go
+++ b/wallet/udb/addressdb.go
@@ -195,6 +195,8 @@ var (
 	coinTypeLegacyPubKeyName    = []byte("ctpub")
 	coinTypeSLIP0044PrivKeyName = []byte("ctpriv-slip0044")
 	coinTypeSLIP0044PubKeyName  = []byte("ctpub-slip0044")
+	vspPurposeBranchPrivKeyName = []byte("vsp-priv")
+	vspPurposeBranchPubKeyName  = []byte("vsp-pub")
 	watchingOnlyName            = []byte("watchonly")
 	slip0044Account0RowName     = []byte("slip0044acct0")
 
@@ -366,6 +368,29 @@ func putCoinTypeSLIP0044Keys(ns walletdb.ReadWriteBucket, coinTypePubKeyEnc []by
 
 	if coinTypePrivKeyEnc != nil {
 		err := bucket.Put(coinTypeSLIP0044PrivKeyName, coinTypePrivKeyEnc)
+		if err != nil {
+			return errors.E(errors.IO, err)
+		}
+	}
+
+	return nil
+}
+
+// putVSPPurposeBranchKeys stores the encrypted vsp purpose keys which are in
+// turn used to derive the address private keys to be shared with vsps. Either
+// parameter can be nil in which case no value is written for the parameter.
+func putVSPPurposeBranchKeys(ns walletdb.ReadWriteBucket, vspXPubEnc []byte, vspXPrivEnc []byte) error {
+	bucket := ns.NestedReadWriteBucket(mainBucketName)
+
+	if vspXPubEnc != nil {
+		err := bucket.Put(vspPurposeBranchPubKeyName, vspXPubEnc)
+		if err != nil {
+			return errors.E(errors.IO, err)
+		}
+	}
+
+	if vspXPrivEnc != nil {
+		err := bucket.Put(vspPurposeBranchPrivKeyName, vspXPrivEnc)
 		if err != nil {
 			return errors.E(errors.IO, err)
 		}
@@ -1229,6 +1254,9 @@ func deletePrivateKeys(ns walletdb.ReadWriteBucket, dbVersion uint32) error {
 		return errors.E(errors.IO, err)
 	}
 	if err := bucket.Delete(coinTypeSLIP0044PrivKeyName); err != nil {
+		return errors.E(errors.IO, err)
+	}
+	if err := bucket.Delete(vspPurposeBranchPrivKeyName); err != nil {
 		return errors.E(errors.IO, err)
 	}
 

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -2126,7 +2126,7 @@ func newManager(chainParams *chaincfg.Params, masterKeyPub *snacl.SecretKey,
 
 // deriveCoinTypeKey derives the cointype key which can be used to derive the
 // extended key for an account according to the hierarchy described by BIP0044
-// given the coin type key.
+// given the coin type.
 //
 // In particular this is the hierarchical deterministic extended key path:
 // m/44'/<coin type>'
@@ -2145,6 +2145,37 @@ func deriveCoinTypeKey(masterNode *hdkeychain.ExtendedKey, coinType uint32) (*hd
 
 	// Derive the purpose key as a child of the master node.
 	purpose, err := masterNode.Child(44 + hdkeychain.HardenedKeyStart)
+	if err != nil {
+		return nil, err
+	}
+
+	// Derive the coin type key as a child of the purpose key.
+	coinTypeKey, err := purpose.Child(coinType + hdkeychain.HardenedKeyStart)
+	if err != nil {
+		return nil, err
+	}
+
+	return coinTypeKey, nil
+}
+
+// deriveVSPPurposeCoinTypeKey derives the extended private key which can be
+// used to derive address private keys to share with VSPs given the coin type.
+//
+// In particular this is the hierarchical deterministic extended key path:
+// m/14679'/<coin type>'
+func deriveVSPPurposeCoinTypeKey(masterNode *hdkeychain.ExtendedKey, coinType uint32) (*hdkeychain.ExtendedKey, error) {
+	// Enforce maximum coin type.
+	if coinType > maxCoinType {
+		return nil, errors.E(errors.Invalid, errors.Errorf("coin type %d", coinType))
+	}
+
+	// The hierarchy described by BIP0043 is:
+	//  m/<purpose>'/*
+	// This is further extended by VSP purpose branch format to:
+	//  m/14679'/<coin type>'/<address index>'
+
+	// Derive the purpose key as a child of the master node.
+	purpose, err := masterNode.Child(14679 + hdkeychain.HardenedKeyStart)
 	if err != nil {
 		return nil, err
 	}
@@ -2189,7 +2220,7 @@ func checkBranchKeys(acctKey *hdkeychain.ExtendedKey) error {
 		return err
 	}
 
-	// Derive the external branch as the second child of the account key.
+	// Derive the internal branch as the second child of the account key.
 	_, err := acctKey.Child(InternalBranch)
 	return err
 }
@@ -2275,6 +2306,9 @@ func CoinTypes(params *chaincfg.Params) (legacyCoinType, slip0044CoinType uint32
 // will be used to create the master root node from which all hierarchical
 // deterministic addresses are derived.  This allows all chained addresses in
 // the address manager to be recovered by using the same seed.
+//
+// The seed is also used to derive the extended public and private keys for
+// the vsp purpose branch.
 //
 // All private and public keys and information are protected by secret keys
 // derived from the provided private and public passphrases.  The public
@@ -2481,6 +2515,29 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 		return errors.E(errors.Crypto, fmt.Errorf("encrypt account 0 privkey: %v", err))
 	}
 
+	// Derive the vsp purpose extended private key.
+	vspPurposeExtPrivKey, err := deriveVSPPurposeCoinTypeKey(root, slip0044CoinType)
+	if err != nil {
+		return err
+	}
+	defer vspPurposeExtPrivKey.Zero()
+
+	// Encrypt the vsp purpose branch keys with the associated crypto keys.
+	vspPurposeExtPubKey, err := vspPurposeExtPrivKey.Neuter()
+	if err != nil {
+		return err
+	}
+	vspPurposeXPub := vspPurposeExtPubKey.String()
+	vspPurposeXPubEnc, err := cryptoKeyPub.Encrypt([]byte(vspPurposeXPub))
+	if err != nil {
+		return errors.E(errors.Crypto, fmt.Errorf("encrypt vsp purpose branch pubkey: %v", err))
+	}
+	vspPurposeXPriv := vspPurposeExtPrivKey.String()
+	vspPurposeXPrivEnc, err := cryptoKeyPriv.Encrypt([]byte(vspPurposeXPriv))
+	if err != nil {
+		return errors.E(errors.Crypto, fmt.Errorf("encrypt vsp purpose branch privkey: %v", err))
+	}
+
 	// Save the master key params to the database.
 	pubParams := masterKeyPub.Marshal()
 	privParams := masterKeyPriv.Marshal()
@@ -2504,6 +2561,12 @@ func createAddressManager(ns walletdb.ReadWriteBucket, seed, pubPassphrase, priv
 
 	// Save the encrypted SLIP0044 cointype keys.
 	err = putCoinTypeSLIP0044Keys(ns, coinTypeSLIP0044PubEnc, coinTypeSLIP0044PrivEnc)
+	if err != nil {
+		return err
+	}
+
+	// Save the encrypted vsp purpose branch keys.
+	err = putVSPPurposeBranchKeys(ns, vspPurposeXPubEnc, vspPurposeXPrivEnc)
 	if err != nil {
 		return err
 	}

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -100,7 +100,7 @@ const (
 	// from properly-synced wallets.
 	lastProcessedTxsBlockVersion = 11
 
-	// ticketCommitmentsVersion the twelfth version of the database. It adds
+	// ticketCommitmentsVersion is the twelfth version of the database. It adds
 	// the ticketCommitment bucket to the txmgr namespace. This bucket is meant
 	// to track outstanding ticket commitment outputs for the purposes of
 	// correct balance calculation: it allows non-voting wallets (eg: funding
@@ -110,10 +110,14 @@ const (
 	// accounting of total locked funds.
 	ticketCommitmentsVersion = 12
 
+	// vspPurposeBranchVersion is the thirteenth version of the database. It ...
+	// todo complete description.
+	vspPurposeBranchVersion = 13
+
 	// DBVersion is the latest version of the database that is understood by the
 	// program.  Databases with recorded versions higher than this will fail to
 	// open (meaning any upgrades prevent reverting to older software).
-	DBVersion = ticketCommitmentsVersion
+	DBVersion = vspPurposeBranchVersion
 )
 
 // upgrades maps between old database versions and the upgrade function to
@@ -131,6 +135,7 @@ var upgrades = [...]func(walletdb.ReadWriteTx, []byte, *chaincfg.Params) error{
 	cfVersion - 1:                    cfUpgrade,
 	lastProcessedTxsBlockVersion - 1: lastProcessedTxsBlockUpgrade,
 	ticketCommitmentsVersion - 1:     ticketCommitmentsUpgrade,
+	vspPurposeBranchVersion - 1:      vspPurposeBranchUpgrade,
 }
 
 func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, params *chaincfg.Params) error {
@@ -989,6 +994,29 @@ func ticketCommitmentsUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, 
 	}
 
 	log.Debug("Ticket commitments db upgrade done")
+
+	// Write the new database version.
+	return unifiedDBMetadata{}.putVersion(metadataBucket, newVersion)
+}
+
+func vspPurposeBranchUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, params *chaincfg.Params) error {
+	const oldVersion = 12
+	const newVersion = 13
+
+	metadataBucket := tx.ReadWriteBucket(unifiedDBMetadata{}.rootBucketKey())
+
+	// Assert that this function is only called on version 11 databases.
+	dbVersion, err := unifiedDBMetadata{}.getVersion(metadataBucket)
+	if err != nil {
+		return err
+	}
+	if dbVersion != oldVersion {
+		return errors.E(errors.Invalid, "ticketCommitmentsUpgrade inappropriately called")
+	}
+
+	// todo upgrade db
+
+	log.Debug("VSP purpose branch db upgrade done")
 
 	// Write the new database version.
 	return unifiedDBMetadata{}.putVersion(metadataBucket, newVersion)

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -268,7 +268,7 @@ func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byt
 		// replaces the next to use indexes with the last used indexes.
 		row = bip0044AccountInfo(row.pubKeyEncrypted, row.privKeyEncrypted,
 			0, 0, lastUsedExtIndex, lastUsedIntIndex, 0, 0, row.name, newVersion)
-		err = putAccountInfo(addrmgrBucket, account, row)
+		err = putBIP0044AccountInfo(addrmgrBucket, account, row)
 		if err != nil {
 			return err
 		}
@@ -400,7 +400,7 @@ func lastReturnedAddressUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte
 			0, 0, row.lastUsedExternalIndex, row.lastUsedInternalIndex,
 			row.lastUsedExternalIndex, row.lastUsedInternalIndex,
 			row.name, newVersion)
-		return putAccountInfo(addrmgrBucket, account, row)
+		return putBIP0044AccountInfo(addrmgrBucket, account, row)
 	}
 
 	// Determine how many BIP0044 accounts have been created.  Each of these


### PR DESCRIPTION
This is an attempt to use the current account/address db structure to store details for the new vsp purpose branch that will enable derivation of address privkeys when needed as opposed to having to import the privkeys into the wallet's `imported` account.