### PR TITLE
Do not record nil feePayment in jobs map

### DIFF
--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -185,6 +185,9 @@ func (c *Client) feePayment(ticketHash *chainhash.Hash, policy Policy) (fp *feeP
 	}
 
 	defer func() {
+		if fp == nil {
+			return
+		}
 		c.mu.Lock()
 		fp2 := c.jobs[*ticketHash]
 		if fp2 != nil {


### PR DESCRIPTION
I had this in an earlier version of the previous commit but removed it
because fp was being unconditionally set to a non-nil struct.
However, some of the early returns will return nil, and this will
modify the returned fp variable which is closed over by the deferred
function.