### PR TITLE
Replace txToOutputs method, use struct for many parameters

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1795,6 +1795,9 @@ func (w *Wallet) findEligibleOutputsAmount(dbtx walletdb.ReadTx, account uint32,
 	if err != nil {
 		return nil, err
 	}
+	shuffle(len(unspent), func(i, j int) {
+		unspent[i], unspent[j] = unspent[j], unspent[i]
+	})
 
 	eligible := make([]Input, 0, len(unspent))
 	var outTotal dcrutil.Amount


### PR DESCRIPTION
Rebased over #1937 

---

This removes the wallet's unexported txToOutputs method by replacing
it with an authorTx method that instead of taking a dozen parameters,
uses a struct.  While not only cleaner, this also allows more fields
of the struct to be set by the method, which will be used in upcoming
commits to change where and how the created transactions are added to
the wallet and published to the network.