### PR TITLE
Remove DisableLog functions

### DIFF
--- a/chain/log.go
+++ b/chain/log.go
@@ -10,18 +10,7 @@ import "github.com/decred/slog"
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log slog.Logger
-
-// The default amount of logging is none.
-func init() {
-	DisableLog()
-}
-
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until either UseLogger or SetLogWriter are called.
-func DisableLog() {
-	log = slog.Disabled
-}
+var log = slog.Disabled
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also

--- a/internal/loader/log.go
+++ b/internal/loader/log.go
@@ -10,18 +10,7 @@ import "github.com/decred/slog"
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log slog.Logger
-
-// The default amount of logging is none.
-func init() {
-	DisableLog()
-}
-
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until either UseLogger or SetLogWriter are called.
-func DisableLog() {
-	log = slog.Disabled
-}
+var log = slog.Disabled
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also

--- a/wallet/log.go
+++ b/wallet/log.go
@@ -10,18 +10,7 @@ import "github.com/decred/slog"
 // log is a logger that is initialized with no output filters.  This
 // means the package will not perform any logging by default until the caller
 // requests it.
-var log slog.Logger
-
-// The default amount of logging is none.
-func init() {
-	DisableLog()
-}
-
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until either UseLogger or SetLogWriter are called.
-func DisableLog() {
-	log = slog.Disabled
-}
+var log = slog.Disabled
 
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also

--- a/wallet/udb/log.go
+++ b/wallet/udb/log.go
@@ -12,12 +12,6 @@ import "github.com/decred/slog"
 // requests it.
 var log = slog.Disabled
 
-// DisableLog disables all library log output.  Logging output is disabled
-// by default until either UseLogger or SetLogWriter are called.
-func DisableLog() {
-	log = slog.Disabled
-}
-
 // UseLogger uses a specified Logger to output package logging info.
 // This should be used in preference to SetLogWriter if the caller is also
 // using slog.


### PR DESCRIPTION
These functions are unnecessary and any usage can be replaced with
UseLogger(slog.Disabled).