### PR TITLE
[release-v1.6] UTXO selection fixes for unpublished outputs

### DIFF
--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -1108,6 +1108,11 @@ func (s *Store) moveMinedTx(ns walletdb.ReadWriteBucket, addrmgrNs walletdb.Read
 		return err
 	}
 
+	err = deleteUnpublished(ns, rec.Hash[:])
+	if err != nil {
+		return err
+	}
+
 	return deleteRawUnmined(ns, rec.Hash[:])
 }
 
@@ -2285,12 +2290,6 @@ func (s *Store) UnspentOutputs(dbtx walletdb.ReadTx) ([]*Credit, error) {
 			continue
 		}
 
-		// Skip outputs from unpublished transactions.
-		txHash := k[:32]
-		if existsUnpublished(ns, txHash) {
-			continue
-		}
-
 		err = readUnspentBlock(v, &block)
 		if err != nil {
 			c.Close()
@@ -2312,6 +2311,12 @@ func (s *Store) UnspentOutputs(dbtx walletdb.ReadTx) ([]*Credit, error) {
 		if existsRawUnminedInput(ns, k) != nil {
 			// Output is spent by an unmined transaction.
 			// Skip to next unmined credit.
+			continue
+		}
+
+		// Skip outputs from unpublished transactions.
+		txHash := k[:32]
+		if existsUnpublished(ns, txHash) {
 			continue
 		}
 
@@ -2356,12 +2361,6 @@ func (s *Store) ForEachUnspentOutpoint(dbtx walletdb.ReadTx, f func(*wire.OutPoi
 			continue
 		}
 
-		// Skip outputs from unpublished transactions.
-		txHash := k[:32]
-		if existsUnpublished(ns, txHash) {
-			continue
-		}
-
 		block := new(Block)
 		err = readUnspentBlock(v, block)
 		if err != nil {
@@ -2387,6 +2386,12 @@ func (s *Store) ForEachUnspentOutpoint(dbtx walletdb.ReadTx, f func(*wire.OutPoi
 		if existsRawUnminedInput(ns, k) != nil {
 			// Output is spent by an unmined transaction.
 			// Skip to next unmined credit.
+			continue
+		}
+
+		// Skip outputs from unpublished transactions.
+		txHash := k[:32]
+		if existsUnpublished(ns, txHash) {
 			continue
 		}
 


### PR DESCRIPTION
When selecting UTXOs, skip over those unmined transactions which are
marked unpublished, not mined transactions.

Unset a transaction from being marked unpublished if it is moved from
the unmined buckets to the mined transaction buckets.