### PR TITLE
[jsonrpc] Add mixing and VSP to purchaseticket

### DIFF
--- a/internal/rpc/jsonrpc/config.go
+++ b/internal/rpc/jsonrpc/config.go
@@ -17,11 +17,13 @@ type Options struct {
 	MaxPOSTClients      int64
 	MaxWebsocketClients int64
 
-	CSPPServer       string
-	DialCSPPServer   func(ctx context.Context, network, addr string) (net.Conn, error)
-	MixAccount       string
-	MixBranch        uint32
-	MixChangeAccount string
+	CSPPServer         string
+	DialCSPPServer     func(ctx context.Context, network, addr string) (net.Conn, error)
+	MixAccount         string
+	MixBranch          uint32
+	MixChangeAccount   string
+	TicketSplitAccount string
 
-	VSPHost string
+	VSPHost   string
+	VSPPubKey string
 }

--- a/internal/rpc/jsonrpc/config.go
+++ b/internal/rpc/jsonrpc/config.go
@@ -26,4 +26,5 @@ type Options struct {
 
 	VSPHost   string
 	VSPPubKey string
+	Dial      func(ctx context.Context, network, addr string) (net.Conn, error)
 }

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3248,7 +3248,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		cfg := vsp.Config{
 			URL:    vspHost,
 			PubKey: vspPubKey,
-			Dialer: nil,
+			Dialer: s.cfg.Dial,
 			Wallet: w,
 			Policy: vsp.Policy{
 				MaxFee:     0.1e8,

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -23,6 +23,7 @@ import (
 
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/internal/loader"
+	"decred.org/dcrwallet/v2/internal/vsp"
 	"decred.org/dcrwallet/v2/p2p"
 	"decred.org/dcrwallet/v2/rpc/client/dcrd"
 	"decred.org/dcrwallet/v2/rpc/jsonrpc/types"
@@ -48,6 +49,8 @@ import (
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // API version constants
@@ -3200,6 +3203,65 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		dontSignTx = *cmd.DontSignTx
 	}
 
+	var csppServer string
+	var mixedAccount uint32
+	var mixedAccountBranch uint32
+	var mixedSplitAccount uint32
+	var changeAccount = account
+
+	if s.cfg.CSPPServer != "" {
+		csppServer = s.cfg.CSPPServer
+		mixedAccount, err = w.AccountNumber(ctx, s.cfg.MixAccount)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"CSPP Server set, but error on mixed account: %v", err)
+		}
+		mixedAccountBranch = s.cfg.MixBranch
+		if mixedAccountBranch != 0 && mixedAccountBranch != 1 {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"MixedAccountBranch should be 0 or 1.")
+		}
+		_, err = w.AccountNumber(ctx, s.cfg.TicketSplitAccount)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"CSPP Server set, but error on mixedSplitAccount: %v", err)
+		}
+		_, err = w.AccountNumber(ctx, s.cfg.MixChangeAccount)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument,
+				"CSPP Server set, but error on changeAccount: %v", err)
+		}
+	}
+
+	var vspHost string
+	var vspPubKey string
+	var vspClient *vsp.Client
+	if s.cfg.VSPHost != "" || s.cfg.VSPPubKey != "" {
+		vspHost = s.cfg.VSPHost
+		vspPubKey = s.cfg.VSPPubKey
+		if vspPubKey == "" {
+			return nil, status.Errorf(codes.InvalidArgument, "vsp pubkey can not be null")
+		}
+		if vspHost == "" {
+			return nil, status.Errorf(codes.InvalidArgument, "vsp host can not be null")
+		}
+		cfg := vsp.Config{
+			URL:    vspHost,
+			PubKey: vspPubKey,
+			Dialer: nil,
+			Wallet: w,
+			Policy: vsp.Policy{
+				MaxFee:     0.1e8,
+				FeeAcct:    account,
+				ChangeAcct: changeAccount,
+			},
+		}
+		vspClient, err = loader.VSP(cfg)
+		if err != nil {
+			return nil, status.Errorf(codes.Unknown, "VSP Server instance failed to start: %v", err)
+		}
+	}
+
 	request := &wallet.PurchaseTicketsRequest{
 		Count:         numTickets,
 		SourceAccount: account,
@@ -3209,7 +3271,21 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		DontSignTx:    dontSignTx,
 		VSPAddress:    poolAddr,
 		VSPFees:       poolFee,
+
+		// CSPP
+		CSPPServer:         csppServer,
+		DialCSPPServer:     s.cfg.DialCSPPServer,
+		MixedAccount:       mixedAccount,
+		MixedAccountBranch: mixedAccountBranch,
+		MixedSplitAccount:  mixedSplitAccount,
+		ChangeAccount:      changeAccount,
 	}
