### PR TITLE
Add config flag to never add tickets from network syncers

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -18,6 +18,7 @@ import (
 	"decred.org/dcrwallet/rpc/client/dcrd"
 	"decred.org/dcrwallet/validate"
 	"decred.org/dcrwallet/wallet"
+	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/wire"
 	"github.com/jrick/wsrpc/v2"
@@ -658,6 +659,9 @@ func (s *Syncer) relevantTxAccepted(ctx context.Context, params json.RawMessage)
 	tx, err := dcrd.RelevantTxAccepted(params)
 	if err != nil {
 		return err
+	}
+	if s.wallet.ManualTickets() && stake.IsSStx(tx) {
+		return nil
 	}
 	return s.wallet.AddTransaction(ctx, tx, nil)
 }

--- a/config.go
+++ b/config.go
@@ -97,6 +97,7 @@ type config struct {
 	PoolFees                float64             `long:"poolfees" description:"VSP fee percentage (1.00 equals 1.00% fee)"`
 	GapLimit                uint32              `long:"gaplimit" description:"Allowed unused address gap between used addresses of accounts"`
 	StakePoolColdExtKey     string              `long:"stakepoolcoldextkey" description:"xpub:maxindex for fee addresses (VSP-only option)"`
+	ManualTickets           bool                `long:"manualtickets" description:"Do not discover new tickets through network synchronization"`
 	AllowHighFees           bool                `long:"allowhighfees" description:"Do not perform high fee checks"`
 	RelayFee                *cfgutil.AmountFlag `long:"txfee" description:"Transaction fee per kilobyte"`
 	AccountGapLimit         int                 `long:"accountgaplimit" description:"Allowed gap of unused accounts"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -162,7 +162,7 @@ func run(ctx context.Context) error {
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
-		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades)
+		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -42,6 +42,7 @@ type Loader struct {
 	accountGapLimit         int
 	disableCoinTypeUpgrades bool
 	allowHighFees           bool
+	manualTickets           bool
 	relayFee                dcrutil.Amount
 
 	mu sync.Mutex
@@ -59,7 +60,7 @@ type StakeOptions struct {
 
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit uint32,
-	allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int, disableCoinTypeUpgrades bool) *Loader {
+	allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int, disableCoinTypeUpgrades bool, manualTickets bool) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
@@ -69,6 +70,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *Sta
 		accountGapLimit:         accountGapLimit,
 		disableCoinTypeUpgrades: disableCoinTypeUpgrades,
 		allowHighFees:           allowHighFees,
+		manualTickets:           manualTickets,
 		relayFee:                relayFee,
 	}
 }
@@ -176,6 +178,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
 		StakePoolColdExtKey:     so.StakePoolColdExtKey,
+		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -19,6 +19,7 @@ import (
 	"decred.org/dcrwallet/validate"
 	"decred.org/dcrwallet/wallet"
 	"github.com/decred/dcrd/addrmgr"
+	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/gcs/v2/blockcf2"
 	"github.com/decred/dcrd/wire"
@@ -749,6 +750,9 @@ func (s *Syncer) handleTxInvs(ctx context.Context, rp *p2p.RemotePeer, hashes []
 	// Save any relevant transaction.
 	relevant := s.filterRelevant(txs)
 	for _, tx := range relevant {
+		if s.wallet.ManualTickets() && stake.IsSStx(tx) {
+			continue
+		}
 		err := s.wallet.AddTransaction(ctx, tx, nil)
 		if err != nil {
 			op := errors.Opf(opf, rp.RemoteAddr())

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -98,6 +98,7 @@ type Wallet struct {
 	votingEnabled      bool
 	poolAddress        dcrutil.Address
 	poolFees           float64
+	manualTickets      bool
 	stakePoolEnabled   bool
 	stakePoolColdAddrs map[string]struct{}
 	subsidyCache       *blockchain.SubsidyCache
@@ -152,6 +153,7 @@ type Config struct {
 	DisableCoinTypeUpgrades bool
 
 	StakePoolColdExtKey string
+	ManualTickets       bool
 	AllowHighFees       bool
 	RelayFee            dcrutil.Amount
 	Params              *chaincfg.Params
@@ -4772,6 +4774,14 @@ func decodeStakePoolColdExtKey(encStr string, params *chaincfg.Params) (map[stri
 // GapLimit returns the currently used gap limit.
 func (w *Wallet) GapLimit() uint32 {
 	return w.gapLimit
+}
+
+// ManualTickets returns whether network syncers should avoid adding ticket
+// transactions to the wallet, instead requiring the wallet administrator to
+// manually record any tickets.  This can be used to prevent wallets from voting
+// using tickets bought by others but which reuse our voting address.
+func (w *Wallet) ManualTickets() bool {
+	return w.manualTickets
 }
 
 // Open loads an already-created wallet from the passed database and namespaces

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -54,7 +54,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
 		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
-		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades)
+		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
With this mode enabled, any ticket added to the wallet must be done so
manually over RPC using the addtransaction method.  This allows wallet
owners to selectively add tickets to their wallets and prevent other
ticket buyers from reusing a voting address to get free votes.