### PR TITLE
check for password when running buyer

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1411,8 +1411,6 @@ func (s *walletServer) ChangePassphrase(ctx context.Context, req *pb.ChangePassp
 func (s *walletServer) SignTransaction(ctx context.Context, req *pb.SignTransactionRequest) (
 	*pb.SignTransactionResponse, error) {
 
-	defer zero(req.Passphrase)
-
 	var tx wire.MsgTx
 	err := tx.Deserialize(bytes.NewReader(req.SerializedTransaction))
 	if err != nil {
@@ -1424,6 +1422,7 @@ func (s *walletServer) SignTransaction(ctx context.Context, req *pb.SignTransact
 		lock := make(chan time.Time, 1)
 		defer func() {
 			lock <- time.Time{} // send matters, not the value
+			zero(req.Passphrase)
 		}()
 		err = s.wallet.Unlock(ctx, req.Passphrase, lock)
 		if err != nil {

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -76,9 +76,11 @@ func New(w *wallet.Wallet) *TB {
 // ever becomes incorrect due to a wallet passphrase change, Run exits with an
 // errors.Passphrase error.
 func (tb *TB) Run(ctx context.Context, passphrase []byte) error {
-	err := tb.wallet.Unlock(ctx, passphrase, nil)
-	if err != nil {
-		return err
+	if len(passphrase) > 0 {
+		err := tb.wallet.Unlock(ctx, passphrase, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	c := tb.wallet.NtfnServer.MainTipChangedNotifications()
@@ -211,12 +213,14 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 		return err
 	}
 
-	// Ensure wallet is unlocked with the current passphrase.  If the passphase
-	// is changed, the Run exits and TB must be restarted with the new
-	// passphrase.
-	err = w.Unlock(ctx, passphrase, nil)
-	if err != nil {
-		return err
+	if len(passphrase) > 0 {
+		// Ensure wallet is unlocked with the current passphrase.  If the passphase
+		// is changed, the Run exits and TB must be restarted with the new
+		// passphrase.
+		err = w.Unlock(ctx, passphrase, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Read config


### PR DESCRIPTION
This PR checks for password when running the buyer. This is necessary for sending grpc commands without the password.

This is needed for running ticket buyer or account mixer, without sending the passphrase through grpc