### PR TITLE
Fix setting of output tree

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4358,7 +4358,7 @@ func (w *Wallet) appendRelevantOutpoints(relevant []wire.OutPoint, dbtx walletdb
 		switch class {
 		case txscript.StakeSubmissionTy, txscript.StakeSubChangeTy,
 			txscript.StakeGenTy, txscript.StakeRevocationTy:
-			op.Tree = wire.TxTreeStake
+			tree = wire.TxTreeStake
 		}
 
 		for _, a := range addrs {


### PR DESCRIPTION
A tree variable was declared but never changed from the zero value,
causing all stake tree outputs to be overwritten with the regular tree
in the loop below.