### PR TITLE
Return from CFiltersV2 on error

### DIFF
--- a/rpc/client/dcrd/calls.go
+++ b/rpc/client/dcrd/calls.go
@@ -275,6 +275,7 @@ func (r *RPC) CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) ([]
 			if err != nil {
 				op := errors.Opf(opf, blockHashes[i])
 				err = errors.E(op, err)
+				return err
 			}
 			filters[i] = filterProof{
 				Filter:     res.Filter.Filter,


### PR DESCRIPTION
A return statement was missing in the error handling path, which would
result in a nil pointer dereference in the happy path.