### PR TITLE
Avoid unmarshaling result when result variable is nil

### DIFF
--- a/rpc/client/dcrwallet/client.go
+++ b/rpc/client/dcrwallet/client.go
@@ -45,6 +45,9 @@ func (r *rawRequester) Call(ctx context.Context, method string, res interface{},
 	if err != nil {
 		return err
 	}
+	if res == nil {
+		return nil
+	}
 	return json.Unmarshal(resp, res)
 }
 


### PR DESCRIPTION
Implementations of Caller are to avoid any unmarshaling of a result
when the result variable passed to the call is nil.  This was not
being performed for the RawRequest wrapper, which caused failing
client calls when results were not needed or discarded.