### PR TITLE
Show full error when test fails

### DIFF
--- a/x509_test.go
+++ b/x509_test.go
@@ -181,7 +181,8 @@ func TestUntrustedClientCert(t *testing.T) {
 		return
 	}
 	if !strings.HasSuffix(err.Error(), "tls: bad certificate") {
-		t.Errorf("server did not report bad certificate error")
+		t.Errorf("server did not report bad certificate error; "+
+			"instead errored with: %v", err)
 		return
 	}
 }


### PR DESCRIPTION
This test failure was observed on Github CI, but I am not able to
reproduce locally after many tries.  If this occurs again, show the
full error to give more insight.