### PR TITLE
Never use proxy when dialing localhost

### DIFF
--- a/config.go
+++ b/config.go
@@ -667,6 +667,9 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 			if err != nil {
 				host = address
 			}
+			if host == "localhost" {
+				return noproxyDialer.DialContext(ctx, network, address)
+			}
 			ip := net.ParseIP(host)
 			if len(ip) == 4 || len(ip) == 16 {
 				for i := range privNets {


### PR DESCRIPTION
The 127.0.0.1 and ::1 IPs are already handled using the default dialer
exclusively, but when dialing localhost connections (by that
hostname), Tor proxies would fail to resolve the address.  This change
also adds the localhost host to the proxy exclusion list.

Fixes #1578 