### PR TITLE
Avoid duplicate JSON-RPC script imports

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -416,7 +416,7 @@ func (s *Server) addMultiSigAddress(ctx context.Context, icmd interface{}) (inte
 	}
 
 	err = w.ImportScript(ctx, script)
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.Exist) {
 		return nil, err
 	}
 
@@ -1355,10 +1355,10 @@ func (s *Server) importScript(ctx context.Context, icmd interface{}) (interface{
 	}
 
 	err = w.ImportScript(ctx, rs)
+	if errors.Is(err, errors.Exist) {
+		return nil, nil
+	}
 	if err != nil {
-		if errors.Is(err, errors.Exist) {
-			return nil, nil
-		}
 		return nil, err
 	}
 

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -601,11 +601,10 @@ func (s *walletServer) ImportScript(ctx context.Context,
 	}
 
 	err = s.wallet.ImportScript(ctx, req.Script)
-	if err != nil {
+	if err != nil && !errors.Is(err, errors.Exist) {
 		return nil, translateError(err)
 	}
-
-	if req.Rescan {
+	if err == nil && req.Rescan {
 		go s.wallet.RescanFromHeight(context.Background(), n, req.ScanFrom)
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3136,9 +3136,6 @@ func (w *Wallet) ImportScript(ctx context.Context, rs []byte) error {
 		addrmgrNs := tx.ReadWriteBucket(waddrmgrNamespaceKey)
 		mscriptaddr, err := w.manager.ImportScript(addrmgrNs, rs)
 		if err != nil {
-			if errors.Is(err, errors.Exist) {
-				return nil
-			}
 			return err
 		}
 


### PR DESCRIPTION
When the P2SH address for the script is already known by the wallet,
skip doing any further imports or rescans in the importscript method.

Fixes #1412.