### PR TITLE
Split a single UTXO into two outputs for VSP ticket purchasing

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -3387,6 +3387,11 @@ func (s *Store) MakeInputSource(ns, addrmgrNs walletdb.ReadBucket, account uint3
 			}
 
 			op.Tree = tree
+
+			if ignore != nil && ignore(&op) {
+				continue
+			}
+
 			input := wire.NewTxIn(&op, int64(amt), nil)
 			var scriptSize int
 


### PR DESCRIPTION
When a wallet account only contains a single UTXO, it is not possible
to perform VSP ticket purchasing, because at least two UTXOs are
required: one to fund the ticket purchase, and a second to pay the
VSP.  When UTXO exhaustion is detected during a ticket purchasing
attempt with a VSP configured, attempt to split a UTXO into two
outputs, followed by a reattempted ticket purchase.

The ticket purchase reattempt must be done with a zero minconf policy,
since it still uses the normal UTXO selection instead of precisely
using the newly created outputs from the extra split transaction.
This is not ideal, and may also result in spending other unconfirmed
outputs in the account that were not considered earlier during the
failed purchase attempt.