### PR TITLE
Add missing locking for UTXOs, locked outputs

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -482,6 +482,9 @@ func (w *Wallet) recordAuthoredTx(ctx context.Context, op errors.Op, a *authorTx
 		return errors.E(op, err)
 	}
 
+	w.lockedOutpointMu.Lock()
+	defer w.lockedOutpointMu.Unlock()
+
 	// To avoid a race between publishing a transaction and potentially opening
 	// a database view during PublishTransaction, the update must be committed
 	// before publishing the transaction to the network.


### PR DESCRIPTION
recordAuthoredTx records a transaction to the database, which requires
the mutex to be acquired prior to opening the database transaction.
Without this added locking, a data race from both reading and writing
to the w.lockedOutpoints map is possible.