### PR TITLE
Don't attempt to vote/revoke without the private key

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -879,12 +879,12 @@ func (w *Wallet) VoteOnOwnedTickets(ctx context.Context, winningTicketHashes []*
 			}
 
 			// Don't create votes when this wallet doesn't have voting
-			// authority.
-			owned, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
+			// authority or the private key to vote.
+			owned, haveKey, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
 			if err != nil {
 				return err
 			}
-			if !owned {
+			if !(owned && haveKey) {
 				continue
 			}
 
@@ -1090,12 +1090,12 @@ func (w *Wallet) RevokeOwnedTickets(ctx context.Context, missedTicketHashes []*c
 			}
 
 			// Don't create revocations when this wallet doesn't have voting
-			// authority.
-			owned, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
+			// authority or the private key to revoke.
+			owned, haveKey, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
 			if err != nil {
 				return err
 			}
-			if !owned {
+			if !(owned && haveKey) {
 				continue
 			}
 

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -266,12 +266,12 @@ func (w *Wallet) RevokeTickets(ctx context.Context, rpcCaller Caller) error {
 			}
 
 			// Don't create revocations when this wallet doesn't have voting
-			// authority.
-			owned, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
+			// authority or the private key to revoke.
+			owned, haveKey, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
 			if err != nil {
 				return err
 			}
-			if !owned {
+			if !(owned && haveKey) {
 				continue
 			}
 
@@ -376,12 +376,12 @@ func (w *Wallet) RevokeExpiredTickets(ctx context.Context, p Peer) (err error) {
 			}
 
 			// Don't create revocations when this wallet doesn't have voting
-			// authority.
-			owned, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
+			// authority or the private key to revoke.
+			owned, haveKey, err := w.hasVotingAuthority(addrmgrNs, ticketPurchase)
 			if err != nil {
 				return err
 			}
-			if !owned {
+			if !(owned && haveKey) {
 				continue
 			}
 


### PR DESCRIPTION
This error is commonly seen on ticketbuyer wallets which will attempt
to revoke any missed tickets, even though an importing voting xpub
account prevents access to the private keys to do so.  This is not an
error, and should be detected up front before ever constructing the
unsigned vote/revocation.

When the private key is recorded by the wallet, but the wallet or
account is locked, the wallet will still error when failing to sign
the revocation.