### PR TITLE
Normalize addresses in HavePrivateKey

### DIFF
--- a/wallet/udb/addressmanager.go
+++ b/wallet/udb/addressmanager.go
@@ -2325,7 +2325,7 @@ func (m *Manager) HavePrivateKey(ns walletdb.ReadBucket, addr stdaddr.Address) (
 		return false, nil
 	}
 
-	id, err := addressID(addr)
+	id, err := addressID(normalizeAddress(addr))
 	if err != nil {
 		return false, nil
 	}


### PR DESCRIPTION
The documentation states this works with P2PK addresses, but it did
not because P2PK addrs were not being normalized to their P2PKH form.