### PR TITLE
Handle VSP's successful processing of fee payment

### DIFF
--- a/internal/vsp/errors.go
+++ b/internal/vsp/errors.go
@@ -1,0 +1,21 @@
+package vsp
+
+const (
+	codeBadRequest = iota
+	codeInternalErr
+	codeVspClosed
+	codeFeeAlreadyReceived
+	codeInvalidFeeTx
+	codeFeeTooSmall
+	codeUnknownTicket
+	codeTicketCannotVote
+	codeFeeExpired
+	codeInvalidVoteChoices
+	codeBadSignature
+	codeInvalidPrivKey
+	codeFeeNotReceived
+	codeInvalidTicket
+	codeCannotBroadcastTicket
+	codeCannotBroadcastFee
+	codeCannotBroadcastFeeUnknownOutputs
+)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5297,9 +5297,24 @@ func (w *Wallet) SetPublished(ctx context.Context, hash *chainhash.Hash, publish
 	return nil
 }
 
+// VSPFeeHashForTicket returns the hash of the fee transaction associated with a
+// VSP payment.
+func (w *Wallet) VSPFeeHashForTicket(ctx context.Context, ticketHash *chainhash.Hash) (chainhash.Hash, error) {
+	var feeHash chainhash.Hash
+	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
+		data, err := udb.GetVSPTicket(dbtx, *ticketHash)
+		if err != nil {
+			return err
+		}
+		feeHash = data.FeeHash
+		return nil
+	})
+	return feeHash, err
+}
+
 // UpdateVspTicketFeeToPaid updates a vsp ticket fee status to paid.
 // This is needed when finishing the fee payment on VSPs Process.
-func (w *Wallet) UpdateVspTicketFeeToPaid(ctx context.Context, ticketHash *chainhash.Hash, feeHash *chainhash.Hash) error {
+func (w *Wallet) UpdateVspTicketFeeToPaid(ctx context.Context, ticketHash, feeHash *chainhash.Hash) error {
 	var err error
 	err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 		err = udb.SetVSPTicket(dbtx, ticketHash, &udb.VSPTicket{


### PR DESCRIPTION
When the VSP has already received a fee payment as valid, the wallet
should update its status for the ticket when trying to process the
payment again on a later restart or due to a RPC request from
Decrediton.  This was not being done, and instead the API error
returned by vspd for this situation was being silently ignored by the
SyncVSPFailedTickets gRPC method and never logged, because that method
was erroneously assuming the error would always be logged elsewhere
(nevermind that dcrwallet logs are not the method by which RPC clients
should obtain error information).