### PR TITLE
Hex-encode marshaled transactions

### DIFF
--- a/rpc/client/dcrwallet/marshaling.go
+++ b/rpc/client/dcrwallet/marshaling.go
@@ -53,7 +53,7 @@ func marshalAddresses(addrs []dcrutil.Address) json.Marshaler {
 func marshalTx(tx *wire.MsgTx) json.Marshaler {
 	return marshalJSONFunc(func() ([]byte, error) {
 		s := new(strings.Builder)
-		err := tx.Serialize(s)
+		err := tx.Serialize(hex.NewEncoder(s))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The JSON-RPC server expects that transactions be sent as JSON strings
in hex encoding.  The previous client code was not performing the hex
encoding, which would result in various escape codes in the JSON and
errors at the server during hex decoding.