### PR TITLE
Handle VSP ticket status "received".

### DIFF
--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -857,6 +857,11 @@ func (fp *feePayment) confirmPayment() (err error) {
 	}
 
 	switch status.FeeTxStatus {
+	case "received":
+		// VSP has received the fee tx but has not yet broadcast it.
+		// VSP will only broadcast the tx when ticket has 6+ confirmations.
+		fp.schedule("confirm payment", fp.confirmPayment)
+		return nil
 	case "broadcast":
 		log.Infof("VSP has successfully sent the fee tx for %v", &fp.ticketHash)
 		// Broadcasted, but not confirmed.


### PR DESCRIPTION
The "received" status is expected during normal operation. The wallet should not just log a warning, it should handle this status the same was as the "broadcast" status - continue waiting for the status to update to "confirmed".