### PR TITLE
Allow unpublished transactions to be saved to DB

### DIFF
--- a/wallet/difficulty.go
+++ b/wallet/difficulty.go
@@ -450,8 +450,7 @@ func (w *Wallet) NextStakeDifficulty(ctx context.Context) (dcrutil.Amount, error
 	const op errors.Op = "wallet.NextStakeDifficulty"
 	var sdiff dcrutil.Amount
 	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
-		ns := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		tipHash, tipHeight := w.txStore.MainChainTip(ns)
+		tipHash, tipHeight := w.txStore.MainChainTip(dbtx)
 		if !deployments.DCP0001.Active(tipHeight, w.chainParams.Net) {
 			return errors.E(errors.Deployment, "DCP0001 is not known to be active")
 		}

--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -179,12 +179,11 @@ func (a *addrFinder) find(ctx context.Context, start *chainhash.Hash, p Peer) er
 	// Load main chain cfilters beginning with start.
 	var fs []*udb.BlockCFilter
 	err := walletdb.View(ctx, a.w.db, func(dbtx walletdb.ReadTx) error {
-		ns := dbtx.ReadBucket(wtxmgrNamespaceKey)
 		h, err := a.w.txStore.GetBlockHeader(dbtx, start)
 		if err != nil {
 			return err
 		}
-		_, tipHeight := a.w.txStore.MainChainTip(ns)
+		_, tipHeight := a.w.txStore.MainChainTip(dbtx)
 		storage := make([]*udb.BlockCFilter, tipHeight-int32(h.Height))
 		fs, err = a.w.txStore.GetMainChainCFilters(dbtx, start, true, storage)
 		return err

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -179,7 +179,7 @@ func makeTxSummary(dbtx walletdb.ReadTx, w *Wallet, details *udb.TxDetails) Tran
 
 func totalBalances(dbtx walletdb.ReadTx, w *Wallet, m map[uint32]dcrutil.Amount) error {
 	addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
-	unspent, err := w.txStore.UnspentOutputs(dbtx.ReadBucket(wtxmgrNamespaceKey))
+	unspent, err := w.txStore.UnspentOutputs(dbtx)
 	if err != nil {
 		return err
 	}
@@ -824,7 +824,7 @@ func (c *ConfirmationNotificationsClient) Watch(txHashes []*chainhash.Hash, stop
 	r := make([]ConfirmationNotification, 0, len(c.watched))
 	err := walletdb.View(c.ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		_, tipHeight := w.txStore.MainChainTip(txmgrNs)
+		_, tipHeight := w.txStore.MainChainTip(dbtx)
 		// cannot range here, txHashes may be modified
 		for i := 0; i < len(txHashes); {
 			h := txHashes[i]

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -389,7 +389,7 @@ func (w *Wallet) rescanPoint(dbtx walletdb.ReadTx) (*chainhash.Hash, error) {
 	if err != nil {
 		return nil, err
 	}
-	if tipHash, _ := w.txStore.MainChainTip(ns); *r == tipHash {
+	if tipHash, _ := w.txStore.MainChainTip(dbtx); *r == tipHash {
 		return nil, nil
 	}
 	// r is not the tip, so a child block must exist in the main chain.

--- a/wallet/sidechains.go
+++ b/wallet/sidechains.go
@@ -248,8 +248,7 @@ func (w *Wallet) EvaluateBestChain(ctx context.Context, f *SidechainForest) ([]*
 	const op errors.Op = "wallet.EvaluateBestChain"
 	var newBestChain []*BlockNode
 	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
-		ns := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		tipHash, _ := w.txStore.MainChainTip(ns)
+		tipHash, _ := w.txStore.MainChainTip(dbtx)
 		tipHeader, err := w.txStore.GetBlockHeader(dbtx, &tipHash)
 		if err != nil {
 			return err

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -78,7 +78,7 @@ func (w *Wallet) LiveTicketHashes(ctx context.Context, rpcCaller Caller, include
 			}
 		}
 
-		_, tipHeight = w.txStore.MainChainTip(txmgrNs)
+		_, tipHeight = w.txStore.MainChainTip(dbtx)
 
 		it := w.txStore.IterateTickets(dbtx)
 		defer it.Close()
@@ -226,11 +226,10 @@ func (w *Wallet) RevokeTickets(ctx context.Context, rpcCaller Caller) error {
 	const op errors.Op = "wallet.RevokeTickets"
 
 	var ticketHashes []chainhash.Hash
-	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
-		ns := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		var err error
-		_, tipHeight := w.txStore.MainChainTip(ns)
-		ticketHashes, err = w.txStore.UnspentTickets(tx, tipHeight, false)
+		_, tipHeight := w.txStore.MainChainTip(dbtx)
+		ticketHashes, err = w.txStore.UnspentTickets(dbtx, tipHeight, false)
 		return err
 	})
 	if err != nil {
@@ -337,8 +336,7 @@ func (w *Wallet) RevokeExpiredTickets(ctx context.Context, p Peer) (err error) {
 
 	var expired []chainhash.Hash
 	err = walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
-		ns := dbtx.ReadBucket(wtxmgrNamespaceKey)
-		_, tipHeight := w.txStore.MainChainTip(ns)
+		_, tipHeight := w.txStore.MainChainTip(dbtx)
 
 		it := w.txStore.IterateTickets(dbtx)
 		defer it.Close()

--- a/wallet/udb/tx_test.go
+++ b/wallet/udb/tx_test.go
@@ -305,12 +305,11 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 					test.name, err)
 			}
 			for _, tx := range unmined {
-				txHash := tx.TxHash()
-				if _, ok := test.unmined[txHash]; !ok {
+				if _, ok := test.unmined[tx.Hash]; !ok {
 					t.Fatalf("%s: unexpected unmined tx: %v",
-						test.name, txHash)
+						test.name, tx.Hash)
 				}
-				delete(test.unmined, txHash)
+				delete(test.unmined, tx.Hash)
 			}
 			if len(test.unmined) != 0 {
 				t.Fatalf("%s: missing expected unmined tx(s)", test.name)

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -90,6 +90,7 @@ type TxRecord struct {
 	Received     time.Time
 	SerializedTx []byte // Optional: may be nil
 	TxType       stake.TxType
+	Unpublished  bool
 }
 
 // NewTxRecord creates a new transaction record that may be inserted into the

--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -441,7 +441,6 @@ func verifyV12Upgrade(t *testing.T, db walletdb.DB) {
 
 	err = walletdb.View(ctx, db, func(tx walletdb.ReadTx) error {
 		txmgrns := tx.ReadBucket(wtxmgrBucketKey)
-		amgrns := tx.ReadBucket(waddrmgrBucketKey)
 
 		if b := txmgrns.NestedReadBucket(bucketTicketCommitments); b == nil {
 			t.Fatalf("upgrade should have created bucketTicketCommitments")
@@ -451,7 +450,7 @@ func verifyV12Upgrade(t *testing.T, db walletdb.DB) {
 			t.Fatalf("upgrade should have created bucketTicketCommitmentsUsp")
 		}
 
-		balances, err := txmgr.AccountBalances(txmgrns, amgrns, 0)
+		balances, err := txmgr.AccountBalances(tx, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/wallet/utxos.go
+++ b/wallet/utxos.go
@@ -38,15 +38,14 @@ func (w *Wallet) UnspentOutputs(ctx context.Context, policy OutputSelectionPolic
 	w.lockedOutpointMu.Lock()
 
 	var outputResults []*TransactionOutput
-	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
+		addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
 
-		_, tipHeight := w.txStore.MainChainTip(txmgrNs)
+		_, tipHeight := w.txStore.MainChainTip(dbtx)
 
 		// TODO: actually stream outputs from the db instead of fetching
 		// all of them at once.
-		outputs, err := w.txStore.UnspentOutputs(txmgrNs)
+		outputs, err := w.txStore.UnspentOutputs(dbtx)
 		if err != nil {
 			return err
 		}
@@ -116,10 +115,10 @@ func (w *Wallet) SelectInputs(ctx context.Context, targetAmount dcrutil.Amount, 
 	defer w.lockedOutpointMu.Unlock()
 	w.lockedOutpointMu.Lock()
 
-	err = walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
-		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)
-		txmgrNs := tx.ReadBucket(wtxmgrNamespaceKey)
-		_, tipHeight := w.txStore.MainChainTip(txmgrNs)
+	err = walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
+		addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
+		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+		_, tipHeight := w.txStore.MainChainTip(dbtx)
 
 		if policy.Account != udb.ImportedAddrAccount {
 			lastAcct, err := w.manager.LastAccount(addrmgrNs)


### PR DESCRIPTION
Note to reviewers: this contains a database upgrade. Back up your DB before testing.

---

Unpublished transactions are unmined transactions which are
specifically recorded as unpublished to the network.  These
transactions are not rebroadcast on startup.  It is necessary to save
unpublished transactions to prevent some previous wallet outputs from
being double spent across application restarts, or to persist
partially signed transactions.

This commit adds the database handling for recording unpublished
transactions but does not yet record any transactions in this state.
This will be used by vspd clients in the future to record unpublished
fee and ticket purchase transactions.