### PR TITLE
Fix grammar in the sample config

### DIFF
--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -50,7 +50,7 @@
 ; The server and port used for dcrd websocket connections.
 ; rpcconnect=localhost:9109
 
-; File containing root certificates to authenticate a TLS connections with dcrd
+; File containing root certificates to authenticate TLS connections with dcrd
 ; cafile=~/.dcrwallet/dcrd.cert
 
 


### PR DESCRIPTION
It should read "authenticate a TLS connection" or "authenticate TLS
connections".  We choose the latter since multiple connections may be
established during program lifetime.