### PR TITLE
Do not clobber RPC passthrough error codes

### DIFF
--- a/internal/rpc/jsonrpc/errors.go
+++ b/internal/rpc/jsonrpc/errors.go
@@ -10,11 +10,18 @@ import (
 
 	"decred.org/dcrwallet/errors"
 	"github.com/decred/dcrd/dcrjson/v3"
+	"github.com/jrick/wsrpc/v2"
 )
 
 func convertError(err error) *dcrjson.RPCError {
-	if err, ok := err.(*dcrjson.RPCError); ok {
+	switch err := err.(type) {
+	case *dcrjson.RPCError:
 		return err
+	case *wsrpc.Error:
+		return &dcrjson.RPCError{
+			Code:    dcrjson.RPCErrorCode(err.Code),
+			Message: err.Message,
+		}
 	}
 
 	code := dcrjson.ErrRPCWallet


### PR DESCRIPTION
When a passthrough RPC is performed, any RPC errors will be of type
*wsrpc.Error.  These describe the JSON-RPC error object, and a
suitable server error can be created from its fields rather than using
a generic error code.