### PR TITLE
Use source account as change account for gRPC ticketbuyer config

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -2195,6 +2195,7 @@ func (t *ticketbuyerV2Server) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr 
 	tb.AccessConfig(func(c *ticketbuyer.Config) {
 		c.BuyTickets = true
 		c.Account = req.Account
+		c.ChangeAccount = req.Account
 		c.VotingAccount = req.VotingAccount
 		c.Maintain = dcrutil.Amount(req.BalanceToMaintain)
 		c.VotingAddr = votingAddress


### PR DESCRIPTION
A breaking change to the ticketbuyer module introduced a ChangeAccount
field to the config.  This was a breaking change due to the field now
being required to keep previous behavior, otherwise the change account
would default to the zero account.  Specify this account explicitly in
the gRPC RunTicketBuyer method handler, so that the previous behavior
is retained.