### PR TITLE
Implement nofilelogging config flag

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -93,6 +93,9 @@ func run(ctx context.Context) error {
 	// Show version at startup.
 	log.Infof("Version %s (Go version %s %s/%s)", version.String(), runtime.Version(),
 		runtime.GOOS, runtime.GOARCH)
+	if cfg.NoFileLogging {
+		log.Info("File logging disabled")
+	}
 
 	// Read IPC messages from the read end of a pipe created and passed by the
 	// parent process, if any.  When this pipe is closed, shutdown is

--- a/log.go
+++ b/log.go
@@ -31,7 +31,9 @@ type logWriter struct{}
 
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
-	logRotator.Write(p)
+	if logRotator != nil {
+		logRotator.Write(p)
+	}
 	return len(p), nil
 }
 


### PR DESCRIPTION
This works the same as dcrd's flag by the same name.  When enabled,
logs will only be written to standard output, and not to any log files
managed by dcrwallet itself.

Of course, persistent logs are useful, so any production setup using
this flag is expected to capture standard output and redirect it to
syslogd, the systemd journal, etc.