### PR TITLE
Fix redeemmultisigout(s) methods to set transaction version

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3174,7 +3174,7 @@ func (s *Server) redeemMultiSigOut(ctx context.Context, icmd interface{}) (inter
 	if sc != txscript.MultiSigTy {
 		return nil, errors.E("P2SH redeem script is not multisig")
 	}
-	var msgTx wire.MsgTx
+	msgTx := wire.NewMsgTx()
 	txIn := wire.NewTxIn(&op, int64(p2shOutput.OutputAmount), nil)
 	msgTx.AddTxIn(txIn)
 
@@ -3183,7 +3183,7 @@ func (s *Server) redeemMultiSigOut(ctx context.Context, icmd interface{}) (inter
 		return nil, err
 	}
 
-	err = w.PrepareRedeemMultiSigOutTxOutput(&msgTx, p2shOutput, &pkScript)
+	err = w.PrepareRedeemMultiSigOutTxOutput(msgTx, p2shOutput, &pkScript)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
They were using the default value 0 as the transaction version, which
is invalid.

Fixes #1911.