### PR TITLE
Remove stake tree distinction from locked outpoint handling

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -2527,15 +2527,14 @@ func (s *Server) lockUnspent(ctx context.Context, icmd interface{}) (interface{}
 		w.ResetLockedOutpoints()
 	default:
 		for _, input := range cmd.Transactions {
-			txSha, err := chainhash.NewHashFromStr(input.Txid)
+			txHash, err := chainhash.NewHashFromStr(input.Txid)
 			if err != nil {
 				return nil, rpcError(dcrjson.ErrRPCDecodeHexString, err)
 			}
-			op := wire.OutPoint{Hash: *txSha, Index: input.Vout}
 			if cmd.Unlock {
-				w.UnlockOutpoint(op)
+				w.UnlockOutpoint(txHash, input.Vout)
 			} else {
-				w.LockOutpoint(op)
+				w.LockOutpoint(txHash, input.Vout)
 			}
 		}
 	}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -550,7 +550,8 @@ func (w *Wallet) processTransactionRecord(ctx context.Context, dbtx walletdb.Rea
 	// Handle input scripts that contain P2PKs that we care about.
 	for i, input := range rec.MsgTx.TxIn {
 		if !skipOutpoints {
-			delete(w.lockedOutpoints, input.PreviousOutPoint)
+			prev := input.PreviousOutPoint
+			delete(w.lockedOutpoints, outpoint{prev.Hash, prev.Index})
 		}
 
 		if txscript.IsMultisigSigScript(input.SignatureScript) {

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -73,7 +73,7 @@ func (w *Wallet) MixOutput(ctx context.Context, dialTLS DialFunc, csppserver str
 	defer hold.release()
 
 	w.lockedOutpointMu.Lock()
-	if _, exists := w.lockedOutpoints[*output]; exists {
+	if _, exists := w.lockedOutpoints[outpoint{output.Hash, output.Index}]; exists {
 		w.lockedOutpointMu.Unlock()
 		err = errors.Errorf("output %v already locked", output)
 		return errors.E(op, err)
@@ -95,12 +95,12 @@ func (w *Wallet) MixOutput(ctx context.Context, dialTLS DialFunc, csppserver str
 		w.lockedOutpointMu.Unlock()
 		return errors.E(op, err)
 	}
-	w.lockedOutpoints[*output] = struct{}{}
+	w.lockedOutpoints[outpoint{output.Hash, output.Index}] = struct{}{}
 	w.lockedOutpointMu.Unlock()
 
 	defer func() {
 		w.lockedOutpointMu.Lock()
-		delete(w.lockedOutpoints, *output)
+		delete(w.lockedOutpoints, outpoint{output.Hash, output.Index})
 		w.lockedOutpointMu.Unlock()
 	}()
 


### PR DESCRIPTION
Outputs should be locked or unlocked even when the tree is not
necessarily known (tx hash collisions can be disconsidered) and this
solves a bug with listunspent reporting stake outputs even when they
were locked over RPC (where the tree is, again, unknown).