### PR TITLE
Use better names for accessing BIP0044 xpubs/xprivs

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -1673,11 +1673,11 @@ func (s *Server) getMasterPubkey(ctx context.Context, icmd interface{}) (interfa
 		}
 	}
 
-	masterPubKey, err := w.MasterPubKey(ctx, account)
+	xpub, err := w.AccountXpub(ctx, account)
 	if err != nil {
 		return nil, err
 	}
-	return masterPubKey.String(), nil
+	return xpub.String(), nil
 }
 
 // getStakeInfo gets a large amounts of information about the stake environment

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1066,7 +1066,7 @@ func (s *walletServer) ConstructTransaction(ctx context.Context, req *pb.Constru
 }
 
 func (s *walletServer) GetAccountExtendedPubKey(ctx context.Context, req *pb.GetAccountExtendedPubKeyRequest) (*pb.GetAccountExtendedPubKeyResponse, error) {
-	accExtendedPubKey, err := s.wallet.MasterPubKey(ctx, req.AccountNumber)
+	accExtendedPubKey, err := s.wallet.AccountXpub(ctx, req.AccountNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -1089,7 +1089,7 @@ func (s *walletServer) GetAccountExtendedPrivKey(ctx context.Context, req *pb.Ge
 	}
 	defer lockWallet()
 
-	accExtendedPrivKey, err := s.wallet.MasterPrivKey(ctx, req.AccountNumber)
+	accExtendedPrivKey, err := s.wallet.AccountXpriv(ctx, req.AccountNumber)
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -434,28 +434,6 @@ func deriveKey(acctInfo *accountInfo, branch, index uint32, private bool) (*hdke
 	return addressKey, err
 }
 
-// GetMasterPubkey gives the encoded string version of the HD master public key
-// for the default account of the wallet.
-func (m *Manager) GetMasterPubkey(ns walletdb.ReadBucket, account uint32) (string, error) {
-	defer m.mtx.Unlock()
-	m.mtx.Lock()
-
-	// The account is either invalid or just wasn't cached, so attempt to
-	// load the information from the database.
-	row, err := fetchAccountInfo(ns, account, DBVersion)
-	if err != nil {
-		return "", err
-	}
-
-	// Use the crypto public key to decrypt the account public extended key.
-	serializedKeyPub, err := m.cryptoKeyPub.Decrypt(row.pubKeyEncrypted)
-	if err != nil {
-		return "", errors.E(errors.IO, err)
-	}
-
-	return string(serializedKeyPub), nil
-}
-
 // loadAccountInfo attempts to load and cache information about the given
 // account from the database.   This includes what is necessary to derive new
 // keys for it and track the state of the internal and external branches.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1811,31 +1811,27 @@ func (w *Wallet) NextAccount(ctx context.Context, name string) (uint32, error) {
 	return account, nil
 }
 
-// MasterPubKey returns the BIP0044 master public key for the passed account.
-func (w *Wallet) MasterPubKey(ctx context.Context, account uint32) (*hdkeychain.ExtendedKey, error) {
-	const op errors.Op = "wallet.MasterPubKey"
-	var masterPubKey string
+// AccountXpub returns a BIP0044 account's extended public key.
+func (w *Wallet) AccountXpub(ctx context.Context, account uint32) (*hdkeychain.ExtendedKey, error) {
+	const op errors.Op = "wallet.AccountXpub"
+
+	var pubKey *hdkeychain.ExtendedKey
 	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
 		var err error
-		masterPubKey, err = w.manager.GetMasterPubkey(addrmgrNs, account)
+		pubKey, err = w.manager.AccountExtendedPubKey(tx, account)
 		return err
 	})
 	if err != nil {
 		return nil, errors.E(op, err)
 	}
-	extKey, err := hdkeychain.NewKeyFromString(masterPubKey, w.chainParams)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	return extKey, nil
+
+	return pubKey, nil
 }
 
-// MasterPrivKey returns the extended private key for the given account. The
-// account must exist and the wallet must be unlocked, otherwise this function
-// fails.
-func (w *Wallet) MasterPrivKey(ctx context.Context, account uint32) (*hdkeychain.ExtendedKey, error) {
-	const op errors.Op = "wallet.MasterPrivKey"
+// AccountXpriv returns a BIP0044 account's extended private key.  The account
+// must exist and the wallet must be unlocked, otherwise this function fails.
+func (w *Wallet) AccountXpriv(ctx context.Context, account uint32) (*hdkeychain.ExtendedKey, error) {
+	const op errors.Op = "wallet.AccountXpriv"
 
 	var privKey *hdkeychain.ExtendedKey
 	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -90,7 +90,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 
 	// Display a mining address when creating a simnet wallet.
 	if cfg.SimNet {
-		xpub, err := w.MasterPubKey(ctx, 0)
+		xpub, err := w.AccountXpub(ctx, 0)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This changes the names of the wallet methods to access BIP0044
extended public and private keys.  The use of "master" in the method
names was misleading, as this can be confused with the master BIP0032
key.