### PR TITLE
Perform low-fee check for smallest mix denom

### DIFF
--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -145,7 +145,7 @@ SplitPoints:
 			if last {
 				changeValue = 0
 			}
-			if changeValue < 0 {
+			if changeValue <= 0 {
 				// Determine required fee without a change
 				// output.  A lower mix count or amount is
 				// required if the fee is still not payable.


### PR DESCRIPTION
The low fee check was not being performed after iterating down to the
lowest mix amount.  This resulted in low-fee submissions to the
CoinShuffle++ server, which are now being rejected as an invalid
submission.