### PR TITLE
Fill stakebase script during vote creation, not signing

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1772,9 +1772,6 @@ func (w *Wallet) signVoteOrRevocation(addrmgrNs walletdb.ReadBucket, ticketPurch
 	if err != nil {
 		return errors.E(errors.Op("txscript.SignTxOutput"), errors.ScriptFailure, err)
 	}
-	if isVote {
-		tx.TxIn[0].SignatureScript = w.chainParams.StakeBaseSigScript
-	}
 	tx.TxIn[inputToSign].SignatureScript = signedScript
 
 	return nil
@@ -1827,7 +1824,8 @@ func createUnsignedVote(ticketHash *chainhash.Hash, ticketPurchase *wire.MsgTx,
 	// Add stakebase input to the vote.
 	stakebaseOutPoint := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0),
 		wire.TxTreeRegular)
-	stakebaseInput := wire.NewTxIn(stakebaseOutPoint, subsidy, nil)
+	stakebaseInput := wire.NewTxIn(stakebaseOutPoint, subsidy,
+		params.StakeBaseSigScript)
 	vote.AddTxIn(stakebaseInput)
 
 	// Votes reference the ticket purchase with the second input.

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4178,13 +4178,10 @@ func (w *Wallet) SignTransaction(ctx context.Context, tx *wire.MsgTx, hashType t
 
 		for i, txIn := range tx.TxIn {
 			// For an SSGen tx, skip the first input as it is a stake base
-			// and doesn't need to be signed.
-			if i == 0 {
-				if stake.IsSSGen(tx) {
-					// Put some garbage in the signature script.
-					txIn.SignatureScript = []byte{0xDE, 0xAD, 0xBE, 0xEF}
-					continue
-				}
+			// and doesn't need to be signed.  The transaction is expected
+			// to already contain the consensus-validated stakebase script.
+			if i == 0 && stake.IsSSGen(tx) {
+				continue
 			}
 
 			prevOutScript, ok := additionalPrevScripts[txIn.PreviousOutPoint]


### PR DESCRIPTION
Vote transactions passed to Wallet.SignTransaction (which is never
done except possibly through an RPC request) are expected to contain
the correct stakebase input script as demanded by consensus for that
network.