### PR TITLE
Avoid race accessing a range loop iterator

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3198,6 +3198,7 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd interface{}) (inte
 			}
 
 			// Asynchronously request the output script.
+			txIn := txIn
 			requestedGroup.Go(func() error {
 				hash := txIn.PreviousOutPoint.Hash.String()
 				index := txIn.PreviousOutPoint.Index


### PR DESCRIPTION
A copy of the variable is created which the closure now closes over,
rather than closing over the mutating iterator variable.