### PR TITLE
Bump required dcrd RPC server version to 7.0.0

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var requiredAPIVersion = semver{Major: 6, Minor: 0, Patch: 0}
+var requiredAPIVersion = semver{Major: 7, Minor: 0, Patch: 0}
 
 // Syncer implements wallet synchronization services by processing
 // notifications from a dcrd JSON-RPC server.

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3926,10 +3926,11 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd interface{}) (inte
 			requestedGroup.Go(func() error {
 				hash := txIn.PreviousOutPoint.Hash.String()
 				index := txIn.PreviousOutPoint.Index
+				tree := txIn.PreviousOutPoint.Tree
 				// gettxout returns null without error if the output exists
 				// but is spent.  A double pointer is used to handle this case.
 				var res *dcrdtypes.GetTxOutResult
-				err := rpc.Call(gctx, "gettxout", &res, hash, index, true)
+				err := rpc.Call(gctx, "gettxout", &res, hash, index, tree, true)
 				if err != nil {
 					return errors.E(errors.Op("dcrd.jsonrpc.gettxout"), err)
 				}

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -127,7 +127,9 @@ func (w *Wallet) LiveTicketHashes(ctx context.Context, rpcCaller Caller, include
 			// gettxout is used first as an optimization to check that output 0
 			// of the ticket is unspent.
 			var txOut *dcrdtypes.GetTxOutResult
-			err := rpcCaller.Call(ctx, "gettxout", &txOut, extraTickets[i].String(), 0)
+			const index = 0
+			const tree = 1
+			err := rpcCaller.Call(ctx, "gettxout", &txOut, extraTickets[i].String(), index, tree)
 			if err != nil || txOut == nil {
 				return nil
 			}


### PR DESCRIPTION
This also includes a change for the gettxout requiring adding an
additional parameter for the tree of the output.