### PR TITLE
vspclient: More fixes for vsp fee confirmation tracking

### DIFF
--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -896,7 +896,6 @@ func (fp *feePayment) submitPayment() (err error) {
 				log.Errorf("error abandoning expired fee tx %v", err)
 			}
 			fp.feeTx = nil
-			fp.submitPayment()
 		}
 		return fmt.Errorf("payfee: %w", err)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5481,6 +5481,9 @@ func (w *Wallet) VSPFeeHashForTicket(ctx context.Context, ticketHash *chainhash.
 		feeHash = data.FeeHash
 		return nil
 	})
+	if err == nil && feeHash == (chainhash.Hash{}) {
+		err = errors.E(errors.NotExist)
+	}
 	return feeHash, err
 }
 


### PR DESCRIPTION
This includes the following fixes for vspClient tracking:
- Schedule all fee payments for reconcile payment, regardless of fee tx status.
- Remove unvotable tickets from jobs and attempt to revoke tickets
- Catch signature errors from SignTransaction attempt
- Handle payfee error for expired fee tx from vspd.  Abandon current fee tx and then retry to make a fresh one.