### PR TITLE
Provide a context when creating vsp clients

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -263,7 +263,7 @@ func run(ctx context.Context) error {
 					cfg.PurchaseAccount, err)
 				return err
 			}
-			vspServer, err = vsp.New(cfg.VSPOpts.URL, cfg.VSPOpts.PubKey,
+			vspServer, err = vsp.New(ctx, cfg.VSPOpts.URL, cfg.VSPOpts.PubKey,
 				purchaseAcct, changeAcct, cfg.dial, w, activeNet.Params)
 			if err != nil {
 				log.Errorf("vsp: %v", err)

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1633,7 +1633,7 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 		if vspHost == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "vsp host can not be null")
 		}
-		vspServer, err = vsp.New(vspHost, vspPubKey, req.Account, req.Account, nil, s.wallet, params)
+		vspServer, err = vsp.New(ctx, vspHost, vspPubKey, req.Account, req.Account, nil, s.wallet, params)
 		if err != nil {
 			return nil, status.Errorf(codes.Unknown, "VSP Server instance failed to start. Error: %v", err)
 		}
@@ -2512,7 +2512,7 @@ func (t *ticketbuyerV2Server) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr 
 		if vspHost == "" {
 			return status.Errorf(codes.InvalidArgument, "vsp host can not be null")
 		}
-		vspServer, err = vsp.New(vspHost, vspPubKey, req.Account, req.Account, nil, wallet, params)
+		vspServer, err = vsp.New(svr.Context(), vspHost, vspPubKey, req.Account, req.Account, nil, wallet, params)
 		if err != nil {
 			return status.Errorf(codes.Unknown, "TicketBuyerV3 instance failed to start. Error: %v", err)
 		}
@@ -3660,7 +3660,7 @@ func (s *walletServer) SyncVSPFailedTickets(ctx context.Context, req *pb.SyncVSP
 		return nil, status.Errorf(codes.InvalidArgument, "vsp host can not be null")
 	}
 	vspServer, err := vsp.New(
-		vspHost, vspPubKey, req.Account, req.Account, nil, s.wallet, s.wallet.ChainParams())
+		ctx, vspHost, vspPubKey, req.Account, req.Account, nil, s.wallet, s.wallet.ChainParams())
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "TicketBuyerV3 instance failed to start. Error: %v", err)
 	}

--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -62,7 +62,7 @@ type VSPTicket struct {
 
 type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
-func New(vspURL, pubKeyStr string, purchaseAccount, changeAccount uint32, dialer DialFunc, w *wallet.Wallet, params *chaincfg.Params) (*VSP, error) {
+func New(ctx context.Context, vspURL, pubKeyStr string, purchaseAccount, changeAccount uint32, dialer DialFunc, w *wallet.Wallet, params *chaincfg.Params) (*VSP, error) {
 	u, err := url.Parse(vspURL)
 	if err != nil {
 		return nil, err
@@ -79,8 +79,6 @@ func New(vspURL, pubKeyStr string, purchaseAccount, changeAccount uint32, dialer
 		Transport: &transport,
 	}
 
-	// TODO ctx
-	ctx := context.Background()
 	c := w.NtfnServer.ConfirmationNotifications(ctx)
 	v := &VSP{
 		vspURL:          u,


### PR DESCRIPTION
At least this should allow all of the background goroutines vsp.New
starts to exit.