### PR TITLE
Use wallet-provided inputs for paying VSP fee

### DIFF
--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -224,7 +224,11 @@ func (c *Client) ProcessWithPolicy(ctx context.Context, ticketHash *chainhash.Ha
 	if fp == nil {
 		return fmt.Errorf("fee payment cannot be processed")
 	}
-
+	fp.mu.Lock()
+	if fp.feeTx == nil {
+		fp.feeTx = feeTx
+	}
+	fp.mu.Unlock()
 	err := fp.receiveFeeAddress()
 	if err != nil {
 		// XXX, retry? (old Process retried)
@@ -235,9 +239,6 @@ func (c *Client) ProcessWithPolicy(ctx context.Context, ticketHash *chainhash.Ha
 	err = fp.makeFeeTx(feeTx)
 	if err != nil {
 		return err
-	}
-	if feeTx != nil {
-		*feeTx = *fp.feeTx
 	}
 	return fp.submitPayment()
 }


### PR DESCRIPTION
The vsp package contained a bug where the partial transaction provided
by the wallet package through a callback function was being completely
ignored, and a new fee tx was being constructed from scratch.  This
caused two bugs:

1. The inputs selected by the wallet, specifically for paying the VSP
   fee, were not being used.  This could result in these inputs not being
   spent, and remaining locked.

2. If the VSP client was configured with an account policy that
   differed from the purchase tickets request used by the wallet, the VSP
   fee would be paid out of the wrong account.  This also had the
   potential to break privacy guarantees in mixing wallets, by possibly
   correlating mixed funds with change.

This change fixes this bug by always using the provided transaction
inputs for constructing the fee transaction.