### PR TITLE
Remove VSP-related config accessors from Wallet

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -271,7 +271,7 @@ func (w *Wallet) evaluateStakePoolTicket(rec *udb.TxRecord, blockHeight int32, p
 		// Calculate the fee required based on the current
 		// height and the required amount from the pool.
 		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
-			tx.TxOut[0].Value), fees, blockHeight, w.PoolFees(),
+			tx.TxOut[0].Value), fees, blockHeight, w.poolFees,
 			w.chainParams)
 		if commitAmt < feeNeeded {
 			log.Warnf("User %s submitted ticket %v which "+

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1202,11 +1202,11 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 	// the same for pool fees, but check sanity too.
 	poolAddress := req.VSPAddress
 	if poolAddress == nil {
-		poolAddress = w.PoolAddress()
+		poolAddress = w.poolAddress
 	}
 	poolFees := req.VSPFees
 	if poolFees == 0.0 {
-		poolFees = w.PoolFees()
+		poolFees = w.poolFees
 	}
 	if poolAddress != nil && poolFees == 0.0 {
 		return nil, errors.E(op, errors.Invalid, "stakepool fee percent unset")

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -86,7 +86,6 @@ type Wallet struct {
 	stakeSettingsLock  sync.Mutex
 	voteBits           stake.VoteBits
 	votingEnabled      bool
-	balanceToMaintain  dcrutil.Amount
 	poolAddress        dcrutil.Address
 	poolFees           float64
 	stakePoolEnabled   bool
@@ -169,22 +168,6 @@ func (w *Wallet) FetchOutput(ctx context.Context, outPoint *wire.OutPoint) (*wir
 	}
 
 	return out, nil
-}
-
-// BalanceToMaintain is used to get the current balancetomaintain for the wallet.
-func (w *Wallet) BalanceToMaintain() dcrutil.Amount {
-	w.stakeSettingsLock.Lock()
-	balance := w.balanceToMaintain
-	w.stakeSettingsLock.Unlock()
-
-	return balance
-}
-
-// SetBalanceToMaintain is used to set the current w.balancetomaintain for the wallet.
-func (w *Wallet) SetBalanceToMaintain(balance dcrutil.Amount) {
-	w.stakeSettingsLock.Lock()
-	w.balanceToMaintain = balance
-	w.stakeSettingsLock.Unlock()
 }
 
 // VotingEnabled returns whether the wallet is configured to vote tickets.
@@ -371,22 +354,6 @@ func (w *Wallet) SetAgendaChoices(ctx context.Context, choices ...AgendaChoice) 
 	w.stakeSettingsLock.Unlock()
 
 	return voteBits, nil
-}
-
-// TicketAddress gets the ticket address for the wallet to give the ticket
-// voting rights to.
-func (w *Wallet) TicketAddress() dcrutil.Address {
-	return w.ticketAddress
-}
-
-// PoolAddress gets the pool address for the wallet to give ticket fees to.
-func (w *Wallet) PoolAddress() dcrutil.Address {
-	return w.poolAddress
-}
-
-// PoolFees gets the per-ticket pool fee for the wallet.
-func (w *Wallet) PoolFees() float64 {
-	return w.poolFees
 }
 
 // RelayFee returns the current minimum relay fee (per kB of serialized


### PR DESCRIPTION
These aren't used and especially in the case of TicketAddress (which
returned a static address) are harmful to privacy.