### PR TITLE
vsp: Remove code duplication

### DIFF
--- a/internal/vsp/client.go
+++ b/internal/vsp/client.go
@@ -1,0 +1,111 @@
+package vsp
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/decred/dcrd/dcrutil/v3"
+)
+
+type client struct {
+	http.Client
+	url  string
+	pub  []byte
+	sign func(context.Context, string, dcrutil.Address) ([]byte, error)
+}
+
+type signer interface {
+	SignMessage(ctx context.Context, message string, address dcrutil.Address) ([]byte, error)
+}
+
+func newClient(url string, pub []byte, s signer) *client {
+	return &client{url: url, pub: pub, sign: s.SignMessage}
+}
+
+type BadRequestError struct {
+	HTTPStatus int    `json:"-"`
+	Code       int    `json:"code"`
+	Message    string `json:"message"`
+}
+
+func (e *BadRequestError) Error() string { return e.Message }
+
+func (c *client) post(ctx context.Context, path string, addr dcrutil.Address, resp, req interface{}) error {
+	return c.do(ctx, "POST", path, addr, resp, req)
+}
+
+func (c *client) get(ctx context.Context, path string, resp interface{}) error {
+	return c.do(ctx, "GET", path, nil, resp, nil)
+}
+
+func (c *client) do(ctx context.Context, method, path string, addr dcrutil.Address, resp, req interface{}) error {
+	var reqBody io.Reader
+	var sig []byte
+	if method == "POST" {
+		body, err := json.Marshal(req)
+		if err != nil {
+			return fmt.Errorf("marshal request: %w", err)
+		}
+		sig, err = c.sign(ctx, string(body), addr)
+		if err != nil {
+			return fmt.Errorf("sign request: %w", err)
+		}
+		reqBody = bytes.NewReader(body)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, method, c.url+path, reqBody)
+	if err != nil {
+		return fmt.Errorf("new request: %w", err)
+	}
+	if sig != nil {
+		httpReq.Header.Set("VSP-Client-Signature", base64.StdEncoding.EncodeToString(sig))
+	}
+	reply, err := c.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("%s %s: %w", method, httpReq.URL.String(), err)
+	}
+	status := reply.StatusCode
+	is200 := status == 200
+	is4xx := status >= 400 && status <= 499
+	if !(is200 || is4xx) {
+		return fmt.Errorf("%s %s: http %v %s", method, httpReq.URL.String(),
+			status, http.StatusText(status))
+	}
+	sigBase64 := reply.Header.Get("VSP-Server-Signature")
+	if sigBase64 == "" {
+		return fmt.Errorf("cannot authenticate server: no signature")
+	}
+	sig, err = base64.StdEncoding.DecodeString(sigBase64)
+	if err != nil {
+		return fmt.Errorf("cannot authenticate server: %w", err)
+	}
+	respBody, err := ioutil.ReadAll(reply.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	if !ed25519.Verify(c.pub, respBody, sig) {
+		return fmt.Errorf("cannot authenticate server: invalid signature")
+	}
+	var apiError *BadRequestError
+	if is4xx {
+		apiError = new(BadRequestError)
+		resp = apiError
+	}
+	if resp != nil {
+		err = json.Unmarshal(respBody, resp)
+		if err != nil {
+			return fmt.Errorf("unmarshal respose body: %w", err)
+		}
+	}
+	if apiError != nil {
+		apiError.HTTPStatus = status
+		return apiError
+	}
+	return nil
+}

--- a/internal/vsp/poolfee.go
+++ b/internal/vsp/poolfee.go
@@ -1,61 +1,12 @@
 package vsp
 
-import (
-	"context"
-	"crypto/ed25519"
-	"encoding/base64"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
-)
+import "context"
 
 func (v *VSP) PoolFee(ctx context.Context) (float64, error) {
-	reqURL := v.vspURL.String() + apiVSPInfo
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-	if err != nil {
-		log.Errorf("failed to create new fee address request: %v", err)
-		return -1, err
-	}
-	resp, err := v.httpClient.Do(req)
-	if err != nil {
-		log.Errorf("vspinfo request failed: %v", err)
-		return -1, err
-	}
-	// TODO - Add numBytes resp check
-
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		log.Errorf("failed to read fee ddress response: %v", err)
-		return -1, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		log.Warnf("vsp responded with an error: %v", string(responseBody))
-		return -1, err
-	}
-
-	serverSigStr := resp.Header.Get(serverSignature)
-	if serverSigStr == "" {
-		log.Warnf("vspinfo response missing server signature")
-		return -1, err
-	}
-	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
-	if err != nil {
-		log.Warnf("failed to decode server signature: %v", err)
-		return -1, err
-	}
-
-	if !ed25519.Verify(v.pubKey, responseBody, serverSig) {
-		log.Warnf("server failed verification")
-		return -1, err
-	}
-
 	var vspInfo vspInfoResponse
-	err = json.Unmarshal(responseBody, &vspInfo)
+	err := v.client.get(ctx, "/api/v3/vspinfo", &vspInfo)
 	if err != nil {
-		log.Warnf("failed to unmarshal vspinfo response: %v", err)
 		return -1, err
 	}
-
 	return vspInfo.FeePercentage, nil
 }

--- a/internal/vsp/ticketstatus.go
+++ b/internal/vsp/ticketstatus.go
@@ -3,12 +3,8 @@ package vsp
 import (
 	"bytes"
 	"context"
-	"crypto/ed25519"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/decred/dcrd/blockchain/stake/v3"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -32,83 +28,26 @@ func (v *VSP) TicketStatus(ctx context.Context, hash *chainhash.Hash) (*TicketSt
 		return nil, err
 	}
 
