### PR TITLE
Bump the last watched indexes of HD accounts

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -930,7 +930,23 @@ func (w *Wallet) watchHDAddrs(ctx context.Context, firstWatch bool, n NetworkBac
 		return 0, deriveError
 	}
 	err = <-watchError
-	return count, err
+	if err != nil {
+		return 0, err
+	}
+
+	w.addressBuffersMu.Lock()
+	for acct, hd := range hdAccounts {
+		ad := w.addressBuffers[acct]
+		if ad.albExternal.lastWatched < hd.externalCount {
+			ad.albExternal.lastWatched = hd.externalCount
+		}
+		if ad.albInternal.lastWatched < hd.internalCount {
+			ad.albInternal.lastWatched = hd.internalCount
+		}
+	}
+	w.addressBuffersMu.Unlock()
+
+	return count, nil
 }
 
 // CoinType returns the active BIP0044 coin type. For watching-only wallets,


### PR DESCRIPTION
The last watched indexes were never being increased except on the very
first call to watchHDAddrs during the wallet sync.  Because this index
is used as the starting point for watching new addresses, the wallet
would increasingly watch more and more of the same addresses each
time, sending each of these in a series of 'loadtxfilter' calls to
dcrd.  This was bottlenecking block processing on long-running
heavily-used wallets which create and watch many addresses (especially
in the case of mixing ticketbuyers).

There are still some duplicate addresses being watched, but this
prevents the worst case situation of what is effectively a memory leak
of data that gets sent over the network on every new derived address.