### PR TITLE
Require peers to implement protocol version 8

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -38,7 +38,7 @@ var uaVersion = version.String()
 
 // minPver is the minimum protocol version we require remote peers to
 // implement.
-const minPver = wire.CFilterV2Version
+const minPver = wire.InitStateVersion
 
 // Pver is the maximum protocol version implemented by the LocalPeer.
 const Pver = wire.InitStateVersion


### PR DESCRIPTION
This new version also accompanies a hard fork, and so this is a useful
way to not receive more peers from the seeders who haven't upgraded
and followed the fork.