### PR TITLE
Avoid address cursor resetting during address discovery

### DIFF
--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -356,7 +356,7 @@ func TestAccountIndexes(t *testing.T) {
 		w.addressBuffersMu.Lock()
 		b := w.addressBuffers[0]
 		t.Logf("ext last=%d, ext cursor=%d, int last=%d, int cursor=%d",
-			b.albExternal.lastUsed,  b.albExternal.cursor,  b.albInternal.lastUsed,  b.albInternal.cursor)
+			b.albExternal.lastUsed, b.albExternal.cursor, b.albInternal.lastUsed, b.albInternal.cursor)
 		check := func(what string, a, b uint32) {
 			if a != b {
 				t.Fatalf("%d: %s do not match: %d != %d", i, what, a, b)

--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -953,13 +953,26 @@ func (w *Wallet) DiscoverActiveAddresses(ctx context.Context, p Peer, startBlock
 			}
 
 			// Update last used index and cursor for this account's address
-			// buffers.
+			// buffers.  The cursor must not be reset backwards to avoid the
+			// possibility of address reuse.
 			w.addressBuffersMu.Lock()
 			acctData := w.addressBuffers[acct]
-			acctData.albExternal.lastUsed = props.LastUsedExternalIndex
-			acctData.albExternal.cursor = props.LastReturnedExternalIndex - props.LastUsedExternalIndex
-			acctData.albInternal.lastUsed = props.LastUsedInternalIndex
-			acctData.albInternal.cursor = props.LastReturnedInternalIndex - props.LastUsedInternalIndex
+			extern := &acctData.albExternal
+			if props.LastUsedExternalIndex+1 > extern.lastUsed+1 {
+				extern.cursor += extern.lastUsed - props.LastUsedExternalIndex
+				if extern.cursor > ^uint32(0)>>1 {
+					extern.cursor = 0
+				}
+				extern.lastUsed = props.LastUsedExternalIndex
+			}
+			intern := &acctData.albInternal
+			if props.LastUsedInternalIndex+1 > intern.lastUsed+1 {
+				intern.cursor += intern.lastUsed - props.LastUsedInternalIndex
+				if intern.cursor > ^uint32(0)>>1 {
+					intern.cursor = 0
+				}
+				intern.lastUsed = props.LastUsedInternalIndex
+			}
 			w.addressBuffersMu.Unlock()
 			return nil
 		})

