### PR TITLE
Narrow rules of what is considered a possible coinjoin

### DIFF
--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -329,8 +329,17 @@ func PossibleCoinJoin(tx *wire.MsgTx) (isMix bool, mixDenom int64, mixCount uint
 	numberOfInputs := len(tx.TxIn)
 
 	mixedOuts := make(map[int64]uint32)
+	scripts := make(map[string]int)
 	for _, o := range tx.TxOut {
+		scripts[string(o.PkScript)]++
+		if scripts[string(o.PkScript)] > 1 {
+			return false, 0, 0
+		}
 		val := o.Value
+		// Multiple zero valued outputs do not count as a coinjoin mix.
+		if val == 0 {
+			continue
+		}
 		mixedOuts[val]++
 	}
 

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5230,6 +5230,9 @@ func (w *Wallet) getCoinjoinTxsSumbByAcct(ctx context.Context) (map[uint32]int, 
 		_, tipHeight := w.txStore.MainChainTip(dbtx)
 		rangeFn := func(details []udb.TxDetails) (bool, error) {
 			for _, detail := range details {
+				if detail.TxType != stake.TxTypeRegular {
+					continue
+				}
 				isMixedTx, mixDenom, _ := PossibleCoinJoin(&detail.MsgTx)
 				if !isMixedTx {
 					continue


### PR DESCRIPTION
Only consider regular transactions, never any stake ones.

If multiple outputs with zero values are found in the transaction,
these are not considered a mix for having similar output values.

If any output script is reused in the transaction, the tx is not
considered a mix.