### PR TITLE
Apply ManualTickets config for all wallets.

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -329,6 +329,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
 		StakePoolColdExtKey:     so.StakePoolColdExtKey,
+		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4960,6 +4960,7 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 		allowHighFees:           cfg.AllowHighFees,
 		accountGapLimit:         cfg.AccountGapLimit,
 		disableCoinTypeUpgrades: cfg.DisableCoinTypeUpgrades,
+		manualTickets:           cfg.ManualTickets,
 
 		// Chain params
 		subsidyCache: blockchain.NewSubsidyCache(cfg.Params),


### PR DESCRIPTION
The --manualtickets config item was only being applied to watch-only wallets and not regular wallets. As a result the manualtickets field of the walletInfo response was always reporting false, even if the config item was set true.