### PR TITLE
Reorganize prng and shuffle code into rand.go

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -901,10 +901,7 @@ func (w *Wallet) VoteOnOwnedTickets(ctx context.Context, winningTicketHashes []*
 				if w.chainParams.Net == wire.MainNet {
 					log.Warnf("block disapprove percent set on mainnet")
 				} else {
-					randSourceMu.Lock()
-					ranN := randSource.Int63n(100)
-					randSourceMu.Unlock()
-					if int64(dp) > ranN {
+					if int64(dp) > randInt63n(100) {
 						log.Infof("Disapproving block %v voted with ticket %v",
 							blockHash, ticketHash)
 						// Set the BlockValid bit to zero,

--- a/wallet/common.go
+++ b/wallet/common.go
@@ -5,30 +5,12 @@
 package wallet
 
 import (
-	"crypto/rand"
-	"sync"
 	"time"
 
-	"decred.org/dcrwallet/v2/internal/uniformprng"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
-)
-
-func init() {
-	var err error
-	randSource, err = uniformprng.RandSource(rand.Reader)
-	if err != nil {
-		panic(err)
-	}
-}
-
-var (
-	// randSource is a source of randomness. randSourceMu must be held when
-	// using.
-	randSourceMu sync.Mutex
-	randSource   *uniformprng.Source
 )
 
 // Note: The following common types should never reference the Wallet type.


### PR DESCRIPTION
Add a helper function to call Int63n with the prng mutex held, so
locking does not need to be performed manually in deeper wallet code.