### PR TITLE
p2p: Bump max supported pver

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -41,7 +41,7 @@ var uaVersion = version.String()
 const minPver = wire.CFilterV2Version
 
 // Pver is the maximum protocol version implemented by the LocalPeer.
-const Pver = wire.CFilterV2Version
+const Pver = wire.InitStateVersion
 
 const maxOutboundConns = 8
 
@@ -170,6 +170,7 @@ func (lp *LocalPeer) newMsgVersion(pver uint32, extaddr net.Addr, c net.Conn) (*
 	}
 	v := wire.NewMsgVersion(la, ra, nonce, 0)
 	v.AddUserAgent(uaName, uaVersion)
+	v.ProtocolVersion = int32(pver)
 	return v, nil
 }
 


### PR DESCRIPTION
This bumps the maximum supported protocol version to the upcoming
version 8, which adds the getinitialstate/initialstate pair of messages.

It also fixes a bug that could happen if the wire package was upgraded
to a version with a new protocol version but the wallet's p2p package
was not updated: in that case SPV clients could negotiate an incorrect
version and fail in undefined ways.

This is fixed by ensuring the protocol version advertised by the wallet
is always the maximum one the wallet understands as opposed to the
default one for NewMsgVersion().