### PR TITLE
Remove request/response types for unimplemented RPCs

### DIFF
--- a/rpc/jsonrpc/types/methods.go
+++ b/rpc/jsonrpc/types/methods.go
@@ -172,16 +172,6 @@ func NewCreateVotingAccountCmd(name, pubKey string, childIndex *uint32) *CreateV
 	return &CreateVotingAccountCmd{name, pubKey, childIndex}
 }
 
-// DropVotingAccountCmd is a type for handling custom marshaling and
-// unmarshalling of dropvotingaccount JSON-RPC command
-type DropVotingAccountCmd struct {
-}
-
-// NewDropVotingAccountCmd creates a new DropVotingAccountCmd.
-func NewDropVotingAccountCmd() *DropVotingAccountCmd {
-	return &DropVotingAccountCmd{}
-}
-
 // DumpPrivKeyCmd defines the dumpprivkey JSON-RPC command.
 type DumpPrivKeyCmd struct {
 	Address string
@@ -299,17 +289,6 @@ func NewGetBalanceCmd(account *string, minConf *int) *GetBalanceCmd {
 	}
 }
 
-// GetContractHashCmd defines the getcontracthash JSON-RPC command.
-type GetContractHashCmd struct {
-	FilePath []string
-}
-
-// NewGetContractHashCmd returns a new instance which can be used to issue a
-// getcontracthash JSON-RPC command.
-func NewGetContractHashCmd(filepaths []string) *GetContractHashCmd {
-	return &GetContractHashCmd{FilePath: filepaths}
-}
-
 // GetMasterPubkeyCmd is a type handling custom marshaling and unmarshaling of
 // getmasterpubkey JSON wallet extension commands.
 type GetMasterPubkeyCmd struct {
@@ -349,19 +328,6 @@ func NewGetNewAddressCmd(account *string, gapPolicy *string) *GetNewAddressCmd {
 	return &GetNewAddressCmd{
 		Account:   account,
 		GapPolicy: gapPolicy,
-	}
-}
-
-// GetPayToContractAddressCmd defines the getpaytocontracthash JSON-RPC command.
-type GetPayToContractAddressCmd struct {
-	FilePath []string
-}
-
-// NewGetPayToContractAddressCmd returns a new instance which can be used to issue a
-// getpaytocontractaddress JSON-RPC command.
-func NewGetPayToContractAddressCmd(filepaths []string) *GetPayToContractAddressCmd {
-	return &GetPayToContractAddressCmd{
-		FilePath: filepaths,
 	}
 }
 
@@ -551,16 +517,6 @@ func NewListAccountsCmd(minConf *int) *ListAccountsCmd {
 	return &ListAccountsCmd{
 		MinConf: minConf,
 	}
-}
-
-// ListTicketsCmd defines the listtickets JSON-RPC command.
-type ListTicketsCmd struct {
-}
-
-// NewListTicketsCmd returns a new instance which can be used to issue a
-// listtickets JSON-RPC command.
-func NewListTicketsCmd() *ListTicketsCmd {
-	return &ListTicketsCmd{}
 }
 
 // ListLockUnspentCmd defines the listlockunspent JSON-RPC command.
@@ -1030,24 +986,6 @@ func NewSweepAccountCmd(sourceAccount string, destinationAddress string, require
 	}
 }
 
-// VerifySeedCmd defines the verifyseed JSON-RPC command.
-type VerifySeedCmd struct {
-	Seed    string
-	Account *uint32
-}
-
-// NewVerifySeedCmd returns a new instance which can be used to issue a
-// walletlock JSON-RPC command.
-//
-// The parameters which are pointers indicate that they are optional. Passing
-// nil for the optional parameters will use the default value.
-func NewVerifySeedCmd(seed string, account *uint32) *VerifySeedCmd {
-	return &VerifySeedCmd{
-		Seed:    seed,
-		Account: account,
-	}
-}
-
 // WalletInfoCmd defines the walletinfo JSON-RPC command.
 type WalletInfoCmd struct {
 }
