### PR TITLE
Add VSP ticket and fee txs into wallet db 

### DIFF
--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
+	"time"
 
 	"decred.org/dcrwallet/wallet"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -280,6 +282,10 @@ func (v *VSP) Sync(ctx context.Context) {
 func (v *VSP) Process(ctx context.Context, ticketHash chainhash.Hash, credits []wallet.Input) (*wire.MsgTx, error) {
 	feeAmount, err := v.GetFeeAddress(ctx, ticketHash)
 	if err != nil {
+		if strings.Contains(err.Error(), "ticket transaction could not be broadcast") {
+			time.Sleep(2 * time.Minute)
+			v.Queue(ctx, ticketHash, nil)
+		}
 		return nil, err
 	}
 

--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -214,9 +214,11 @@ func New(hostname, pubKeyStr string, purchaseAccount, changeAccount uint32, dial
 				feeTx, err := v.Process(ctx, queuedItem.TicketHash, nil)
 				if err != nil {
 					log.Warnf("Failed to process queued ticket %v, err: %v", queuedItem.TicketHash, err)
-					for _, input := range queuedItem.FeeTx.TxIn {
-						outpoint := input.PreviousOutPoint
-						go func() { w.UnlockOutpoint(&outpoint.Hash, outpoint.Index) }()
+					if queuedItem.FeeTx != nil {
+						for _, input := range queuedItem.FeeTx.TxIn {
+							outpoint := input.PreviousOutPoint
+							go func() { w.UnlockOutpoint(&outpoint.Hash, outpoint.Index) }()
+						}
 					}
 					continue
 				}

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -169,7 +169,10 @@ const (
 	// top-level bucket for recording voting policy on treasury-spending
 	// transactions.
 	tspendPolicyVersion = 19
-	//
+
+	// vspBucketVersion is the 20th version of the database. It adds a
+	// a top-level bucket for recording vsp ticket hashes as key and its
+	// related fee txs hash.
 	vspBucketVersion = 20
 
 	// DBVersion is the latest version of the database that is understood by the
@@ -1432,14 +1435,14 @@ func tspendPolicyUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, param
 	return unifiedDBMetadata{}.putVersion(metadataBucket, newVersion)
 }
 
-// vspBucketUpgrade updates the wallet db from version 17 to 18. It creates
-// a new vspBucket and two subbuckets.
+// vspBucketUpgrade updates the wallet db from version 19 to 20. It creates
+// a new top level vspBucket.
 func vspBucketUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, params *chaincfg.Params) error {
 	const oldVersion = 19
 	const newVersion = 20
 
 	metadataBucket := tx.ReadWriteBucket(unifiedDBMetadata{}.rootBucketKey())
-	// Assert that this function is only called on version 18 databases.
+	// Assert that this function is only called on version 19 databases.
 	dbVersion, err := unifiedDBMetadata{}.getVersion(metadataBucket)
 	if err != nil {
 		return err

--- a/wallet/udb/upgrades.go
+++ b/wallet/udb/upgrades.go
@@ -169,11 +169,13 @@ const (
 	// top-level bucket for recording voting policy on treasury-spending
 	// transactions.
 	tspendPolicyVersion = 19
+	//
+	vspBucketVersion = 20
 
 	// DBVersion is the latest version of the database that is understood by the
 	// program.  Databases with recorded versions higher than this will fail to
 	// open (meaning any upgrades prevent reverting to older software).
-	DBVersion = tspendPolicyVersion
+	DBVersion = vspBucketVersion
 )
 
 // upgrades maps between old database versions and the upgrade function to
@@ -198,6 +200,7 @@ var upgrades = [...]func(walletdb.ReadWriteTx, []byte, *chaincfg.Params) error{
 	accountVariablesVersion - 1:           accountVariablesUpgrade,
 	unpublishedTxsVersion - 1:             unpublishedTxsUpgrade,
 	tspendPolicyVersion - 1:               tspendPolicyUpgrade,
+	vspBucketVersion - 1:                  vspBucketUpgrade,
 }
 
 func lastUsedAddressIndexUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, params *chaincfg.Params) error {
@@ -1423,6 +1426,32 @@ func tspendPolicyUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, param
 	_, err = tx.CreateTopLevelBucket(treasuryPolicyBucketKey)
 	if err != nil {
 		return errors.E(errors.IO, err)
+	}
+
+	// Write the new database version.
+	return unifiedDBMetadata{}.putVersion(metadataBucket, newVersion)
+}
+
+// vspBucketUpgrade updates the wallet db from version 17 to 18. It creates
+// a new vspBucket and two subbuckets.
+func vspBucketUpgrade(tx walletdb.ReadWriteTx, publicPassphrase []byte, params *chaincfg.Params) error {
+	const oldVersion = 19
+	const newVersion = 20
+
+	metadataBucket := tx.ReadWriteBucket(unifiedDBMetadata{}.rootBucketKey())
+	// Assert that this function is only called on version 18 databases.
+	dbVersion, err := unifiedDBMetadata{}.getVersion(metadataBucket)
+	if err != nil {
+		return err
+	}
+	if dbVersion != oldVersion {
+		return errors.E(errors.Invalid, "vspBucketUpgrade inappropriately called")
+	}
+
+	// Create the vsp tickets bucket.
+	_, err = tx.CreateTopLevelBucket(vspBucketKey)
+	if err != nil {
+		return err
 	}
 
 	// Write the new database version.

--- a/wallet/udb/vsp.go
+++ b/wallet/udb/vsp.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package udb
+
+import (
+	"decred.org/dcrwallet/wallet/walletdb"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+)
+
+var (
+	vspBucketKey = []byte("vsp")
+)
+
+type VSPTicket struct {
+	FeeHash chainhash.Hash
+	// TODO add vote preferences?
+	// VotingPreference map[string]string
+}
+
+// SetVSPTicket sets a VSPTicket record into the db.
+func SetVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash *chainhash.Hash, record *VSPTicket) error {
+	bucket := dbtx.ReadWriteBucket(vspBucketKey)
+	serializedRecord := serializeVSPTicket(record)
+
+	// Save the creation date of the store.
+	return bucket.Put(ticketHash.CloneBytes(), serializedRecord)
+}
+
+// VSPTickets gets all vsp tickets from the db.
+func VSPTickets(dbtx walletdb.ReadTx) ([]*VSPTicket, error) {
+	bucket := dbtx.ReadBucket(vspBucketKey)
+	var tickets []*VSPTicket
+	err := bucket.ForEach(func(k, v []byte) error {
+		if len(v) == 0 {
+			return nil
+		}
+		ticket := deserializeVSPTicket(v)
+		tickets = append(tickets, ticket)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return tickets, nil
+}
+
+// GetVSPTicket gets a specific ticket by its hash.
+func GetVSPTicket(dbtx walletdb.ReadTx, tickethash chainhash.Hash) (*VSPTicket, error) {
+	bucket := dbtx.ReadBucket(vspBucketKey)
+	serializedTicket := bucket.Get(tickethash.CloneBytes())
+	ticket := deserializeVSPTicket(serializedTicket)
+
+	return ticket, nil
+}
+
+// deserializeUserTicket deserializes the passed serialized user
+// ticket information.
+func deserializeVSPTicket(serializedTicket []byte) *VSPTicket {
+	// Cursory check to make sure that the size of the
+	// ticket makes sense.
+	// if len(serializedTicket)%stakePoolUserTicketSize != 0 {
+	// 	return nil, errors.E(errors.IO, "invalid pool ticket record size")
+	// }
+
+	curPos := 0
+
+	var feeHash chainhash.Hash
+
+	// Insert the ticket hash into the record.
+	feeHash.SetBytes(serializedTicket[curPos : curPos+hashSize])
+
+	vspTicket := &VSPTicket{
+		FeeHash: feeHash,
+	}
+	return vspTicket
+}
+
+// serializeUserTicket returns the serialization of a single stake pool
+// user ticket.
+func serializeVSPTicket(record *VSPTicket) []byte {
+	buf := make([]byte, hashSize)
+	curPos := 0
+
+	// Write the fee hash.
+	copy(buf[curPos:curPos+hashSize], record.FeeHash[:])
+
+	return buf
+}


### PR DESCRIPTION
**contains db upgrade -- backup db before testing**

This PR depends on  #1840

~~This PR stills a wip.~~

~~Right now it is not possible to know the status of a registered vspd ticket. This PR updates the wallet db so we can know if a ticket fee is paid, and its txid.~~

This PR fixes the double spend bug, which a ticket fee tx would be double spend with the ticket auto buyer.

## Diff Description

 - I Created a new vspBucket and two subbuckets `pendingFeeKey`, `VotingPreferencesKey` (right now still not using the voting preference bucket, but the idea is saving ticket's voting preference.
  - vsp tickets are being saved on the vspBucket keyed by timestamps.
  - vsp tickets fee are being saved on the pendingFeeKey bucket, keyed by ticket's hash
  - changed how vsp ticket fee processments are being done
    - added `VSPServerProcess` into wallet's `PurchaseTicketsRequest`
    - Setting unpublished tickets fees into the db, on purchasing ticket, as well.
  - adding `vsp_pubkey` and `vsp_host` into the grpc `PurchaseTicketsRequest`
  - separating fee creation from fee payment
  - moved many "https://" strings to use var `protocol` instead
  - added a wallet method  `GetUnpublishedFeesTxs` (TODO - still need to call this method on wallet start and publish unpublished fees)  
