### PR TITLE
Remove --tlscurve=P-224 support

### DIFF
--- a/internal/cfgutil/curve.go
+++ b/internal/cfgutil/curve.go
@@ -20,8 +20,7 @@ type CurveID int
 
 // Recognized curve IDs.
 const (
-	CurveP224 CurveID = iota
-	CurveP256
+	CurveP256 CurveID = iota
 	CurveP384
 	CurveP521
 	Ed25519
@@ -45,8 +44,6 @@ func NewCurveFlag(defaultValue CurveID) *CurveFlag {
 // curve is not one of the elliptic curves suitable for ECDSA.
 func (f *CurveFlag) ECDSACurve() (elliptic.Curve, bool) {
 	switch f.curveID {
-	case CurveP224:
-		return elliptic.P224(), true
 	case CurveP256:
 		return elliptic.P256(), true
 	case CurveP384:
@@ -61,8 +58,6 @@ func (f *CurveFlag) ECDSACurve() (elliptic.Curve, bool) {
 // MarshalFlag satisfies the flags.Marshaler interface.
 func (f *CurveFlag) MarshalFlag() (name string, err error) {
 	switch f.curveID {
-	case CurveP224:
-		name = "P-224"
 	case CurveP256:
 		name = "P-256"
 	case CurveP384:
@@ -80,8 +75,6 @@ func (f *CurveFlag) MarshalFlag() (name string, err error) {
 // UnmarshalFlag satisfies the flags.Unmarshaler interface.
 func (f *CurveFlag) UnmarshalFlag(value string) error {
 	switch value {
-	case "P-224":
-		f.curveID = CurveP224
 	case "P-256":
 		f.curveID = CurveP256
 	case "P-384":


### PR DESCRIPTION
This elliptic curve is not a supported algorithm for the TLS server.
dcrctl clients are unable to talk to a server that generated one of
these keys, and the server will log an error in this case:

http: TLS handshake error from [::1]:46531: tls: unsupported certificate curve (P-224)