### PR TITLE
Set VSP choices from setvotechoices JSON-RPC method

### DIFF
--- a/internal/rpc/jsonrpc/config.go
+++ b/internal/rpc/jsonrpc/config.go
@@ -22,4 +22,6 @@ type Options struct {
 	MixAccount       string
 	MixBranch        uint32
 	MixChangeAccount string
+
+	VSPHost string
 }

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -369,6 +369,7 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 			MixAccount:          cfg.mixedAccount,
 			MixBranch:           cfg.mixedBranch,
 			MixChangeAccount:    cfg.ChangeAccount,
+			VSPHost:             cfg.VSPOpts.URL,
 		}
 		jsonrpcServer = jsonrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
 		for _, lis := range listeners {


### PR DESCRIPTION
There was previously no way using dcrwallet to update the choices for
VSP-bought tickets through the command line autobuyer.  This fixes
this, by performing the API call(s) whenever vote choices are set
using the setvotechoices method, and a VSP host is configured in the
dcrwallet settings.
