### PR TITLE
Added go_package option

### DIFF
--- a/rpc/api.proto
+++ b/rpc/api.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package walletrpc;
 
+option go_package = "decred.org/dcrwallet/rpc/walletrpc";
+
 service VersionService {
 	rpc Version (VersionRequest) returns (VersionResponse);
 }


### PR DESCRIPTION
This option enables consumers of the API to `import` `api.proto` into other protobuf packages.