### PR TITLE
Improve heuristic for creating additional split tx

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1524,18 +1524,17 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 				req.Count--
 			}
 			vspFeeCredits = credits
+			var remaining int64
 			for _, c := range vspFeeCredits {
+				remaining += total(c)
 				for i := range c {
 					w.LockOutpoint(&c[i].OutPoint.Hash, c[i].OutPoint.Index)
 				}
 			}
 
 			if req.Count < 2 && extraSplit {
-				var remaining int64
-				if len(vspFeeCredits) > 0 {
-					remaining = total(vspFeeCredits[0])
-				}
-				if int64(ticketPrice) > remaining { // XXX still a bad estimate
+				// XXX still a bad estimate
+				if int64(ticketPrice) > freedBalance+remaining {
 					return nil, errors.E(errors.InsufficientBalance)
 				}
 				// A new transaction may need to be created to


### PR DESCRIPTION
When the additional split transaction must be created, the total
balance from the account that had been reserved for all fee txs and
all ticket purchases can be summed together, to determine if it is
enough to create the additional split transaction.  Previously, only
the partial balance of some of the selected inputs were being used,
and this had been triggering an unnecessary insufficient balance error
when attempting to create the additional split transaction would have
been a better idea.