### PR TITLE
Avoid child index cursor backwards resets

### DIFF
--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -355,6 +355,8 @@ func TestAccountIndexes(t *testing.T) {
 		}
 		w.addressBuffersMu.Lock()
 		b := w.addressBuffers[0]
+		t.Logf("ext last=%d, ext cursor=%d, int last=%d, int cursor=%d",
+			b.albExternal.lastUsed,  b.albExternal.cursor,  b.albInternal.lastUsed,  b.albInternal.cursor)
 		check := func(what string, a, b uint32) {
 			if a != b {
 				t.Fatalf("%d: %s do not match: %d != %d", i, what, a, b)


### PR DESCRIPTION
Some operations delay the database update recording the last returned
address of an account branch.  This may cause the lookahead address
watching code to set a new cursor which does not reflect these new
returned addresses, effectively causing the next child index for a new
address in the account to be reset and go backwards.  This corrects
this bug by considering the current difference between the in-memory
child index management and the values read from the db.