### PR TITLE
vsp: Remove hard-coded header name.

### DIFF
--- a/internal/vsp/client.go
+++ b/internal/vsp/client.go
@@ -77,7 +77,7 @@ func (c *client) do(ctx context.Context, method, path string, addr dcrutil.Addre
 		return fmt.Errorf("%s %s: http %v %s", method, httpReq.URL.String(),
 			status, http.StatusText(status))
 	}
-	sigBase64 := reply.Header.Get("VSP-Server-Signature")
+	sigBase64 := reply.Header.Get(serverSignature)
 	if sigBase64 == "" {
 		return fmt.Errorf("cannot authenticate server: no signature")
 	}


### PR DESCRIPTION
The header name "VSP-Server-Signature" is already stored in a package
variable so there's no need for it to be hard-coded in the do() func.