### PR TITLE
Define Address and KnownAddress interfaces

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -101,9 +101,12 @@ func (s *Syncer) LoadTxFilter(ctx context.Context, reload bool, addrs []dcrutil.
 	}
 	for _, addr := range addrs {
 		var pkScript []byte
+		type scripter interface {
+			PaymentScript() (uint16, []byte)
+		}
 		switch addr := addr.(type) {
-		case wallet.V0Scripter:
-			pkScript = addr.ScriptV0()
+		case scripter:
+			_, pkScript = addr.PaymentScript()
 		default:
 			pkScript, _ = txscript.PayToAddrScript(addr)
 		}

--- a/wallet/addresses_test.go
+++ b/wallet/addresses_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"io/ioutil"
 	"os"
-	"strings"
 	"testing"
 
 	"decred.org/dcrwallet/wallet/walletdb"
@@ -23,7 +22,7 @@ import (
 type expectedAddr struct {
 	address     string
 	addressHash []byte
-	internal    bool
+	branch      uint32
 	pubKey      []byte
 }
 
@@ -64,7 +63,8 @@ var (
 		Params:        chaincfg.SimNetParams(),
 	}
 
-	defaultAccount = uint32(0)
+	defaultAccount     = uint32(0)
+	defaultAccountName = "default"
 
 	waddrmgrBucketKey = []byte("waddrmgr")
 
@@ -72,31 +72,31 @@ var (
 		{
 			address:     "SsrFKd8aX4KHabWSQfbmEaDv3BJCpSH2ySj",
 			addressHash: hexToBytes("f032b89ec075ab2847e2ec186ad000be16cf354b"),
-			internal:    true,
+			branch:      1,
 			pubKey:      hexToBytes("03d1ad44eeac8eb59e9598f7e530a1cbe2c1684c0aa5f45ab24d33d38a2102dd1a"),
 		},
 		{
 			address:     "SsW4roiFKWkbbhiAeEV5byet1pLKAP4xRks",
 			addressHash: hexToBytes("12d5a8e19b9a070d6d5e6e425b593c2c137285e3"),
-			internal:    true,
+			branch:      1,
 			pubKey:      hexToBytes("02cbcf5c1aa84bf8e6d04412d867eccbaa6cc12ebb792f3f1eaf4d2887f8e884f3"),
 		},
 		{
 			address:     "SscaK4A6V94dawc6ZBRCGUxPjdf7um1GJgD",
 			addressHash: hexToBytes("5a38638f09937214b07481c656d0c9c73020f8bf"),
-			internal:    true,
+			branch:      1,
 			pubKey:      hexToBytes("0392735a0eee9026425556ef5c5ae23ad3e54598132a1ca0d74dbcac7bfe31bfa4"),
 		},
 		{
 			address:     "Ssm4BeTKgwKGTqNR63WiGtP1FJaKCRJsN1S",
 			addressHash: hexToBytes("b73edb8f32957800e2e3b9424c3b659acac51b7f"),
-			internal:    true,
+			branch:      1,
 			pubKey:      hexToBytes("037c1e500884c6c3cb044390b52525d324fd67c031fdd9a47d742d0323fe5de73f"),
 		},
 		{
 			address:     "SssBoVxTkCUb6xs7vph3BHdPmki3weVvRsF",
 			addressHash: hexToBytes("fa8073fcb670ba7312a1ef0d908cfb05c59b70b9"),
-			internal:    true,
+			branch:      1,
 			pubKey:      hexToBytes("0327540e546f9cfac45f51699e2656732727507971060641ead554d78eeea88aa6"),
 		},
 	}
@@ -105,31 +105,26 @@ var (
 		{
 			address:     "SsfPTmZmaXGkXfcNGjftRPmoGGCqtNPCHKx",
 			addressHash: hexToBytes("791376f67fb3becf392b071d25d7c99c82139ee3"),
-			internal:    false,
 			pubKey:      hexToBytes("031634efb3e83c834a82cdc898000f85215a09dc742d5b3b82ace7221ca1bb0938"),
 		},
 		{
 			address:     "SsXhSHBiaEan7Ls36bvhLspZ3LC1NKzuwQz",
 			addressHash: hexToBytes("24b8b3d89f987bf3cd80a8c16d9368d683217fa4"),
-			internal:    false,
 			pubKey:      hexToBytes("0280beb72c6ef42ce3133fd6d340fd5bedcfccaded5a6eabb6d2430e3958bf7c85"),
 		},
 		{
 			address:     "SspSfaWDNwc9TA31Q9iR2jot2eV1hk2ix6U",
 			addressHash: hexToBytes("dc67b3d95adb1789efe4aa73607d8a8c57eee2bb"),
-			internal:    false,
 			pubKey:      hexToBytes("03b120e0e073a12a1957680251a1562c5c6e30e547797fb5411107eac19699f601"),
 		},
 		{
 			address:     "SsrSYTB9MQQ1czAfPmWE66ZFqv7NrwzqfQT",
 			addressHash: hexToBytes("f252015c8e0059c21cae623704d8588d12ca5c74"),
-			internal:    false,
 			pubKey:      hexToBytes("0350822c9bd61f524f4d68fa605e850c34c5e8ccc9b5cf278782131c1e21dd261b"),
 		},
 		{
 			address:     "SsqBcGBre8SZrG61cd5M5e2GaMJbK2CMdEa",
 			addressHash: hexToBytes("e486d22d1244becac5a30b38dda1c8c4c1b3bdeb"),
-			internal:    false,
 			pubKey:      hexToBytes("031c494068c9c454bef7de35fa4717f21c07dec4471bd8500650b133d57e49a81d"),
 		},
 	}
@@ -170,11 +165,12 @@ func setupWallet(t *testing.T, cfg *Config) (*Wallet, walletdb.DB, func()) {
 	return w, db, teardown
 }
 
-func testExternalAddresses(tc *testContext) {
+type newAddressFunc func(*Wallet, context.Context, uint32, ...NextAddressCallOption) (dcrutil.Address, error)
+
+func testKnownAddresses(tc *testContext, prefix string, newAddr newAddressFunc, tests []expectedAddr) {
 	w, db, teardown := setupWallet(tc.t, &walletConfig)
 	defer teardown()
 
-	prefix := "testExternalAddresses"
 	ctx := context.Background()
 
 	if tc.watchingOnly {
@@ -188,144 +184,73 @@ func testExternalAddresses(tc *testContext) {
 		}
 	}
 
-	for i := 0; i < len(expectedExternalAddrs); i++ {
-		addr, err := w.NewExternalAddress(context.Background(), defaultAccount)
+	for i := 0; i < len(tests); i++ {
+		addr, err := newAddr(w, context.Background(), defaultAccount)
 		if err != nil {
 			tc.t.Fatalf("%s: failed to generate external address: %v",
 				prefix, err)
 		}
 
-		maddr, err := w.AddressInfo(ctx, addr)
+		ka, err := w.KnownAddress(ctx, addr)
 		if err != nil {
 			tc.t.Errorf("Unexpected error: %v", err)
+			continue
 		}
 
-		if maddr.Account() != defaultAccount {
-			tc.t.Fatalf("%s: expected account %v got %v", prefix,
-				defaultAccount, maddr.Account())
+		if ka.AccountName() != defaultAccountName {
+			tc.t.Errorf("%s: expected account %v got %v", prefix,
+				defaultAccount, ka.AccountName())
 		}
 
-		if strings.Compare(maddr.Address().String(),
-			expectedExternalAddrs[i].address) != 0 {
-			tc.t.Fatalf("%s: expected address %v got %v", prefix,
-				expectedExternalAddrs[i].address, maddr.Address().String())
+		if ka.String() != tests[i].address {
+			tc.t.Errorf("%s: expected address %v got %v", prefix,
+				tests[i].address, ka)
+		}
+		a := ka.(BIP0044Address)
+		if !bytes.Equal(a.PubKeyHash(), tests[i].addressHash) {
+			tc.t.Errorf("%s: expected address hash %v got %v", prefix,
+				hex.EncodeToString(tests[i].addressHash),
+				hex.EncodeToString(a.PubKeyHash()))
 		}
 
-		if !bytes.Equal(maddr.AddrHash(), expectedExternalAddrs[i].addressHash) {
-			tc.t.Fatalf("%s: expected address hash %v got %v", prefix,
-				hex.EncodeToString(expectedExternalAddrs[i].addressHash),
-				hex.EncodeToString(maddr.AddrHash()))
+		if _, branch, _ := a.Path(); branch != tests[i].branch {
+			tc.t.Errorf("%s: expected branch of %v got %v", prefix,
+				tests[i].branch, branch)
 		}
 
-		if maddr.Internal() != expectedExternalAddrs[i].internal {
-			tc.t.Fatalf("%s: expected internal status of %v got %v", prefix,
-				expectedExternalAddrs[i].internal, maddr.Internal())
-		}
-
-		pubKey, err := w.PubKeyForAddress(ctx, addr)
-		if err != nil {
-			tc.t.Fatalf("%s: failed to get public key for address %s: %v",
-				prefix, addr.String(), err)
-		}
-
-		if !bytes.Equal(pubKey.SerializeCompressed(), expectedExternalAddrs[i].pubKey) {
-			tc.t.Fatalf("%s: expected pubkey %v got %v",
-				prefix, hex.EncodeToString(expectedExternalAddrs[i].pubKey),
-				hex.EncodeToString(pubKey.SerializeCompressed()))
-		}
-	}
-}
-
-func testInternalAddresses(tc *testContext) {
-	w, db, teardown := setupWallet(tc.t, &walletConfig)
-	defer teardown()
-
-	prefix := "testInternalAddresses"
-	ctx := context.Background()
-
-	if tc.watchingOnly {
-		err := walletdb.Update(ctx, db, func(tx walletdb.ReadWriteTx) error {
-			ns := tx.ReadWriteBucket(waddrmgrBucketKey)
-			return w.manager.ConvertToWatchingOnly(ns)
-		})
-		if err != nil {
-			tc.t.Fatalf("%s: failed to convert wallet to watching only: %v",
-				prefix, err)
-		}
-	}
-
-	for i := 0; i < len(expectedInternalAddrs); i++ {
-		addr, err := w.NewInternalAddress(context.Background(), defaultAccount)
-		if err != nil {
-			tc.t.Fatalf("%s: failed to generate internal address: %v",
-				prefix, err)
-		}
-
-		maddr, err := w.AddressInfo(ctx, addr)
-		if err != nil {
-			tc.t.Errorf("Unexpected error: %v", err)
-		}
-
-		if maddr.Account() != defaultAccount {
-			tc.t.Fatalf("%s: expected account %v got %v", prefix,
-				defaultAccount, maddr.Account())
-		}
-
-		if strings.Compare(maddr.Address().String(),
-			expectedInternalAddrs[i].address) != 0 {
-			tc.t.Fatalf("%s: expected address %v got %v", prefix,
-				expectedExternalAddrs[i].address, maddr.Address().String())
-		}
-
-		if !bytes.Equal(maddr.AddrHash(), expectedInternalAddrs[i].addressHash) {
-			tc.t.Fatalf("%s: expected address hash %v got %v", prefix,
-				hex.EncodeToString(expectedInternalAddrs[i].addressHash),
-				hex.EncodeToString(maddr.AddrHash()))
-		}
-
-		if maddr.Internal() != expectedInternalAddrs[i].internal {
-			tc.t.Fatalf("%s: expected internal status of %v got %v", prefix,
-				expectedExternalAddrs[i].internal, maddr.Internal())
-		}
-
-		pubKey, err := w.PubKeyForAddress(ctx, addr)
-		if err != nil {
-			tc.t.Fatalf("%s: failed to get public key for address %s: %v",
-				prefix, addr.String(), err)
-		}
-
-		if !bytes.Equal(pubKey.SerializeCompressed(), expectedInternalAddrs[i].pubKey) {
-			tc.t.Fatalf("%s: expected pubkey %v got %v",
-				prefix, hex.EncodeToString(expectedInternalAddrs[i].pubKey),
-				hex.EncodeToString(pubKey.SerializeCompressed()))
+		pubKey := a.PubKey()
+		if !bytes.Equal(pubKey, tests[i].pubKey) {
+			tc.t.Errorf("%s: expected pubkey %v got %v",
+				prefix, hex.EncodeToString(tests[i].pubKey),
+				hex.EncodeToString(pubKey))
 		}
 	}
 }
 
 func TestAddresses(t *testing.T) {
-	testInternalAddresses(&testContext{
+	testKnownAddresses(&testContext{
 		t:            t,
 		account:      defaultAccount,
 		watchingOnly: false,
-	})
+	}, "testInternalAddresses", (*Wallet).NewInternalAddress, expectedInternalAddrs)
 
-	testInternalAddresses(&testContext{
+	testKnownAddresses(&testContext{
 		t:            t,
 		account:      defaultAccount,
 		watchingOnly: true,
-	})
+	}, "testInternalAddresses", (*Wallet).NewInternalAddress, expectedInternalAddrs)
 
-	testExternalAddresses(&testContext{
+	testKnownAddresses(&testContext{
 		t:            t,
 		account:      defaultAccount,
 		watchingOnly: false,
-	})
+	}, "testExternalAddresses", (*Wallet).NewExternalAddress, expectedExternalAddrs)
 
-	testExternalAddresses(&testContext{
+	testKnownAddresses(&testContext{
 		t:            t,
 		account:      defaultAccount,
 		watchingOnly: true,
-	})
+	}, "testExternalAddresses", (*Wallet).NewExternalAddress, expectedExternalAddrs)
 }
 
 func TestAccountIndexes(t *testing.T) {

--- a/wallet/coinjoin.go
+++ b/wallet/coinjoin.go
@@ -67,7 +67,9 @@ func (c *csppJoin) Gen() ([][]byte, error) {
 	var updates []func(walletdb.ReadWriteTx) error
 	for i := 0; i < c.mcount; i++ {
 		persist := c.wallet.deferPersistReturnedChild(c.ctx, &updates)
-		mixAddr, err := c.wallet.nextAddress(c.ctx, op, persist, c.mixAccount, c.mixBranch, WithGapPolicyIgnore())
+		const accountName = "" // not used, so can be faked.
+		mixAddr, err := c.wallet.nextAddress(c.ctx, op, persist,
+			accountName, c.mixAccount, c.mixBranch, WithGapPolicyIgnore())
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -148,7 +148,9 @@ func (w *Wallet) MixOutput(ctx context.Context, dialTLS DialFunc, csppserver str
 	var change *wire.TxOut
 	if !txrules.IsDustAmount(changeValue, P2PKHv0Len, feeRate) {
 		persist := w.deferPersistReturnedChild(ctx, &updates)
-		addr, err := w.nextAddress(ctx, op, persist, changeAccount, udb.InternalBranch, WithGapPolicyIgnore())
+		const accountName = "" // not used, so can be faked.
+		addr, err := w.nextAddress(ctx, op, persist,
+			accountName, changeAccount, udb.InternalBranch, WithGapPolicyIgnore())
 		if err != nil {
 			return errors.E(op, err)
 		}


### PR DESCRIPTION
Address is a generic address type, which may or may not represent an
address or key managed by the wallet.  Unlike dcrutil.Address, this
interface defines the method to produce the script bytes and version,
whereas dcrutil.Address cannot create a script and instead the
txscript package must be used (but this operation does not work for
every possible dcrutil.Address implementation).

KnownAddress is an Address with additional methods providing details
regarding the wallet account associated with the address.  A new
wallet method, also named KnownAddress, replaces the previous AddrInfo
method which returned an udb type.

Three other address interfaces are defined which add to the methods of
the KnownAddress interface.  These are:

* PubKeyHashAddress: a KnownAddress for any P2PKH output script.

* P2SHAddress: a KnownAddress for any P2SH output script. This type
  requires the redeem script to be known.

* BIP0044Address: a KnownAddress for any BIP0044 account address
  (including imported xpub accounts).

All existing wallet methods continue to operate on dcrutil.Address,
but it is expected that these will be cut over to use wallet's defined
Address interface in the future.  Compatibility wrappers will likely
be required for some time to implement the interface for a parsed
dcrutil.Address.

If a dcrd package ever copies the definition of the Address interface,
the wallet's definition can become a type alias to this interface
without breaking any backwards compatibility.

The ideas for address interfaces were originally implemented in commit
958ad8bfb9d3171bdeab838d19534a97e6676341.  The new interfaces simplify
and replace these previous interfaces.  The reduced complexity is
largely due to addresses always knowing how to encode as a transaction
script, rather than needing to define this method on top of an
embedded dcrutil.Address.

In addition to the Address types, the concept of an account kind or
purpose is also introduced.  These are defined by new AccountKind
constants in the wallet package.  Currently, there are three account
kinds (for seed-derived BIP0044 accounts, for the pre-created imported
account, and for imported xpub accounts).  It is planned to introduce
more account kinds as well, e.g. accounts which derive P2SH multisig
addresses using incrementing BIP0044 keys.