### PR TITLE
Update version prerelease and build metadata naming scheme

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -29,12 +29,12 @@ const Integer = 1000000*Major + 10000*Minor + 100*Patch
 // so it can be modified at link time (e.g.
 // `-ldflags "-X github.com/decred/dcrwallet/version.PreRelease=rc1"`).
 // It must only contain characters from the semantic version alphabet.
-var PreRelease = "pre"
+var PreRelease = ""
 
 // BuildMetadata defines additional build metadata.  It is modified at link time
 // for official releases.  It must only contain characters from the semantic
 // version alphabet.
-var BuildMetadata = "dev"
+var BuildMetadata = "release.local"
 
 // String returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (https://semver.org/).

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ const semverAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrst
 const (
 	Major = 1
 	Minor = 5
-	Patch = 1
+	Patch = 2
 )
 
 // Integer is an integer encoding of the major.minor.patch version.
@@ -29,12 +29,12 @@ const Integer = 1000000*Major + 10000*Minor + 100*Patch
 // so it can be modified at link time (e.g.
 // `-ldflags "-X github.com/decred/dcrwallet/version.PreRelease=rc1"`).
 // It must only contain characters from the semantic version alphabet.
-var PreRelease = ""
+var PreRelease = "pre"
 
 // BuildMetadata defines additional build metadata.  It is modified at link time
 // for official releases.  It must only contain characters from the semantic
 // version alphabet.
-var BuildMetadata = "release.local"
+var BuildMetadata = ""
 
 // String returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (https://semver.org/).


### PR DESCRIPTION
Releases will now use the empty string for the prerelease field, and
"release.local" for build metadata.  This indicates that the code is
for a release, but the release was built from the repo or using go get
without the release build tool.

Development versions will use "pre" for the prerelease and default to
no build metadata.

This PR contains a series of two commits.  The first will be tagged and then required from the release branch.  The second exists so that builds from master do not display as release builds.