### PR TITLE
Silence ticketbuyer insufficient balance errors

### DIFF
--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -279,14 +279,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	for _, hash := range tix {
 		log.Infof("Purchased ticket %v at stake difficulty %v", hash, sdiff)
 	}
-	if err != nil && !errors.Is(errors.InsufficientBalance, err) {
-		// Invalid passphrase errors must be returned so Run exits.
-		if errors.Is(err, errors.Passphrase) {
-			return err
-		}
-		log.Errorf("One or more tickets could not be purchased: %v", err)
-	}
-	return nil
+	return err
 }
 
 // AccessConfig runs f with the current config passed as a parameter.  The


### PR DESCRIPTION
There was a bug in the detection of insufficient balance errors
(reversed parameters passed to errors.Is) that was causing these
errors to be logged when they were intended to be silenced.  Since the
calling code already logs errors (and correctly silences the logs for
insufficient balance errors), just remove this unneeded code.