-	ticketStatusRequest := TicketStatusRequest{
+	var resp TicketStatusResponse
+	requestBody, err := json.Marshal(&TicketStatusRequest{
 		TicketHash: hash.String(),
-	}
-
-	requestBody, err := json.Marshal(&ticketStatusRequest)
+	})
 	if err != nil {
-		log.Errorf("failed to marshal ticket status request: %v", err)
 		return nil, err
 	}
-
-	reqURL := v.vspURL.String() + "/api/v3/ticketstatus"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL, bytes.NewReader(requestBody))
+	err = v.client.post(ctx, "/api/v3/ticketstatus", commitmentAddr, &resp, json.RawMessage(requestBody))
 	if err != nil {
-		log.Errorf("failed to create new fee address request: %v", err)
-		return nil, err
-	}
-
-	signature, err := v.cfg.Wallet.SignMessage(ctx, string(requestBody), commitmentAddr)
-	if err != nil {
-		log.Errorf("failed to sign feeAddress request: %v", err)
-		return nil, err
-	}
-	req.Header.Set("VSP-Client-Signature", base64.StdEncoding.EncodeToString(signature))
-
-	resp, err := v.httpClient.Do(req)
-	if err != nil {
-		log.Errorf("ticket status request failed: %v", err)
-		return nil, err
-	}
-	serverSigStr := resp.Header.Get(serverSignature)
-	if serverSigStr == "" {
-		log.Warnf("ticket status response missing server signature")
-		return nil, fmt.Errorf("ticket status response missing server signature")
-	}
-	serverSig, err := base64.StdEncoding.DecodeString(serverSigStr)
-	if err != nil {
-		log.Warnf("failed to decode server signature: %v", err)
-		return nil, err
-	}
-
-	// TODO - Add numBytes resp check
-	responseBody, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	if err != nil {
-		log.Errorf("failed to read response body: %v", err)
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		log.Warnf("vsp responded with an error: %v", string(responseBody))
-		return nil, fmt.Errorf("vsp responded with an error (%v): %v", resp.StatusCode, string(responseBody))
-	}
-
-	if !ed25519.Verify(v.pubKey, responseBody, serverSig) {
-		log.Warnf("server failed verification")
-		return nil, fmt.Errorf("server failed verification")
-	}
-
-	var ticketStatusResponse TicketStatusResponse
-	err = json.Unmarshal(responseBody, &ticketStatusResponse)
-	if err != nil {
-		log.Warnf("failed to unmarshal ticketstatus response: %v", err)
 		return nil, err
 	}
 
 	// verify initial request matches server
-	serverRequestBody, err := json.Marshal(ticketStatusResponse.Request)
-	if err != nil {
-		log.Warnf("failed to marshal response request: %v", err)
-		return nil, err
-	}
-	if !bytes.Equal(requestBody, serverRequestBody) {
+	if !bytes.Equal(requestBody, resp.Request) {
 		log.Warnf("server response has differing request: %#v != %#v",
-			requestBody, serverRequestBody)
+			requestBody, resp.Request)
 		return nil, fmt.Errorf("server response contains differing request")
 	}
 
 	// TODO - validate server timestamp?
 
-	return &ticketStatusResponse, nil
+	return &resp, nil
 }

--- a/internal/vsp/types.go
+++ b/internal/vsp/types.go
@@ -1,5 +1,7 @@
 package vsp
 
+import "encoding/json"
+
 type FeeAddressRequest struct {
 	Timestamp  int64  `json:"timestamp" `
 	TicketHash string `json:"tickethash"`
@@ -7,11 +9,11 @@ type FeeAddressRequest struct {
 }
 
 type FeeAddressResponse struct {
-	Timestamp  int64             `json:"timestamp"`
-	FeeAddress string            `json:"feeaddress"`
-	FeeAmount  int64             `json:"feeamount"`
-	Expiration int64             `json:"expiration"`
-	Request    FeeAddressRequest `json:"request"`
+	Timestamp  int64           `json:"timestamp"`
+	FeeAddress string          `json:"feeaddress"`
+	FeeAmount  int64           `json:"feeamount"`
+	Expiration int64           `json:"expiration"`
+	Request    json.RawMessage `json:"request"`
 }
 
 type PayFeeRequest struct {
@@ -22,17 +24,22 @@ type PayFeeRequest struct {
 	VoteChoices map[string]string `json:"votechoices" `
 }
 
+type PayFeeResponse struct {
+	Timestamp int64           `json:"timestamp"`
+	Request   json.RawMessage `json:"request"`
+}
+
 type TicketStatusRequest struct {
 	TicketHash string `json:"tickethash" `
 }
 
 type TicketStatusResponse struct {
-	Timestamp       int64               `json:"timestamp"`
-	TicketConfirmed bool                `json:"ticketconfirmed"`
-	FeeTxStatus     string              `json:"feetxstatus"`
-	FeeTxHash       string              `json:"feetxhash"`
-	VoteChoices     map[string]string   `json:"votechoices"`
-	Request         TicketStatusRequest `json:"request"`
+	Timestamp       int64             `json:"timestamp"`
+	TicketConfirmed bool              `json:"ticketconfirmed"`
+	FeeTxStatus     string            `json:"feetxstatus"`
+	FeeTxHash       string            `json:"feetxhash"`
+	VoteChoices     map[string]string `json:"votechoices"`
+	Request         json.RawMessage   `json:"request"`
 }
 
 type vspInfoResponse struct {


### PR DESCRIPTION
This commit adds a client type which handles both GET and POST
requests for the vspd API.  The server signature is always checked,
and during POSTs, the request body is signed using the private key of
some wallet address.

This also fixes the handling of HTTP 400 status codes for bad client
requests, and will unmarshal these into a BadRequestError type.