### PR TITLE
Combine logic for loading and watching future addresses

### DIFF
--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -385,9 +385,8 @@ func nextAddresses(n int) func(t *testing.T, w *Wallet) {
 
 func watchFutureAddresses(t *testing.T, w *Wallet) {
 	ctx := context.Background()
-	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
-		return w.watchFutureAddresses(context.Background(), dbtx)
-	})
+	n, _ := w.NetworkBackend()
+	_, err := w.watchHDAddrs(ctx, false, n)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -453,11 +453,7 @@ func (w *Wallet) txToOutputs(ctx context.Context, op errors.Op, outputs []*wire.
 	}
 
 	// Watch for future relevant transactions.
-	w.addressBuffersMu.Lock()
-	err = walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
-		return w.watchFutureAddresses(ctx, dbtx)
-	})
-	w.addressBuffersMu.Unlock()
+	_, err = w.watchHDAddrs(ctx, false, n)
 	if err != nil {
 		log.Errorf("Failed to watch for future address usage after publishing "+
 			"transaction: %v", err)
@@ -1328,11 +1324,11 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op, n NetworkBac
 	// relevant transactions
 	var watchOutPoints []wire.OutPoint
 	defer func() {
-		w.addressBuffersMu.Lock()
-		err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
-			return w.watchFutureAddresses(ctx, tx)
-		})
-		w.addressBuffersMu.Unlock()
+		_, err := w.watchHDAddrs(ctx, false, n)
+		if err != nil {
+			log.Errorf("Failed to watch for future address usage after publishing "+
+				"transaction: %v", err)
+		}
 		if err != nil {
 			log.Errorf("Failed to watch for future addresses after ticket "+
 				"purchases: %v", err)


### PR DESCRIPTION
The logic to initally load the transaction filter with watched
addresses is more efficient and avoids TCP timeout issues from loading
too many addresses at once.  In addition, unlike the previous
watchFutureAddresses method, it will never load the filter with
duplicate addresses.