### PR TITLE
Avoid spurious error logs caused by cancelling ticket purchasing

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1285,6 +1285,9 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 	// relevant transactions
 	var watchOutPoints []wire.OutPoint
 	defer func() {
+		if ctx.Err() != nil {
+			return
+		}
 		_, err := w.watchHDAddrs(ctx, false, n)
 		if err != nil {
 			log.Errorf("Failed to watch for future address usage after publishing "+


### PR DESCRIPTION
When the context passed to the ticket purchasing methods is cancelled,
an error log was being created for the failed deferred call to
watchHDAddrs.  Rather than continuing to call this method, if the
context is cancelled, return early from the deferred function.

Because the automated ticketbuyer uses context cancellation to stop
ongoing purchases whenever the ticket price changes, this was causing
unnecessary and unhelpful errors to be logged.