### PR TITLE
vsp: Make maximum fee configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -175,9 +175,10 @@ type ticketBuyerOptions struct {
 
 type vspOptions struct {
 	// VSP - TODO: VSPServer to a []string to support multiple VSPs
-	URL    string `long:"url" description:"Base URL of the VSP server"`
-	PubKey string `long:"pubkey" description:"VSP server pubkey"`
-	Sync   bool   `long:"sync" description:"sync tickets to vsp"`
+	URL    string              `long:"url" description:"Base URL of the VSP server"`
+	PubKey string              `long:"pubkey" description:"VSP server pubkey"`
+	Sync   bool                `long:"sync" description:"sync tickets to vsp"`
+	MaxFee *cfgutil.AmountFlag `long:"maxfee" description:"Maximum VSP fee"`
 }
 
 // cleanAndExpandPath expands environement variables and leading ~ in the
@@ -361,6 +362,10 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		TBOpts: ticketBuyerOptions{
 			BalanceToMaintainAbsolute: cfgutil.NewAmountFlag(defaultBalanceToMaintainAbsolute),
 			VotingAddress:             cfgutil.NewAddressFlag(),
+		},
+
+		VSPOpts: vspOptions{
+			MaxFee: cfgutil.NewAmountFlag(0.1e8),
 		},
 	}
 

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -269,6 +269,7 @@ func run(ctx context.Context) error {
 				PubKey:          cfg.VSPOpts.PubKey,
 				PurchaseAccount: purchaseAcct,
 				ChangeAccount:   changeAcct,
+				MaxFee:          cfg.VSPOpts.MaxFee.Amount,
 				Dialer:          cfg.dial,
 				Wallet:          w,
 				Params:          activeNet.Params,

--- a/internal/vsp/feeaddress.go
+++ b/internal/vsp/feeaddress.go
@@ -102,15 +102,11 @@ func (v *VSP) GetFeeAddress(ctx context.Context, ticketHash chainhash.Hash) (dcr
 	}
 	feeAmount := dcrutil.Amount(feeResponse.FeeAmount)
 
-	// TODO - convert to vsp.maxfee config option
-	maxFee, err := dcrutil.NewAmount(0.1)
-	if err != nil {
+	log.Infof("VSP requires fee %v", feeAmount)
+	if feeAmount > v.cfg.MaxFee {
+		err := fmt.Errorf("server fee amount too high: %v > %v", feeAmount, v.cfg.MaxFee)
+		log.Warn(err)
 		return 0, err
-	}
-
-	if feeAmount > maxFee {
-		log.Warnf("fee amount too high: %v > %v", feeAmount, maxFee)
-		return 0, fmt.Errorf("server fee amount too high: %v > %v", feeAmount, maxFee)
 	}
 
 	v.ticketToFeeMu.Lock()

--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -47,6 +47,11 @@ type Config struct {
 	// ChangeAccount specifies the change account when creating fee transactions.
 	ChangeAccount uint32
 
+	// MaxFee specifies the maximum allowed fee which the VSP may require.
+	// Fees exceeding this value will result in the fee transaction not
+	// being paid to the VSP.
+	MaxFee dcrutil.Amount
+
 	// Dialer specifies an optional dialer when connecting to the VSP.
 	Dialer DialFunc
 


### PR DESCRIPTION
The default maximum fee is set to 0.1 DCR, and matches the previous
hardcoded fee check.