### PR TITLE
Split out recording and notifying new txs from authorTx

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1795,6 +1795,9 @@ func (w *Wallet) findEligibleOutputsAmount(dbtx walletdb.ReadTx, account uint32,
 	if err != nil {
 		return nil, err
 	}
+	shuffle(len(unspent), func(i, j int) {
+		unspent[i], unspent[j] = unspent[j], unspent[i]
+	})
 
 	eligible := make([]Input, 0, len(unspent))
 	var outTotal dcrutil.Amount

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4367,6 +4367,10 @@ func (w *Wallet) SendOutputs(ctx context.Context, outputs []*wire.TxOut, account
 	if err != nil {
 		return nil, err
 	}
+	err = w.recordAuthoredTx(ctx, op, a)
+	if err != nil {
+		return nil, err
+	}
 	err = w.publishAndWatch(ctx, op, nil, a.atx, a.watch)
 	if err != nil {
 		return nil, err
@@ -4398,6 +4402,10 @@ func (w *Wallet) SendOutputsToTreasury(ctx context.Context, outputs []*wire.TxOu
 		isTreasury:         true,
 	}
 	err := w.authorTx(ctx, op, a)
+	if err != nil {
+		return nil, err
+	}
+	err = w.recordAuthoredTx(ctx, op, a)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Rebased over #1938

---

This will help callers use the correct ordering for recording,
notifying, and publishing transactions after they are created and
signed.