### PR TITLE
Fix output mixing from using lowest denom with insane fees

### DIFF
--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -105,6 +105,7 @@ func (w *Wallet) MixOutput(ctx context.Context, dialTLS DialFunc, csppserver str
 SplitPoints:
 	for i = 0; i < len(splitPoints); i++ {
 		last := i == len(splitPoints)-1
+		mixValue = splitPoints[i]
 
 		// When the sdiff is more than this mixed output amount, there
 		// is a smaller common mixed amount with more pairing activity
@@ -118,7 +119,6 @@ SplitPoints:
 			continue
 		}
 
-		mixValue = splitPoints[i]
 		count = int(amount / mixValue)
 		if count > 4 {
 			count = 4


### PR DESCRIPTION
The mixValue variable was not being assigned to the expected value in
the splitPoints array, causing the loop to skip to the last common mix
denomination and result in an insane fee contributed to the coinjoin
transaction due to the mixed output count being limited to a maximum
of four per input.

Fixes #2000.