### PR TITLE
Fix getaddressesbyaccount for the imported account

### DIFF
--- a/internal/rpc/jsonrpc/marshaling.go
+++ b/internal/rpc/jsonrpc/marshaling.go
@@ -1,0 +1,42 @@
+package jsonrpc
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"decred.org/dcrwallet/wallet"
+)
+
+type marshalJSONFunc func() ([]byte, error)
+
+func (f marshalJSONFunc) MarshalJSON() ([]byte, error) { return f() }
+
+func addressArrayMarshaler(n int, s func(i int) string) json.Marshaler {
+	return marshalJSONFunc(func() ([]byte, error) {
+		// Make buffer of estimated needed size.  Base58 Hash160
+		// addresses are typically 35 characters long, plus 3 additional
+		// characters per item for string quotes and comma.  Minimum two
+		// characters are needed for the outer [].
+		buf := new(bytes.Buffer)
+		buf.Grow(2 + n*(3+35))
+
+		buf.WriteByte('[')
+		for i := 0; i < n; i++ {
+			if i != 0 {
+				buf.WriteByte(',')
+			}
+			buf.WriteByte('"')
+			buf.WriteString(s(i))
+			buf.WriteByte('"')
+		}
+		buf.WriteByte(']')
+
+		return buf.Bytes(), nil
+	})
+}
+
+func knownAddressMarshaler(addrs []wallet.KnownAddress) json.Marshaler {
+	return addressArrayMarshaler(len(addrs), func(i int) string {
+		return addrs[i].String()
+	})
+}

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -866,6 +866,14 @@ func (s *Server) getAddressesByAccount(ctx context.Context, icmd interface{}) (i
 		return nil, errUnloadedWallet
 	}
 
+	if cmd.Account == "imported" {
+		addrs, err := w.ImportedAddresses(ctx, cmd.Account)
+		if err != nil {
+			return nil, err
+		}
+		return knownAddressMarshaler(addrs), nil
+	}
+
 	account, err := w.AccountNumber(ctx, cmd.Account)
 	if err != nil {
 		if errors.Is(err, errors.NotExist) {


### PR DESCRIPTION
An ImportedAddresses method is added to Wallet which returns
[]KnownAddress for each imported address of an account.  The method
takes an account name, but currently the only valid account name is
"imported".

Some infractructure was added to the jsonrpc package to simplify the
marshaling of address arrays and reduce memory usage.  This can be
reused for other methods later, to avoid the need to allocate []string
objects for JSON serialization.