### PR TITLE
Remove pseudo-versions from main module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,17 +24,17 @@ require (
 	github.com/decred/dcrd/txscript v1.1.0
 	github.com/decred/dcrd/txscript/v2 v2.1.0
 	github.com/decred/dcrd/wire v1.3.0
-	github.com/decred/dcrwallet/chain/v3 v3.0.0-00010101000000-000000000000
+	github.com/decred/dcrwallet/chain/v3 v3.0.1
 	github.com/decred/dcrwallet/errors/v2 v2.0.0
 	github.com/decred/dcrwallet/p2p/v2 v2.0.0
 	github.com/decred/dcrwallet/rpc/client/dcrd v1.0.0
 	github.com/decred/dcrwallet/rpc/jsonrpc/types v1.3.0
-	github.com/decred/dcrwallet/rpc/walletrpc v0.2.0
-	github.com/decred/dcrwallet/spv/v3 v3.0.0-00010101000000-000000000000
-	github.com/decred/dcrwallet/ticketbuyer/v4 v4.0.0-00010101000000-000000000000
-	github.com/decred/dcrwallet/version v1.0.1
+	github.com/decred/dcrwallet/rpc/walletrpc v0.3.0
+	github.com/decred/dcrwallet/spv/v3 v3.0.1
+	github.com/decred/dcrwallet/ticketbuyer/v4 v4.0.1
+	github.com/decred/dcrwallet/version v1.0.3
 	github.com/decred/dcrwallet/wallet/v3 v3.1.0
-	github.com/decred/dcrwallet/walletseed v1.0.1
+	github.com/decred/dcrwallet/walletseed v1.0.3
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.0.0
 	github.com/gorilla/websocket v1.4.1


### PR DESCRIPTION
During the last series of major module bumps, the main module was
updated with pseudo zero versions (00010101000000-000000000000), which
go get cannot deal with.  This change updates all dcrwallet modules to
their latest tagged versions.