### PR TITLE
Prepare walletseed/v1.0.3 with pgpwordlist 1.0.1

### DIFF
--- a/walletseed/go.mod
+++ b/walletseed/go.mod
@@ -5,5 +5,5 @@ go 1.12
 require (
 	github.com/decred/dcrd/hdkeychain/v2 v2.0.1
 	github.com/decred/dcrwallet/errors/v2 v2.0.0
-	github.com/decred/dcrwallet/pgpwordlist v1.0.0
+	github.com/decred/dcrwallet/pgpwordlist v1.0.1
 )

--- a/walletseed/go.sum
+++ b/walletseed/go.sum
@@ -26,12 +26,10 @@ github.com/decred/dcrd/hdkeychain/v2 v2.0.1 h1:LnMLuPDx6j1/7ywGdfX5onPOsa98yObzB
 github.com/decred/dcrd/hdkeychain/v2 v2.0.1/go.mod h1:qPv+vTla19liVHFuXVnQ70dMI4ERPCniDXbV5RzwQiM=
 github.com/decred/dcrd/wire v1.2.0 h1:HqJVB7vcklIguzFWgRXw/WYCQ9cD3bUC5TKj53i1Hng=
 github.com/decred/dcrd/wire v1.2.0/go.mod h1:/JKOsLInOJu6InN+/zH5AyCq3YDIOW/EqcffvU8fJHM=
-github.com/decred/dcrwallet/errors v1.0.0 h1:XjSILZ2mK5HqWYlhdBpsm+CimFDqDB+hY3tuX0Yh0Jo=
-github.com/decred/dcrwallet/errors v1.0.0/go.mod h1:XUm95dWmm9XmQGvneBXJkkIaFeRsQVBB6ni/KTy1hrY=
 github.com/decred/dcrwallet/errors/v2 v2.0.0 h1:b3QHoQNjKkrcO0GSpueeHvFKp5eqtRv9aw649MDyejA=
 github.com/decred/dcrwallet/errors/v2 v2.0.0/go.mod h1:2HYvtRuCE9XqDNCWhKmBuzLG364xUgcUIsJu02r0F5Q=
-github.com/decred/dcrwallet/pgpwordlist v1.0.0 h1:H7Y3+yRZq7PXMPfpKLMnY5TKTjTWhc0oJmyN7v8tC/M=
-github.com/decred/dcrwallet/pgpwordlist v1.0.0/go.mod h1:Fek3uYn+9DnEFIreA/8PnTIXUl2lBO64JpEBkL9BXtk=
+github.com/decred/dcrwallet/pgpwordlist v1.0.1 h1:SIGGOEQ+hNFDr/1wJOf8XAKxEw4zooKIpjLNQSxGjH8=
+github.com/decred/dcrwallet/pgpwordlist v1.0.1/go.mod h1:lPHIIVPkuRNwCfBPSr80kjR+6a2Vpm3nsUeUoUIPPQ4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8 h1:1wopBVtVdWnn03fZelqdXTqk7U7zPQCb+T4rbU9ZEoU=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
The previous tagged walletseed release depended on pgpwordlist 1.0.0
which caused a transitive module dependency on the v1 errors module.