+
+	if vspClient != nil {
+		request.VSPFeePaymentProcess = vspClient.Process
+		request.VSPFeeProcess = vspClient.FeePercentage
+	}
+
 	ticketsResponse, err := w.PurchaseTickets(ctx, n, request)
 	if err != nil {
 		return nil, err

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -21,9 +21,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/internal/loader"
 	"decred.org/dcrwallet/v2/internal/vsp"
@@ -3214,22 +3211,22 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		csppServer = s.cfg.CSPPServer
 		mixedAccount, err = w.AccountNumber(ctx, s.cfg.MixAccount)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
 				"CSPP Server set, but error on mixed account: %v", err)
 		}
 		mixedAccountBranch = s.cfg.MixBranch
 		if mixedAccountBranch != 0 && mixedAccountBranch != 1 {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
 				"MixedAccountBranch should be 0 or 1.")
 		}
 		_, err = w.AccountNumber(ctx, s.cfg.TicketSplitAccount)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
 				"CSPP Server set, but error on mixedSplitAccount: %v", err)
 		}
 		_, err = w.AccountNumber(ctx, s.cfg.MixChangeAccount)
 		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument,
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
 				"CSPP Server set, but error on changeAccount: %v", err)
 		}
 	}
@@ -3241,10 +3238,12 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		vspHost = s.cfg.VSPHost
 		vspPubKey = s.cfg.VSPPubKey
 		if vspPubKey == "" {
-			return nil, status.Errorf(codes.InvalidArgument, "vsp pubkey can not be null")
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
+				"vsp pubkey can not be null")
 		}
 		if vspHost == "" {
-			return nil, status.Errorf(codes.InvalidArgument, "vsp host can not be null")
+			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
+				"vsp host can not be null")
 		}
 		cfg := vsp.Config{
 			URL:    vspHost,
@@ -3259,7 +3258,8 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 		}
 		vspClient, err = loader.VSP(cfg)
 		if err != nil {
-			return nil, status.Errorf(codes.Unknown, "VSP Server instance failed to start: %v", err)
+			return nil, rpcErrorf(dcrjson.ErrRPCMisc,
+				"VSP Server instance failed to start: %v", err)
 		}
 	}
 

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -21,6 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/internal/loader"
 	"decred.org/dcrwallet/v2/internal/vsp"
@@ -49,8 +52,6 @@ import (
 	"github.com/decred/dcrd/txscript/v4/stdaddr"
 	"github.com/decred/dcrd/wire"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // API version constants

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -372,6 +372,7 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 			VSPHost:             cfg.VSPOpts.URL,
 			VSPPubKey:           cfg.VSPOpts.PubKey,
 			TicketSplitAccount:  cfg.TicketSplitAccount,
+			Dial:                cfg.dial,
 		}
 		jsonrpcServer = jsonrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
 		for _, lis := range listeners {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -370,6 +370,8 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 			MixBranch:           cfg.mixedBranch,
 			MixChangeAccount:    cfg.ChangeAccount,
 			VSPHost:             cfg.VSPOpts.URL,
+			VSPPubKey:           cfg.VSPOpts.PubKey,
+			TicketSplitAccount:  cfg.TicketSplitAccount,
 		}
 		jsonrpcServer = jsonrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
 		for _, lis := range listeners {


### PR DESCRIPTION
Previously, the jsonrpc purchaseticket request would simply use the provided account in the request and purchase a ticket without mixing or VSP processing, no matter what the user has set in their options.  Now the options that they have set will be used.