--- a/wallet/discovery_test.go
+++ b/wallet/discovery_test.go
@@ -1,0 +1,102 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+	"testing"
+
+	"github.com/decred/dcrwallet/wallet/v3/walletdb"
+)
+
+// TestDiscoveryCursorPos tests that the account cursor index is not reset
+// during address discovery such that an address could be reused.
+func TestDiscoveryCursorPos(t *testing.T) {
+	ctx := context.Background()
+
+	cfg := basicWalletConfig
+	// normally would just do the upgrade, but the buffers record
+	// off-by-ones after the upgrade.  will be fixed in a later commit.
+	cfg.DisableCoinTypeUpgrades = true
+
+	w, teardown := testWallet(t, &cfg)
+	defer teardown()
+
+	/*
+		// Upgrade the cointype before proceeding.  The test is invalid if a
+		// cointype upgrade occurs during discovery.
+		err := w.UpgradeToSLIP0044CoinType(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+	*/
+
+	// Advance the cursor within the gap limit but without recording the
+	// returned addresses in the database (these may be persisted during a
+	// later update).
+	w.addressBuffersMu.Lock()
+	xpub := w.addressBuffers[0].albExternal.branchXpub
+	w.addressBuffers[0].albExternal.cursor = 9 // 0-9 have been returned
+	w.addressBuffersMu.Unlock()
+
+	// Perform address discovery
+	// All peer funcs may be left unimplemented; wallet only records the genesis block.
+	peer := &peerFuncs{}
+	err := w.DiscoverActiveAddresses(ctx, peer, &w.chainParams.GenesisHash, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w.addressBuffersMu.Lock()
+	lastUsed := w.addressBuffers[0].albExternal.lastUsed
+	cursor := w.addressBuffers[0].albExternal.cursor
+	w.addressBuffersMu.Unlock()
+	wasLastUsed := ^uint32(0)
+	wasCursor := uint32(9)
+	if lastUsed != wasLastUsed || cursor != wasCursor {
+		t.Errorf("cursor was reset: lastUsed=%d (want %d) cursor=%d (want %d)",
+			lastUsed, wasLastUsed, cursor, wasCursor)
+	}
+
+	// Manually mark an address between the lastUsed and cursor as used, and
+	// addresses through the cursor as returned, then perform discovery
+	// again.  The cursor should be reduced such that the next returned
+	// address would be the same as before, without introducing a backwards
+	// reset or wasted addresses.
+	addr4, err := deriveChildAddress(xpub, 4, w.chainParams)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
+		ns := dbtx.ReadBucket(waddrmgrNamespaceKey)
+		err = w.Manager.MarkReturnedChildIndex(dbtx, 0, 0, 9) // 0-9 have been returned
+		if err != nil {
+			return err
+		}
+		maddr4, err := w.Manager.Address(ns, addr4)
+		if err != nil {
+			return err
+		}
+		return w.markUsedAddress("", dbtx, maddr4)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.DiscoverActiveAddresses(ctx, peer, &w.chainParams.GenesisHash, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w.addressBuffersMu.Lock()
+	lastUsed = w.addressBuffers[0].albExternal.lastUsed
+	cursor = w.addressBuffers[0].albExternal.cursor
+	w.addressBuffersMu.Unlock()
+	wasLastUsed += 5
+	wasCursor -= 5
+	if lastUsed != wasLastUsed || cursor != wasCursor {
+		t.Errorf("cursor was reset: lastUsed=%d (want %d) cursor=%d (want %d)",
+			lastUsed, wasLastUsed, cursor, wasCursor)
+	}
+}

--- a/wallet/main_test.go
+++ b/wallet/main_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"flag"
+	"os"
+	"testing"
+
+	"github.com/decred/slog"
+)
+
+var logFlag = flag.Bool("log", false, "enable package logger")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *logFlag {
+		UseLogger(slog.NewBackend(os.Stderr).Logger("WLLT"))
+	}
+
+	os.Exit(m.Run())
+}

--- a/wallet/peer_test.go
+++ b/wallet/peer_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"context"
+
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/gcs"
+	"github.com/decred/dcrd/wire"
+)
+
+// peerFuncs implements Peer with custom implementations of each individual method.
+// Functions may be left nil (unimplemented) if they will not be called by the test code.
+type peerFuncs struct {
+	blocks              func(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error)
+	cfilters            func(ctx context.Context, blockHashes []*chainhash.Hash) ([]*gcs.Filter, error)
+	headers             func(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error)
+	publishTransactions func(ctx context.Context, txs ...*wire.MsgTx) error
+}
+
+func (p *peerFuncs) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error) {
+	return p.blocks(ctx, blockHashes)
+}
+func (p *peerFuncs) CFilters(ctx context.Context, blockHashes []*chainhash.Hash) ([]*gcs.Filter, error) {
+	return p.cfilters(ctx, blockHashes)
+}
+func (p *peerFuncs) Headers(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error) {
+	return p.headers(ctx, blockLocators, hashStop)
+}
+func (p *peerFuncs) PublishTransactions(ctx context.Context, txs ...*wire.MsgTx) error {
+	return p.publishTransactions(ctx, txs...)
+}


### PR DESCRIPTION
This is a similar fix as 848d33040d, where the address cursor was
occasionally being reset.  In this case, the cause was occuring during
address discovery, and it was possible to introduce address reusage
this way when the RPC syncing process temporarily disconnected and
reconnected.

Tests have been added to ensure the the reset fix works as intended.
These tests fail without the changes in discovery.go.

A few minor changes to the wallet package's testing features were
added.  A peerFuncs type was introduced to allow definitions of custom
implementations of the Peer interface.  Wallet logs may also be viewed
now when running tests, though due to the package global logger, it is
recommended to only use this feature when running one test at a time
to avoid intertwined logs.  For example, to use it with the new test:

  $ go test -run TestDiscoveryCursorPos -v -args -log