### PR TITLE
Zero change value when change cannot be included

### DIFF
--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -155,7 +155,7 @@ SplitPoints:
 				if remValue < fee {
 					continue
 				}
-				changeValue = remValue - fee
+				changeValue = 0
 			}
 			if txrules.IsDustAmount(changeValue, P2PKHv0Len, feeRate) {
 				changeValue = 0


### PR DESCRIPTION
This would be eventually be fixed during the dust check, but it's
clearer to just leave it zero, as we expect no change at all.