### PR TITLE
Use last returned key counts in grpc Accounts response

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -357,11 +357,12 @@ func (s *walletServer) Accounts(ctx context.Context, req *pb.AccountsRequest) (*
 	for i := range resp.Accounts {
 		a := &resp.Accounts[i]
 		accounts[i] = &pb.AccountsResponse_Account{
-			AccountNumber:    a.AccountNumber,
-			AccountName:      a.AccountName,
-			TotalBalance:     int64(a.TotalBalance),
-			ExternalKeyCount: a.LastUsedExternalIndex + 20, // Add gap limit
-			InternalKeyCount: a.LastUsedInternalIndex + 20,
+			AccountNumber: a.AccountNumber,
+			AccountName:   a.AccountName,
+			TotalBalance:  int64(a.TotalBalance),
+			// indexes are zero based, add 1 for the count
+			ExternalKeyCount: a.LastReturnedExternalIndex + 1,
+			InternalKeyCount: a.LastReturnedInternalIndex + 1,
 			ImportedKeyCount: a.ImportedKeyCount,
 			AccountEncrypted: a.AccountEncrypted,
 			AccountUnlocked:  a.AccountUnlocked,


### PR DESCRIPTION
The last returned counts are more useful as they indicate the true
number of keys derived for an account, rather than the last one that
has been marked as used.

While here, remove the hardcoded addition of 20 for the gap limit.
The gap limit is configurable so this hack was incorrect.

A later commit can add additional fields to this message to include
the last address index marked used, under a more appropriate field
name.