### PR TITLE
Describe current account gap limit in error message

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1764,7 +1764,8 @@ func (w *Wallet) NextAccount(ctx context.Context, name string) (uint32, error) {
 			}
 		}
 		if !canCreate {
-			return errors.New("last 100 accounts have no transaction history")
+			return errors.Errorf("last %d accounts have no transaction history",
+				maxEmptyAccounts)
 		}
 
 		account, err = w.manager.NewAccount(addrmgrNs, name)


### PR DESCRIPTION
The previous limit used to be 100, but was reduced to 10, however the
error message was never updated for this change.