### PR TITLE
vsp: base64 decode server signature

### DIFF
--- a/vsp/feeaddress.go
+++ b/vsp/feeaddress.go
@@ -102,7 +102,7 @@ func (v *VSP) GetFeeAddress(ctx context.Context, ticketHash *chainhash.Hash) (dc
 		log.Warnf("feeaddress missing server signature")
 		return 0, fmt.Errorf("server signature missing from feeaddress response")
 	}
-	serverSig, err := hex.DecodeString(serverSigStr)
+	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
 	if err != nil {
 		log.Warnf("failed to decode server signature: %v", err)
 		return 0, err

--- a/vsp/payfee.go
+++ b/vsp/payfee.go
@@ -208,7 +208,7 @@ func (v *VSP) PayFee(ctx context.Context, ticketHash *chainhash.Hash, credits []
 		log.Warnf("pay fee response missing server signature")
 		return nil, err
 	}
-	serverSig, err := hex.DecodeString(serverSigStr)
+	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
 	if err != nil {
 		log.Warnf("failed to decode server signature: %v", err)
 		return nil, err

--- a/vsp/poolfee.go
+++ b/vsp/poolfee.go
@@ -3,7 +3,7 @@ package vsp
 import (
 	"context"
 	"crypto/ed25519"
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -40,7 +40,7 @@ func (v *VSP) PoolFee(ctx context.Context) (float64, error) {
 		log.Warnf("vspinfo response missing server signature")
 		return -1, err
 	}
-	serverSig, err := hex.DecodeString(serverSigStr)
+	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
 	if err != nil {
 		log.Warnf("failed to decode server signature: %v", err)
 		return -1, err

--- a/vsp/ticketstatus.go
+++ b/vsp/ticketstatus.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -68,7 +67,7 @@ func (v *VSP) TicketStatus(ctx context.Context, hash *chainhash.Hash) (*TicketSt
 		log.Warnf("ticket status response missing server signature")
 		return nil, fmt.Errorf("ticket status response missing server signature")
 	}
-	serverSig, err := hex.DecodeString(serverSigStr)
+	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
 	if err != nil {
 		log.Warnf("failed to decode server signature: %v", err)
 		return nil, err


### PR DESCRIPTION
vspd was accepting `VSP-Client-Signature` base64 encoded, but then returning `VSP-Server-Signature` hex encoded.

This was changed in decred/vspd#179 so both are using base64 encoding. 