### PR TITLE
Require client cert auth for gRPC, allow for JSON-RPC

### DIFF
--- a/internal/cfgutil/file.go
+++ b/internal/cfgutil/file.go
@@ -8,6 +8,9 @@ import "os"
 
 // FileExists reports whether the named file or directory exists.
 func FileExists(filePath string) (bool, error) {
+	if filePath == "" {
+		return false, nil
+	}
 	_, err := os.Stat(filePath)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/ipc.go
+++ b/ipc.go
@@ -32,12 +32,12 @@ var outgoingPipeMessages = make(chan pipeMessage)
 
 // serviceControlPipeRx reads from the file descriptor fd of a read end pipe.
 // This is intended to be used as a simple control mechanism for parent
-// processes to communicate with and and manage the lifetime of a dcrd child
-// process using a unidirectional pipe (on Windows, this is an anonymous pipe,
-// not a named pipe).
+// processes to communicate with and and manage the lifetime of a dcrwallet
+// child process using a unidirectional pipe (on Windows, this is an anonymous
+// pipe, not a named pipe).
 //
 // When the pipe is closed or any other errors occur reading the control
-// message, shutdown begins.  This prevents dcrd from continuing to run
+// message, shutdown begins.  This prevents dcrwallet from continuing to run
 // unsupervised after the parent process closes unexpectedly.
 //
 // No control messages are currently defined and the only use for the pipe is to
@@ -62,7 +62,7 @@ func serviceControlPipeRx(fd uintptr) {
 
 // serviceControlPipeTx sends pipe messages to the file descriptor fd of a write
 // end pipe.  This is intended to be a simple response and notification system
-// for a child dcrd process to communicate with a parent process without the
+// for a child dcrwallet process to communicate with a parent process without the
 // need to go through the RPC server.
 //
 // See the comment on the pipeMessage interface for the binary encoding of a
@@ -174,4 +174,30 @@ func (s grpcListenerEventServer) notify(laddr string) {
 		return
 	}
 	s <- grpcListenerEvent(laddr)
+}
+
+type issuedClientCertEvent []byte
+
+func (issuedClientCertEvent) Type() string          { return "issuedclientcertificate" }
+func (e issuedClientCertEvent) PayloadSize() uint32 { return uint32(len(e)) }
+func (e issuedClientCertEvent) WritePayload(w io.Writer) error {
+	_, err := w.Write(e)
+	return err
+}
+
+type issuedClientCertEventServer chan<- pipeMessage
+
+func newIssuedClientCertEventServer(outChan chan<- pipeMessage) issuedClientCertEventServer {
+	return issuedClientCertEventServer(outChan)
+}
+
+func (s issuedClientCertEventServer) notify(key []byte, certChain ...[]byte) {
+	if s == nil {
+		return
+	}
+	blocks := key
+	for _, cert := range certChain {
+		blocks = append(blocks, cert...)
+	}
+	s <- issuedClientCertEvent(blocks)
 }

--- a/x509_test.go
+++ b/x509_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) 2020 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"io/ioutil"
+	logpkg "log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+type keygen func(t *testing.T) (pub, priv interface{}, name string)
+
+func ed25519Keygen() keygen {
+	return func(t *testing.T) (pub, priv interface{}, name string) {
+		seed := make([]byte, ed25519.SeedSize)
+		_, err := io.ReadFull(rand.Reader, seed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := ed25519.NewKeyFromSeed(seed)
+		return key.Public(), key, "ed25519"
+	}
+}
+
+func ecKeygen(curve elliptic.Curve) keygen {
+	return func(t *testing.T) (pub, priv interface{}, name string) {
+		var key *ecdsa.PrivateKey
+		key, err := ecdsa.GenerateKey(curve, rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return key.Public(), key, curve.Params().Name
+	}
+}
+
+func TestClientCert(t *testing.T) {
+	algos := []keygen{
+		ed25519Keygen(),
+		ecKeygen(elliptic.P256()),
+		ecKeygen(elliptic.P384()),
+		ecKeygen(elliptic.P521()),
+	}
+
+	for _, algo := range algos {
+		pub, priv, name := algo(t)
+		testClientCert(t, pub, priv, name)
+	}
+}
+
+func echo(w http.ResponseWriter, r *http.Request) {
+	io.Copy(w, r.Body)
+}
+
+func testClientCert(t *testing.T, pub, priv interface{}, name string) {
+	ca, err := generateAuthority(pub, priv)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	keyBlock, err := marshalPrivateKey(ca.PrivateKey)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	certBlock, err := createSignedClientCert(pub, ca.PrivateKey, ca.Cert)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	keypair, err := tls.X509KeyPair(certBlock, keyBlock)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(echo))
+	s.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  x509.NewCertPool(),
+	}
+	s.TLS.ClientCAs.AddCert(ca.Cert)
+	defer s.Close()
+	s.StartTLS()
+
+	client := s.Client()
+	tr := client.Transport.(*http.Transport)
+	tr.TLSClientConfig.Certificates = []tls.Certificate{keypair}
+
+	req, err := http.NewRequest("PUT", s.URL, strings.NewReader("balls"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	resp, err := s.Client().Do(req)
+	if err != nil {
+		t.Errorf("algorithm %s: %v", name, err)
+		return
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if !bytes.Equal(body, []byte("balls")) {
+		t.Errorf("echo handler did not return expected result")
+	}
+}
+
+func TestUntrustedClientCert(t *testing.T) {
+	algo := ed25519Keygen()
+	pub1, priv1, _ := algo(t) // trusted by server
+	pub2, priv2, _ := algo(t) // presented by client
+
+	ca1, err := generateAuthority(pub1, priv1)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	ca2, err := generateAuthority(pub2, priv2)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	keyBlock2, err := marshalPrivateKey(ca2.PrivateKey)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	certBlock2, err := createSignedClientCert(pub2, ca2.PrivateKey, ca2.Cert)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	keypair2, err := tls.X509KeyPair(certBlock2, keyBlock2)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	s := httptest.NewUnstartedServer(http.HandlerFunc(echo))
+	s.Config = &http.Server{
+		// Don't log remote cert errors for this negative test
+		ErrorLog: logpkg.New(ioutil.Discard, "", 0),
+	}
+	s.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		ClientAuth: tls.RequireAndVerifyClientCert,
+		ClientCAs:  x509.NewCertPool(),
+	}
+	s.TLS.ClientCAs.AddCert(ca1.Cert)
+	defer s.Close()
+	s.StartTLS()
+
+	client := s.Client()
+	tr := client.Transport.(*http.Transport)
+	tr.TLSClientConfig.Certificates = []tls.Certificate{keypair2}
+
+	req, err := http.NewRequest("PUT", s.URL, strings.NewReader("balls"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = s.Client().Do(req)
+	if err == nil {
+		t.Errorf("request with bad client cert did not error")
+		return
+	}
+	if !strings.HasSuffix(err.Error(), "tls: bad certificate") {
+		t.Errorf("server did not report bad certificate error")
+		return
+	}
+}


### PR DESCRIPTION
Client authentication for JSON-RPC previously required configuring a
user and password, with both client and server holding knowledge of
the secret.  By allowing client authentication to be performed with
TLS client certificates, only the client side must hold a private key,
as long as the dcrwallet server is configured to trust the public key.

The gRPC server had no client authentication at all previously, and
the only reason this was marginally safe was that all requests that
could use a wallet key also required supplying and checking the wallet
private passhprase in the request.  However, with per-account
passphrases, this is no longer a suitable mechanism, and instead the
entire transport layer must be authenticated.  The simplest way to
perform this is by requiring and verifying client certificates.

TLS client certificate authentication must be enabled with the
--authtype=clientcerts flag or config setting.  The gRPC server will
no longer start without this setting, and enabling this also allows
the JSON-RPC server to be started without any user or password.

There are two ways in which a client certificate may be trusted:

1. A certificate authority is created which adds trust for a client
   cert, or certs signed by the authority.  This file defaults to
   clients.pem in the dcrwallet application data directory and can
   be modified to use other paths with the --clientcafile option.
   Certificates can be created using gencerts, OpenSSL, and similar
   tooling.

2. A parent process can read an issued ephemeral certificate and key
   through a pipe.  These certs and keys never reach the filesystem,
   and this is the expected mechanism by which Decrediton will
   authenticate itself to the gRPC server.  This behavior is enabled
   with the --issueclientcert flag.