### PR TITLE
Update addrmgr and connmgr modules

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,7 +21,7 @@ import (
 
 	"decred.org/dcrwallet/internal/cfgutil"
 	"decred.org/dcrwallet/internal/netparams"
-	"github.com/decred/dcrd/connmgr"
+	"github.com/decred/dcrd/connmgr/v2"
 	"github.com/decred/dcrd/dcrutil/v2"
 	"github.com/decred/dcrwallet/errors/v2"
 	"github.com/decred/dcrwallet/version"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module decred.org/dcrwallet
 go 1.12
 
 require (
-	github.com/decred/dcrd/addrmgr v1.0.2
+	github.com/decred/dcrd/addrmgr v1.1.0
 	github.com/decred/dcrd/blockchain/stake v1.2.1
 	github.com/decred/dcrd/blockchain/stake/v2 v2.0.2
 	github.com/decred/dcrd/blockchain/standalone v1.1.0
@@ -12,7 +12,7 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v2 v2.3.0
 	github.com/decred/dcrd/connmgr v1.0.2
-	github.com/decred/dcrd/connmgr/v2 v2.0.0
+	github.com/decred/dcrd/connmgr/v2 v2.1.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrjson/v2 v2.2.0
 	github.com/decred/dcrd/dcrjson/v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/decred/dcrd/chaincfg v1.5.2
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/chaincfg/v2 v2.3.0
-	github.com/decred/dcrd/connmgr v1.0.2
 	github.com/decred/dcrd/connmgr/v2 v2.1.0
 	github.com/decred/dcrd/dcrec v1.0.0
 	github.com/decred/dcrd/dcrjson/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/decred/base58 v1.0.1 h1:w5qTcb0hYpKuIBYIn4Ckirkj1aOWrSq8onPQpb3eGg8=
 github.com/decred/base58 v1.0.1/go.mod h1:H2ENcsJjye1G7CbRa67kV9OFaui0LGr56ntKKoY5g9c=
 github.com/decred/dcrd/addrmgr v1.0.2 h1:BfJoFEkdDDhaQSsx9NkVOTiOTUbEevbVf+aYRQSIAmU=
 github.com/decred/dcrd/addrmgr v1.0.2/go.mod h1:gNnmTuf/Xkg8ZX3j5GXbajzPrSdf5bA7HitO2bjmq0Q=
+github.com/decred/dcrd/addrmgr v1.1.0 h1:VQkn1qmafZypfN2u7yi7J/girwz4ZDicquo7JzsoxdQ=
+github.com/decred/dcrd/addrmgr v1.1.0/go.mod h1:exghL+0+QeVvO4MXezWJ1C2tcpBn3ngfuP6S1R+adB8=
 github.com/decred/dcrd/blockchain/stake v1.0.1 h1:IYGsNZRyMUsoFtVAUjd7XIccrIQ4YIqDeNzQJCjyS8A=
 github.com/decred/dcrd/blockchain/stake v1.0.1 h1:IYGsNZRyMUsoFtVAUjd7XIccrIQ4YIqDeNzQJCjyS8A=
 github.com/decred/dcrd/blockchain/stake v1.0.1/go.mod h1:hgoGmWMIu2LLApBbcguVpzCEEfX7M2YhuMrQdpohJzc=
@@ -69,6 +71,8 @@ github.com/decred/dcrd/connmgr v1.0.2/go.mod h1:jBNfQLh+454n3crgNCPrhMgZ9mVvYcMb
 github.com/decred/dcrd/connmgr v1.0.2/go.mod h1:jBNfQLh+454n3crgNCPrhMgZ9mVvYcMbWSCEAHsJQus=
 github.com/decred/dcrd/connmgr/v2 v2.0.0 h1:GjDy9KD5m8uBs34yDXriwj4dvf5VLo/JeiPkUHwFg0k=
 github.com/decred/dcrd/connmgr/v2 v2.0.0/go.mod h1:HJ2q+m7DaMlNmQlY3WtbV3zETZfo4dfAi78z0ILLdqA=
+github.com/decred/dcrd/connmgr/v2 v2.1.0 h1:nfitnK4FXWLvuE5uNNtUjiyBZtwzROEpuWD5OdWeGpo=
+github.com/decred/dcrd/connmgr/v2 v2.1.0/go.mod h1:a3cjZ9xP5Ulm/eptpqma2Is3wHcoUXYvx5gFoOou5J0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/crypto/ripemd160 v1.0.0 h1:MciTnR4NfBqDFRFjFkrn8WPLP4Vo7t6ww6ghfn6wcXQ=

--- a/go.sum
+++ b/go.sum
@@ -65,10 +65,6 @@ github.com/decred/dcrd/chaincfg/v2 v2.1.0 h1:2S7TL9YWnKDDiH5bTpp3xcBo+1gl1IXFi5K
 github.com/decred/dcrd/chaincfg/v2 v2.1.0/go.mod h1:hpKvhLCDAD/xDZ3V1Pqpv9fIKVYYi11DyxETguazyvg=
 github.com/decred/dcrd/chaincfg/v2 v2.3.0 h1:ItmU+7DeUtyiabrcW+16MJFgY/BBeeYaPfkBLrFLyjo=
 github.com/decred/dcrd/chaincfg/v2 v2.3.0/go.mod h1:7qUJTvn+y/kswSRZ4sT2+EmvlDTDyy2InvNFtX/hxk0=
-github.com/decred/dcrd/connmgr v1.0.2 h1:ipHJBV9fmhLi8ZZCtsNpG+kLY2c+yu59/8oOkA8BNJY=
-github.com/decred/dcrd/connmgr v1.0.2 h1:ipHJBV9fmhLi8ZZCtsNpG+kLY2c+yu59/8oOkA8BNJY=
-github.com/decred/dcrd/connmgr v1.0.2/go.mod h1:jBNfQLh+454n3crgNCPrhMgZ9mVvYcMbWSCEAHsJQus=
-github.com/decred/dcrd/connmgr v1.0.2/go.mod h1:jBNfQLh+454n3crgNCPrhMgZ9mVvYcMbWSCEAHsJQus=
 github.com/decred/dcrd/connmgr/v2 v2.0.0 h1:GjDy9KD5m8uBs34yDXriwj4dvf5VLo/JeiPkUHwFg0k=
 github.com/decred/dcrd/connmgr/v2 v2.0.0/go.mod h1:HJ2q+m7DaMlNmQlY3WtbV3zETZfo4dfAi78z0ILLdqA=
 github.com/decred/dcrd/connmgr/v2 v2.1.0 h1:nfitnK4FXWLvuE5uNNtUjiyBZtwzROEpuWD5OdWeGpo=


### PR DESCRIPTION
This updates the addrmgr and connmgr modules from the dcrd project to
their latest released versions.  These are the same versions as used
by dcrd 1.5.0-rc1.