### PR TITLE
Fix type in sync.Map.Delete call

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1337,7 +1337,7 @@ func (s *Syncer) handleMempool(ctx context.Context) error {
 				select {
 				case <-ctx.Done():
 				case <-time.After(mempoolEvictionTimeout):
-					s.mempool.Delete(txHash)
+					s.mempool.Delete(*txHash)
 				}
 			}()
 		case <-ctx.Done():


### PR DESCRIPTION
The map key must be chainhash.Hash, not *chainhash.Hash.

Spotted by @chappjc.