### PR TITLE
Change regen.sh methods name to use underscore instead of dashes

### DIFF
--- a/rpc/regen.sh
+++ b/rpc/regen.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-build-protoc-gen-go() {
+build_protoc_gen_go() {
     mkdir -p bin
     export GOBIN=$PWD/bin
     GO111MODULE=on go install github.com/golang/protobuf/protoc-gen-go
@@ -13,5 +13,5 @@ generate() {
     [ -n "$UID" ] && chown -R $UID . 2>/dev/null
 }
 
-(cd tools && build-protoc-gen-go)
+(cd tools && build_protoc_gen_go)
 PATH=$PWD/tools/bin:$PATH generate


### PR DESCRIPTION
As discussed at matrix, using dashes `-` on the method name will throw an error when using dash, as /bin/sh: 

```
vctt@vctt:~/projects/decred/dcrwallet/rpc$ ./regen.sh 
./regen.sh: 3: ./regen.sh: Syntax error: Bad function name
```

This PR changes it to use underscore `_`, instead. 