### PR TITLE
Fix type confusion

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3575,7 +3575,7 @@ func (s *Server) validateAddress(ctx context.Context, icmd interface{}) (interfa
 		result.PubKeyAddr = pubKeyAddr.String()
 	case wallet.P2SHAddress:
 		result.IsScript = true
-		script, _ := ka.RedeemScript()
+		_, script := ka.RedeemScript()
 		result.Hex = hex.EncodeToString(script)
 
 		// This typically shouldn't fail unless an invalid script was

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -205,7 +205,7 @@ func (w *Wallet) KnownAddress(ctx context.Context, a dcrutil.Address) (KnownAddr
 		addr: ma,
 	}
 	var p2pkhKnownAddr managedP2PKHAddress
-	var p2shKnownAddr managedP2PKHAddress
+	var p2shKnownAddr managedP2SHAddress
 	var child uint32
 	switch ma := ma.(type) {
 	case udb.ManagedPubKeyAddress:

--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -105,7 +105,7 @@ type P2SHAddress interface {
 	// version is the script version of the address, or the script version
 	// of the redeemed previous output, and must be used for any operations
 	// involving the script.
-	RedeemScript() (script []byte, version uint16)
+	RedeemScript() (version uint16, script []byte)
 }
 
 // managedAddress implements KnownAddress for a wrapped udb.ManagedAddress.
@@ -172,7 +172,10 @@ func (m *managedBIP0044Address) Path() (account, branch, child uint32) {
 // managedP2SHAddress implements P2SHAddress for a wrapped udb.ManagedAddress.
 type managedP2SHAddress struct {
 	managedAddress
-	redeemScript []byte
+}
+
+func (m *managedP2SHAddress) RedeemScript() (uint16, []byte) {
+	return m.addr.(udb.ManagedScriptAddress).RedeemScript()
 }
 
 // KnownAddress returns the KnownAddress implementation for an address.  The


### PR DESCRIPTION
The wrong implementation for P2SH addresses was being returned by
KnownAddress.  This caused a type conversion panic from
validateaddress after the address was handled like a P2PKH address.

Fixes #1693.