### PR TITLE
Fix change account detection for incomplete configs

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -2754,7 +2754,7 @@ func makeOutputs(pairs map[string]dcrutil.Amount, chainParams *chaincfg.Params) 
 // All errors are returned in dcrjson.RPCError format
 func (s *Server) sendPairs(ctx context.Context, w *wallet.Wallet, amounts map[string]dcrutil.Amount, account uint32, minconf int32) (string, error) {
 	changeAccount := account
-	if s.cfg.CSPPServer != "" {
+	if s.cfg.CSPPServer != "" && s.cfg.MixAccount != "" && s.cfg.MixChangeAccount != "" {
 		mixAccount, err := w.AccountNumber(ctx, s.cfg.MixAccount)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
When --csppserver was configured, but --mixaccount and
--mixchangeaccount were not, the sendtoaddress/sendfrom/sendmany
JSON-RPC calls were failing due to a failed lookup of account "", as
there was no verification that either --mixaccount or
--mixchangeaccount were configured with a nonzero value.  This change
modifies the logic to pick the appropriate change account for sends
from the mixed account only when all of these options are configured.