### PR TITLE
dcrwallet: Set up vsp client if url provided.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -246,7 +246,7 @@ func run(ctx context.Context) error {
 			passphrase = startPromptPass(ctx, w)
 		}
 
-		if cfg.EnableTicketBuyer && cfg.VSPOpts.URL != "" {
+		if cfg.VSPOpts.URL != "" {
 			changeAccountName := cfg.ChangeAccount
 			if changeAccountName == "" && cfg.CSPPServer == "" {
 				log.Warnf("Change account not set, using "+
@@ -420,7 +420,7 @@ func run(ctx context.Context) error {
 		}
 
 		loader.RunAfterLoad(func(w *wallet.Wallet) {
-			if cfg.VSPOpts.Sync {
+			if vspClient != nil && cfg.VSPOpts.Sync {
 				vspClient.ProcessManagedTickets(ctx, vspClient.Policy)
 			}
 


### PR DESCRIPTION
    Remove the dependency of the ticketbuyer being on. This allows
    processing already bought tickets when the ticketbuyer is off.

closes #1913