### PR TITLE
Unlock previous outpoints during transaction processing

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -549,6 +549,10 @@ func (w *Wallet) processTransactionRecord(ctx context.Context, dbtx walletdb.Rea
 
 	// Handle input scripts that contain P2PKs that we care about.
 	for i, input := range rec.MsgTx.TxIn {
+		w.lockedOutpointMu.Lock()
+		delete(w.lockedOutpoints, input.PreviousOutPoint)
+		w.lockedOutpointMu.Unlock()
+
 		if txscript.IsMultisigSigScript(input.SignatureScript) {
 			rs := txscript.MultisigRedeemScriptFromScriptSig(input.SignatureScript)
 


### PR DESCRIPTION
When a transaction is processed (whether it is mined or in mempool),
any referenced previous outputs should be unlocked by the wallet.
Transaction creation already unlocked selected outputs when
transactions were created by the same wallet, but transactions seen
from the network were not causing spent locked outpoints to be
removed.

Fixes #1752.