### PR TITLE
apply cleanAndExpandPath() on CSPPServer.ca option

### DIFF
--- a/config.go
+++ b/config.go
@@ -706,6 +706,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		}
 	}
 	if cfg.CSPPServerCA != "" {
+		cfg.CSPPServerCA = cleanAndExpandPath(cfg.CSPPServerCA)
 		ca, err := ioutil.ReadFile(cfg.CSPPServerCA)
 		if err != nil {
 			err := errors.Errorf("Cannot read CoinShuffle++ "+


### PR DESCRIPTION
The `CSPPServer.ca` option didn't accept the same file spec's as `--cafile`, i.e. `~/.dcrwallet/cspp.pem`.