### PR TITLE
createtx: Add change output to size estimation.

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -629,11 +629,12 @@ func (w *Wallet) txToMultisigInternal(ctx context.Context, op errors.Op, dbtx wa
 	}
 	msgtx.AddTxOut(txOut)
 
-	// Add change if we need it. The case in which
-	// totalInput == amount+feeEst is skipped because
-	// we don't need to add a change output in this
-	// case.
-	feeSize := txsizes.EstimateSerializeSize(scriptSizes, msgtx.TxOut, 0)
+	// Add change if we need it.
+	changeSize := 0
+	if totalInput > amount+feeEstForTx {
+		changeSize = txsizes.P2PKHPkScriptSize
+	}
+	feeSize := txsizes.EstimateSerializeSize(scriptSizes, msgtx.TxOut, changeSize)
 	feeEst := txrules.FeeForSerializeSize(w.RelayFee(), feeSize)
 
 	if totalInput < amount+feeEst {


### PR DESCRIPTION
    A multisig transaction will sometimes need a change output. Add that
    scipt size to the worst case size estimation that is used in fee
    calculation.

closes #1972