### PR TITLE
Move package-global VSP client map to loader package

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -278,7 +278,7 @@ func run(ctx context.Context) error {
 					ChangeAcct: changeAcct,
 				},
 			}
-			vspClient, err = vsp.New(vspCfg)
+			vspClient, err = ldr.VSP(vspCfg)
 			if err != nil {
 				log.Errorf("vsp: %v", err)
 				return err

--- a/internal/loader/vsp.go
+++ b/internal/loader/vsp.go
@@ -1,0 +1,47 @@
+package loader
+
+import (
+	"sync"
+
+	"decred.org/dcrwallet/v2/errors"
+	"decred.org/dcrwallet/v2/internal/vsp"
+)
+
+var vspClients = struct {
+	mu      sync.Mutex
+	clients map[string]*vsp.Client
+}{
+	clients: make(map[string]*vsp.Client),
+}
+
+// VSP loads or creates a package-global instance of the VSP client for a host.
+// This allows clients to be created and reused across various subsystems.
+func VSP(cfg vsp.Config) (*vsp.Client, error) {
+	key := cfg.URL
+	vspClients.mu.Lock()
+	defer vspClients.mu.Unlock()
+	client, ok := vspClients.clients[key]
+	if ok {
+		return client, nil
+	}
+	client, err := vsp.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	vspClients.clients[key] = client
+	return client, nil
+}
+
+// LookupVSP returns a previously-configured VSP client, if one has been created
+// and registered with the VSP function.  Otherwise, a NotExist error is
+// returned.
+func LookupVSP(host string) (*vsp.Client, error) {
+	vspClients.mu.Lock()
+	defer vspClients.mu.Unlock()
+	client, ok := vspClients.clients[host]
+	if !ok {
+		err := errors.Errorf("VSP client for %q not found", host)
+		return nil, errors.E(errors.NotExist, err)
+	}
+	return client, nil
+}


### PR DESCRIPTION
Add to the map when the VSP client is created for the ticket autobuyer
with the global application settings.

This will be used by an upcoming change to the JSON-RPC server to
allow voting preferences to be set and updated through this server.
Currently, it is only possible to modify VSP voting preferences for
registered tickets through the gRPC server.