### PR TITLE
rpc: Fix grpc binding generation

### DIFF
--- a/rpc/Dockerfile
+++ b/rpc/Dockerfile
@@ -1,9 +1,8 @@
-FROM golang:1.12-stretch
+FROM golang:1.14-buster
 
 RUN apt-get update && apt-get install -y protobuf-compiler
-RUN go get -u github.com/golang/protobuf/protoc-gen-go
 
-WORKDIR /build
-CMD "./regen.sh"
+WORKDIR /build/rpc
+CMD ["/bin/bash", "regen.sh"]
 
 

--- a/rpc/regen-docker.sh
+++ b/rpc/regen-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 docker build  -t protobuf-builder  . &&\
-docker run --rm -e UID=$UID -v `pwd`:/build -it protobuf-builder
+docker run --rm -e UID=$UID -v `pwd`/../:/build -it protobuf-builder
 

--- a/rpc/regen.sh
+++ b/rpc/regen.sh
@@ -7,7 +7,7 @@ build-protoc-gen-go() {
 }
 
 generate() {
-    protoc -I. api.proto --go_out=plugins=grpc:walletrpc
+    protoc -I. api.proto --go_out=plugins=grpc:walletrpc --go_opt=paths=source_relative
 
     # fix uid mapping on files created within the container
     [ -n "$UID" ] && chown -R $UID . 2>/dev/null


### PR DESCRIPTION
The addition of the go_package directive in commit 3710c8d8 broke
regenerating the scripts locally.

This fixes the issue by using the source_relative option when generating
bindings.

It also fixes the docker version by updating to the latest golang docker
image and mounting from the root wallet source dir so that module
directives are correctly accounted for inside the image.