### PR TITLE
Upgrade database account format

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -780,7 +780,7 @@ func minUint32(a, b uint32) uint32 {
 func (w *Wallet) markUsedAddress(op errors.Op, dbtx walletdb.ReadWriteTx, addr udb.ManagedAddress) error {
 	ns := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
 	account := addr.Account()
-	err := w.manager.MarkUsed(ns, addr.Address())
+	err := w.manager.MarkUsed(dbtx, addr.Address())
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -273,25 +273,29 @@ func verifyV5Upgrade(t *testing.T, db walletdb.DB) {
 		const dbVersion = 5
 
 		for _, d := range data {
-			row, err := fetchAccountInfo(ns, d.acct, dbVersion)
+			acct, err := fetchDBAccount(ns, d.acct, dbVersion)
 			if err != nil {
 				return err
 			}
-			if row.lastUsedExternalIndex != d.lastUsedExtChild {
+			a, ok := acct.(*dbBIP0044Account)
+			if !ok {
+				return fmt.Errorf("unknown account type %T", acct)
+			}
+			if a.lastUsedExternalIndex != d.lastUsedExtChild {
 				t.Errorf("Account %d last used ext child mismatch %d != %d",
-					d.acct, row.lastUsedExternalIndex, d.lastUsedExtChild)
+					d.acct, a.lastUsedExternalIndex, d.lastUsedExtChild)
 			}
-			if row.lastReturnedExternalIndex != d.lastUsedExtChild {
+			if a.lastReturnedExternalIndex != d.lastUsedExtChild {
 				t.Errorf("Account %d last returned ext child mismatch %d != %d",
-					d.acct, row.lastReturnedExternalIndex, d.lastUsedExtChild)
+					d.acct, a.lastReturnedExternalIndex, d.lastUsedExtChild)
 			}
-			if row.lastUsedInternalIndex != d.lastUsedIntChild {
+			if a.lastUsedInternalIndex != d.lastUsedIntChild {
 				t.Errorf("Account %d last used int child mismatch %d != %d",
-					d.acct, row.lastUsedInternalIndex, d.lastUsedIntChild)
+					d.acct, a.lastUsedInternalIndex, d.lastUsedIntChild)
 			}
-			if row.lastReturnedInternalIndex != d.lastUsedIntChild {
+			if a.lastReturnedInternalIndex != d.lastUsedIntChild {
 				t.Errorf("Account %d last returned int child mismatch %d != %d",
-					d.acct, row.lastReturnedInternalIndex, d.lastUsedIntChild)
+					d.acct, a.lastReturnedInternalIndex, d.lastUsedIntChild)
 			}
 		}
 


### PR DESCRIPTION
Note to reviewers: this contains a database upgrade. Back up your DB before testing.

___

A database upgrade is introduced which rewrites all BIP0044 accounts into a new serialization format.  The account "row" is modified to only contain the information that never changes (such as the account's extended pubkey and privkeys) and a "variables" buckets are created for each individual account to record, in separate key/value pairs, account fields that do change over time (such as the account name and last used/returned child indexes).  This allows faster access to read and modify the particular field(s) in question, rather than requiring all account metadata to be read or written back to the db when only a small amount of data must be changed.

Upcoming PRs will take advantage of the account variables buckets to record additional properties of accounts in a way that retains compatibility with existing account management.