### PR TITLE
Fix data race

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -630,11 +630,7 @@ func (w *Wallet) watchHDAddrs(ctx context.Context, firstWatch bool, n NetworkBac
 	if deriveError != nil {
 		return 0, deriveError
 	}
-	select {
-	case err = <-watchError:
-	case <-ctx.Done():
-		err = ctx.Err()
-	}
+	err = <-watchError
 	return count, err
 }
 


### PR DESCRIPTION
In watchHDAddrs, if the context is cancelled before an error is
received on the watchError channel, a goroutine closing over the
returned count may still be running, introducing a data race on the
count variable.  This is fixed by replacing the multi-channel select
operation on both the watchError and the context's Done channel with a
single read of the watchError channel.  This prevents count from being
read while the goroutine closure may still modify the count, and is
context safe since the closure will send any context errors down the
watchError channel.

Fixes #1682.