@@ -1151,7 +1089,6 @@ func init() {
 		{"createnewaccount", (*CreateNewAccountCmd)(nil)},
 		{"createvotingaccount", (*CreateVotingAccountCmd)(nil)},
 		{"discoverusage", (*DiscoverUsageCmd)(nil)},
-		{"dropvotingaccount", (*DropVotingAccountCmd)(nil)},
 		{"dumpprivkey", (*DumpPrivKeyCmd)(nil)},
 		{"fundrawtransaction", (*FundRawTransactionCmd)(nil)},
 		{"generatevote", (*GenerateVoteCmd)(nil)},
@@ -1159,11 +1096,9 @@ func init() {
 		{"getaccountaddress", (*GetAccountAddressCmd)(nil)},
 		{"getaddressesbyaccount", (*GetAddressesByAccountCmd)(nil)},
 		{"getbalance", (*GetBalanceCmd)(nil)},
-		{"getcontracthash", (*GetContractHashCmd)(nil)},
 		{"getmasterpubkey", (*GetMasterPubkeyCmd)(nil)},
 		{"getmultisigoutinfo", (*GetMultisigOutInfoCmd)(nil)},
 		{"getnewaddress", (*GetNewAddressCmd)(nil)},
-		{"getpaytocontractaddress", (*GetPayToContractAddressCmd)(nil)},
 		{"getrawchangeaddress", (*GetRawChangeAddressCmd)(nil)},
 		{"getreceivedbyaccount", (*GetReceivedByAccountCmd)(nil)},
 		{"getreceivedbyaddress", (*GetReceivedByAddressCmd)(nil)},
@@ -1184,7 +1119,6 @@ func init() {
 		{"listreceivedbyaccount", (*ListReceivedByAccountCmd)(nil)},
 		{"listreceivedbyaddress", (*ListReceivedByAddressCmd)(nil)},
 		{"listsinceblock", (*ListSinceBlockCmd)(nil)},
-		{"listtickets", (*ListTicketsCmd)(nil)},
 		{"listtransactions", (*ListTransactionsCmd)(nil)},
 		{"listunspent", (*ListUnspentCmd)(nil)},
 		{"lockunspent", (*LockUnspentCmd)(nil)},
@@ -1206,7 +1140,6 @@ func init() {
 		{"signrawtransaction", (*SignRawTransactionCmd)(nil)},
 		{"signrawtransactions", (*SignRawTransactionsCmd)(nil)},
 		{"sweepaccount", (*SweepAccountCmd)(nil)},
-		{"verifyseed", (*VerifySeedCmd)(nil)},
 		{"validatepredcp0005cf", (*ValidatePreDCP0005CFCmd)(nil)},
 		{"walletinfo", (*WalletInfoCmd)(nil)},
 		{"walletislocked", (*WalletIsLockedCmd)(nil)},

--- a/rpc/jsonrpc/types/methods_test.go
+++ b/rpc/jsonrpc/types/methods_test.go
@@ -1080,35 +1080,6 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
-			name: "verifyseed",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("verifyseed", "abc")
-			},
-			staticCmd: func() interface{} {
-				return NewVerifySeedCmd("abc", nil)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"verifyseed","params":["abc"],"id":1}`,
-			unmarshalled: &VerifySeedCmd{
-				Seed:    "abc",
-				Account: nil,
-			},
-		},
-		{
-			name: "verifyseed optional",
-			newCmd: func() (interface{}, error) {
-				return dcrjson.NewCmd("verifyseed", "abc", 5)
-			},
-			staticCmd: func() interface{} {
-				account := dcrjson.Uint32(5)
-				return NewVerifySeedCmd("abc", account)
-			},
-			marshalled: `{"jsonrpc":"1.0","method":"verifyseed","params":["abc",5],"id":1}`,
-			unmarshalled: &VerifySeedCmd{
-				Seed:    "abc",
-				Account: dcrjson.Uint32(5),
-			},
-		},
-		{
 			name: "walletlock",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd("walletlock")

--- a/rpc/jsonrpc/types/results.go
+++ b/rpc/jsonrpc/types/results.go
@@ -41,11 +41,6 @@ type GetBalanceResult struct {
 	TotalVotingAuthority         float64                   `json:"totalvotingauthority,omitempty"`
 }
 
-// GetContractHashResult models the data from the getcontracthash command.
-type GetContractHashResult struct {
-	ContractHash string `json:"contracthash"`
-}
-
 // GetMultisigOutInfoResult models the data returned from the getmultisigoutinfo
 // command.
 type GetMultisigOutInfoResult struct {
@@ -75,12 +70,6 @@ type CreateMultiSigResult struct {
 type CreateSignatureResult struct {
 	Signature string `json:"signature"`
 	PublicKey string `json:"publickey"`
-}
-
-// GetPayToContractHashResult models the data returned from the getpaytocontracthash
-// command.
-type GetPayToContractHashResult struct {
-	Address string `json:"address"`
 }
 
 // GetStakeInfoResult models the data returned from the getstakeinfo
@@ -190,44 +179,6 @@ type ScriptInfo struct {
 	Hash160      string `json:"hash160"`
 	Address      string `json:"address"`
 	RedeemScript string `json:"redeemscript"`
-}
-
-// ListTicketsTransactionSummaryInput defines the type used in the listtickets JSON-RPC
-// result for the MyInputs field of Ticket and Spender command field.
-type ListTicketsTransactionSummaryInput struct {
-	Index           uint32  `json:"index"`
-	PreviousAccount string  `json:"previousaccount"`
-	PreviousAmount  float64 `json:"previousamount"`
-}
-
-// ListTicketsTransactionSummaryOutput defines the type used in the listtickets JSON-RPC
-// result for the MyOutputs field of Ticket and Spender command field.
-type ListTicketsTransactionSummaryOutput struct {
-	Index        uint32  `json:"index"`
-	Account      string  `json:"account"`
-	Internal     bool    `json:"internal"`
-	Amount       float64 `json:"amount"`
-	Address      string  `json:"address"`
-	OutputScript string  `json:"outputscript"`
-}
-
-// ListTicketsTransactionSummary defines the type used in the listtickets JSON-RPC
-// result for the Ticket and Spender command fields.
-type ListTicketsTransactionSummary struct {
-	Hash        string                                `json:"hash"`
-	Transaction string                                `json:"transaction"`
-	MyInputs    []ListTicketsTransactionSummaryInput  `json:"myinputs"`
-	MyOutputs   []ListTicketsTransactionSummaryOutput `json:"myoutputs"`
-	Fee         float64                               `json:"fee"`
-	Timestamp   int64                                 `json:"timestamp"`
-	Type        string                                `json:"type"`
-}
-
-// ListTicketsResult models the data from the listtickets command.
-type ListTicketsResult struct {
-	Ticket  *ListTicketsTransactionSummary `json:"ticket"`
-	Spender *ListTicketsTransactionSummary `json:"spender"`
-	Status  string                         `json:"status"`
 }
 
 // ListTransactionsTxType defines the type used in the listtransactions JSON-RPC
@@ -395,13 +346,6 @@ type ValidateAddressResult struct {
 
 // ValidateAddressWalletResult aliases ValidateAddressResult.
 type ValidateAddressWalletResult = ValidateAddressResult
-
-// VerifySeedResult models the data returned by the wallet server verify
-// seed command.
-type VerifySeedResult struct {
-	Result   bool   `json:"keyresult"`
-	CoinType uint32 `json:"cointype"`
-}
 
 // WalletInfoResult models the data returned from the walletinfo command.
 type WalletInfoResult struct {


### PR DESCRIPTION
Most of these appear to have been merged into prior versions of
dcrjson, without the associated dcrwallet change ever being
implemented or approved, before the types package was split into the
dcrwallet module.  Because this package globally registers commands
into dcrjson for command listing and help, these types and the init
registration for them should be removed.

After dcrctl is updated with this change, it will no longer present
listings for the unimplemented dcrwallet RPCs.