### PR TITLE
Fix JSON-RPC error message when sending from locked wallet

### DIFF
--- a/internal/rpc/jsonrpc/errors.go
+++ b/internal/rpc/jsonrpc/errors.go
@@ -101,7 +101,7 @@ var (
 
 	errWalletUnlockNeeded = &dcrjson.RPCError{
 		Code:    dcrjson.ErrRPCWalletUnlockNeeded,
-		Message: "enter the wallet passphrase with walletpassphrase first",
+		Message: "wallet or account locked; use walletpassphrase or unlockaccount first",
 	}
 
 	errReservedAccountName = &dcrjson.RPCError{

--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -443,6 +443,11 @@ func deriveKey(acctInfo *accountInfo, branch, index uint32, private bool) (*hdke
 				return nil, errors.E(errors.Locked,
 					"account with unique passphrase is locked")
 			}
+			if len(acctInfo.acctKeyEncrypted) != 0 {
+				return nil, errors.E(errors.Locked,
+					"private key %s/%d/%d is locked",
+					acctInfo.acctName, branch, index)
+			}
 			return nil, errors.Errorf("no private key for %s/%d/%d",
 				acctInfo.acctName, branch, index)
 		}


### PR DESCRIPTION
This error no longer returned a helpful error message about what to
run ever since the per-account encryption was implemented, because
walletpassphrase was not in all cases the correct method to run if the
account was encrypted by unique keys.  Fix this error message to
suggest either walletpassphrase or unlockaccount, and wrap
errors.Locked errors when the account is locked and created from an
xpriv, not an xpub.