### PR TITLE
Remove deprecated ticket purchasing methods

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -2481,7 +2481,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		VSPAddress:    poolAddr,
 		VSPFees:       poolFee,
 	}
-	ticketsResponse, err := w.PurchaseTicketsWithResponse(ctx, n, request)
+	ticketsResponse, err := w.PurchaseTickets(ctx, n, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1631,7 +1631,7 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 		}
 	}
 
-	ticketsResponse, err := s.wallet.PurchaseTicketsWithResponse(ctx, n, request)
+	ticketsResponse, err := s.wallet.PurchaseTickets(ctx, n, request)
 	if err != nil {
 		return nil, err
 	}

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -256,7 +256,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 		buy = limit
 	}
 
-	tix, err := w.PurchaseTicketsContext(ctx, n, &wallet.PurchaseTicketsRequest{
+	tix, err := w.PurchaseTickets(ctx, n, &wallet.PurchaseTicketsRequest{
 		Count:         buy,
 		SourceAccount: account,
 		VotingAddress: votingAddr,
@@ -276,7 +276,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 		VSPAddress: poolFeeAddr,
 		VSPFees:    poolFees,
 	})
-	for _, hash := range tix {
+	for _, hash := range tix.TicketHashes {
 		log.Infof("Purchased ticket %v at stake difficulty %v", hash, sdiff)
 	}
 	return err


### PR DESCRIPTION
Rename the only remaining method (PurchaseTicketsWithResponse) to
simply PurchaseTickets.