### PR TITLE
Pass nil udb.BlockMeta when processing unmined transactions

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -330,7 +330,7 @@ func (w *Wallet) AddTransaction(ctx context.Context, tx *wire.MsgTx, blockHash *
 		}
 
 		var header *wire.BlockHeader
-		var meta udb.BlockMeta
+		var meta *udb.BlockMeta
 		switch {
 		case blockHash != nil:
 			inChain, _ := w.txStore.BlockInMainChain(dbtx, blockHash)
@@ -341,13 +341,14 @@ func (w *Wallet) AddTransaction(ctx context.Context, tx *wire.MsgTx, blockHash *
 			if err != nil {
 				return err
 			}
-			meta, err = w.txStore.GetBlockMetaForHash(txmgrNs, blockHash)
+			meta = new(udb.BlockMeta)
+			*meta, err = w.txStore.GetBlockMetaForHash(txmgrNs, blockHash)
 			if err != nil {
 				return err
 			}
 		}
 
-		watchOutPoints, err = w.processTransactionRecord(ctx, dbtx, rec, header, &meta)
+		watchOutPoints, err = w.processTransactionRecord(ctx, dbtx, rec, header, meta)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
A non-nil pointer to the zero value was being passed previously.  This
was causing unmined transactions to panic the wallet after a block
header was failed to be looked up for the zero hash.

Fixes #1719.