### PR TITLE
Promote error kind even if wrapped error would be overwritten

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -204,6 +204,9 @@ func E(args ...interface{}) error {
 			e.bottom = true
 		case *Error:
 			prev = arg
+			if e.Kind == 0 {
+				e.Kind = arg.Kind
+			}
 			e.Err = arg
 			e.bottom = false
 		case error:

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -89,3 +89,14 @@ func TestCause(t *testing.T) {
 		}
 	}
 }
+
+func TestDoubleWrappedErrorWithKind(t *testing.T) {
+	err := E(Invalid, "abc")
+	// Wrap the error again
+	err = E(err, "def")
+	// Now try to match against the kind
+	if !Is(err, Invalid) {
+		t.Errorf("Is returned false for error object: %T %+[1]v", err)
+		t.Errorf("Wrapped error: %T %+[1]v", err.(*Error).Unwrap())
+	}
+}


### PR DESCRIPTION
This fixes an issue where a wrapped errors.Error can lose its Kind
matching when another error object is used in the E function.  There
is still the issue of the earlier error being forgotten dropped
entirely, but this at least fixes most detection issues that depend on
the Kind matching.

A test (which fails without the patch) is added to demonstrate the
issue.