### PR TITLE
Limit mixed ticketbuying to one when limit is unset.

### DIFF
--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -252,7 +252,9 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	if max := int(w.ChainParams().MaxFreshStakePerBlock); buy > max {
 		buy = max
 	}
-	if limit > 0 && buy > limit {
+	if limit == 0 && csppServer != "" {
+		buy = 1
+	} else if limit > 0 && buy > limit {
 		buy = limit
 	}
 


### PR DESCRIPTION
Larger limits are still possible but must require manually setting
the larger limit (--ticketbuyer.limit).