### PR TITLE
Remove SFNodeCF from required services

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -29,7 +29,7 @@ import (
 // reqSvcs defines the services that must be supported by outbounded peers.
 // After fetching more addresses (if needed), peers are disconnected from if
 // they do not provide each of these services.
-const reqSvcs = wire.SFNodeNetwork | wire.SFNodeCF
+const reqSvcs = wire.SFNodeNetwork
 
 // Syncer implements wallet synchronization services by over the Decred wire
 // protocol using Simplified Payment Verification (SPV) with compact filters.


### PR DESCRIPTION
This service flag indicates v1 gcs cfilters, which the wallet no
longer requests or uses.

Depends on #1924 