### PR TITLE
Switch to per-network scrypt options

### DIFF
--- a/wallet/udb/initialize.go
+++ b/wallet/udb/initialize.go
@@ -31,7 +31,7 @@ func Initialize(ctx context.Context, db walletdb.DB, params *chaincfg.Params, se
 		}
 
 		// Create the address manager, transaction store, and stake store.
-		err = createAddressManager(addrmgrNs, seed, pubPass, privPass, params, &defaultScryptOptions)
+		err = createAddressManager(addrmgrNs, seed, pubPass, privPass, params)
 		if err != nil {
 			return err
 		}
@@ -77,7 +77,7 @@ func InitializeWatchOnly(ctx context.Context, db walletdb.DB, params *chaincfg.P
 		}
 
 		// Create the address manager, transaction store, and stake store.
-		err = createWatchOnly(addrmgrNs, hdPubKey, pubPass, params, &defaultScryptOptions)
+		err = createWatchOnly(addrmgrNs, hdPubKey, pubPass, params)
 		if err != nil {
 			return err
 		}

--- a/wallet/udb/internal_test.go
+++ b/wallet/udb/internal_test.go
@@ -29,7 +29,7 @@ func TstRunWithReplacedNewSecretKey(callback func()) {
 	defer func() {
 		newSecretKey = orig
 	}()
-	newSecretKey = func(passphrase *[]byte, config *ScryptOptions) (*snacl.SecretKey, error) {
+	newSecretKey = func(passphrase *[]byte, config *scryptOptions) (*snacl.SecretKey, error) {
 		return nil, errors.E(errors.Crypto)
 	}
 	callback()


### PR DESCRIPTION
Close #1470 

This adds a new package-level type and variable to the `wallet` package that allows consumers to set their preferred PBKDF algorithm.

This allows external tests to use a faster (albeit unsafe) algorithm to speed up wallet creation.

It also adds a grpc endpoint to the `WalletLoaderService` so that remote users can also setup this parameter before creating a wallet.