### PR TITLE
Add assets package for accessing dcrwallet file assets

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,25 @@
+package assets
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+var basepath string
+
+func init() {
+	_, goFilename, _, _ := runtime.Caller(0)
+	basepath = filepath.Dir(goFilename)
+}
+
+// Path returns the absolute filepath of a file in the dcrwallet main module,
+// relative to the assets package.
+//
+// For example, to access the filepath of a sample-dcrwallet.conf file from the
+// root of the main module, call Path("../sample-dcrwallet.conf").
+//
+// This function is only usable when built without -trimpath and on the host the
+// Go program was compiled on.
+func Path(asset string) string {
+	return filepath.Join(basepath, asset)
+}


### PR DESCRIPTION
The assets package is part of the main module.  It provides a single
function, Path, which returns the absolute path to any file in the
dcrwallet main module, relative to assets package.  This function is
usable by release tooling to access module file contents without
needing to copy the contents into a Go variable or constant.