### PR TITLE
Do not cleanly unload wallet during panic

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -168,6 +168,12 @@ func run(ctx context.Context) error {
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.
 	defer func() {
+		// When panicing, do not cleanly unload the wallet (by closing
+		// the db).  If a panic occured inside a bolt transaction, the
+		// db mutex is still held and this causes a deadlock.
+		if r := recover(); r != nil {
+			panic(r)
+		}
 		err := loader.UnloadWallet()
 		if err != nil && !errors.Is(err, errors.Invalid) {
 			log.Errorf("Failed to close wallet: %v", err)


### PR DESCRIPTION
A panic was observed deep in the bbolt module due to database file
corruption after a system crash.  Running the wallet with this
corrupted database would cause an internal consistency error in bbolt
and a panic inside of a database update.  During unwind, the bbolt
mutex was not released.  Attempting to cleanly unload the wallet in
this state caused a deadlock.  Instead, rethrow the panic when
panicing so that the full stack trace can be observed and the wallet
process to exit.