### PR TITLE
Randomize inputs selected for paying VSP fees

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1795,6 +1795,9 @@ func (w *Wallet) findEligibleOutputsAmount(dbtx walletdb.ReadTx, account uint32,
 	if err != nil {
 		return nil, err
 	}
+	shuffle(len(unspent), func(i, j int) {
+		unspent[i], unspent[j] = unspent[j], unspent[i]
+	})
 
 	eligible := make([]Input, 0, len(unspent))
 	var outTotal dcrutil.Amount


### PR DESCRIPTION
The input selection was not randomized previously (as this code did
not use the randomized InputSource that was previously added for input
selection for all funded transactions).

Randomizing these chosen inputs may (randomly) allow VSP-using ticket
purchasing to succeed where it would have reliably failed before, if
the user's high-valued UTXOs are not selected for fee payments.  This
would then enable a user or a client to reattempt the purchase.