### PR TITLE
Remove more udb types from public wallet API

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -952,17 +951,10 @@ func (s *Server) getBalance(ctx context.Context, icmd interface{}) (interface{},
 	}
 
 	if accountName == "*" {
-		balanceMap, err := w.CalculateAccountBalances(ctx, int32(*cmd.MinConf))
+		balances, err := w.AccountBalances(ctx, int32(*cmd.MinConf))
 		if err != nil {
 			return nil, err
 		}
-		balances := make([]*udb.Balances, 0, len(balanceMap))
-		for _, bal := range balanceMap {
-			balances = append(balances, bal)
-		}
-		sort.Slice(balances, func(i, j int) bool {
-			return balances[i].Account < balances[j].Account
-		})
 
 		var (
 			totImmatureCoinbase dcrutil.Amount
@@ -1025,7 +1017,7 @@ func (s *Server) getBalance(ctx context.Context, icmd interface{}) (interface{},
 			return nil, err
 		}
 
-		bal, err := w.CalculateAccountBalance(ctx, account, int32(*cmd.MinConf))
+		bal, err := w.AccountBalance(ctx, account, int32(*cmd.MinConf))
 		if err != nil {
 			// Expect account lookup to succeed
 			if errors.Is(err, errors.NotExist) {
@@ -1130,7 +1122,7 @@ func (s *Server) getInfo(ctx context.Context, icmd interface{}) (interface{}, er
 		return nil, err
 	}
 
-	balances, err := w.CalculateAccountBalances(ctx, 1)
+	balances, err := w.AccountBalances(ctx, 1)
 	if err != nil {
 		return nil, err
 	}
@@ -1278,7 +1270,7 @@ func (s *Server) getUnconfirmedBalance(ctx context.Context, icmd interface{}) (i
 		}
 		return nil, err
 	}
-	bals, err := w.CalculateAccountBalance(ctx, account, 1)
+	bals, err := w.AccountBalance(ctx, account, 1)
 	if err != nil {
 		// Expect account lookup to succeed
 		if errors.Is(err, errors.NotExist) {
@@ -2031,7 +2023,7 @@ func (s *Server) listAccounts(ctx context.Context, icmd interface{}) (interface{
 	}
 
 	accountBalances := map[string]float64{}
-	results, err := w.CalculateAccountBalances(ctx, int32(*cmd.MinConf))
+	results, err := w.AccountBalances(ctx, int32(*cmd.MinConf))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -622,7 +622,7 @@ func (s *walletServer) Balance(ctx context.Context, req *pb.BalanceRequest) (
 
 	account := req.AccountNumber
 	reqConfs := req.RequiredConfirmations
-	bals, err := s.wallet.CalculateAccountBalance(ctx, account, reqConfs)
+	bals, err := s.wallet.AccountBalance(ctx, account, reqConfs)
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -230,7 +230,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	tb.mu.Unlock()
 
 	// Determine how many tickets to buy
-	bal, err := w.CalculateAccountBalance(ctx, account, minconf)
+	bal, err := w.AccountBalance(ctx, account, minconf)
 	if err != nil {
 		return err
 	}

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -149,7 +149,7 @@ type accountInfo struct {
 // the account name, number, and the nubmer of derived and imported keys.  If no
 // address usage has been recorded on any of the external or internal branches,
 // the child index is ^uint32(0).
-type AccountProperties struct {
+type AccountProperties = struct {
 	AccountNumber             uint32
 	AccountName               string
 	LastUsedExternalIndex     uint32

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -3575,7 +3575,7 @@ func (s *Store) balanceFullScan(ns, addrmgrNs walletdb.ReadBucket, minConf int32
 }
 
 // Balances is an convenience type.
-type Balances struct {
+type Balances = struct {
 	Account                 uint32
 	ImmatureCoinbaseRewards dcrutil.Amount
 	ImmatureStakeGeneration dcrutil.Amount


### PR DESCRIPTION
This is done by defining types idenical to the old udb.Balances and
udb.AccountProperties in the wallet package, and modifying udb's
definitions to be type aliases of an unnamed struct type.

While here, clean up some method names and change the return on
AccountBalances to a slice instead of a map.  The map served no
purpose and the only caller simply created a sorted slice from the map
values anyways.