### PR TITLE
Add logsize config option.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 
 	"decred.org/dcrwallet/v2/errors"
@@ -39,6 +40,7 @@ const (
 	defaultLogLevel                = "info"
 	defaultLogDirname              = "logs"
 	defaultLogFilename             = "dcrwallet.log"
+	defaultLogSize                 = "10M"
 	defaultRPCMaxClients           = 10
 	defaultRPCMaxWebsockets        = 25
 	defaultAuthType                = "basic"
@@ -84,6 +86,7 @@ type config struct {
 	NoInitialLoad      bool                    `long:"noinitialload" description:"Defer wallet creation/opening on startup and enable loading wallets over RPC"`
 	DebugLevel         string                  `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	LogDir             *cfgutil.ExplicitString `long:"logdir" description:"Directory to log output."`
+	LogSize            string                  `long:"logsize" description:"Maximum size of log file before it is rotated"`
 	NoFileLogging      bool                    `long:"nofilelogging" description:"Disable file logging"`
 	Profile            []string                `long:"profile" description:"Enable HTTP profiling this interface/port"`
 	MemProfile         string                  `long:"memprofile" description:"Write mem profile to the specified file"`
@@ -334,6 +337,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		ConfigFile:              cfgutil.NewExplicitString(defaultConfigFile),
 		AppDataDir:              cfgutil.NewExplicitString(defaultAppDataDir),
 		LogDir:                  cfgutil.NewExplicitString(defaultLogDir),
+		LogSize:                 defaultLogSize,
 		WalletPass:              wallet.InsecurePubPassphrase,
 		CAFile:                  cfgutil.NewExplicitString(""),
 		ClientCAFile:            cfgutil.NewExplicitString(defaultRPCClientCAFile),
@@ -474,9 +478,41 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		cfg.LogDir.Value = filepath.Join(cfg.LogDir.Value,
 			activeNet.Params.Name)
 
+		var units int
+		for i, r := range cfg.LogSize {
+			if r < '0' || r > '9' {
+				units = i
+				break
+			}
+		}
+		invalidSize := func() error {
+			str := "%s: Invalid logsize: %v "
+			err := errors.Errorf(str, funcName, cfg.LogSize)
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		if units == 0 {
+			return loadConfigError(invalidSize())
+		}
+		// Parsing a 32-bit number prevents 64-bit overflow after unit
+		// multiplication.
+		logsize, err := strconv.ParseInt(cfg.LogSize[:units], 10, 32)
+		if err != nil {
+			return loadConfigError(invalidSize())
+		}
+		switch cfg.LogSize[units:] {
+		case "k", "K", "KiB":
+		case "m", "M", "MiB":
+			logsize <<= 10
+		case "g", "G", "GiB":
+			logsize <<= 20
+		default:
+			return loadConfigError(invalidSize())
+		}
+
 		// Initialize log rotation.  After log rotation has been initialized, the
 		// logger variables may be used.
-		initLogRotator(filepath.Join(cfg.LogDir.Value, defaultLogFilename))
+		initLogRotator(filepath.Join(cfg.LogDir.Value, defaultLogFilename), logsize)
 	}
 
 	// Special show command to list supported subsystems and exit.

--- a/log.go
+++ b/log.go
@@ -95,16 +95,19 @@ var subsystemLoggers = map[string]slog.Logger{
 }
 
 // initLogRotator initializes the logging rotater to write logs to logFile and
-// create roll files in the same directory.  It must be called before the
-// package-global log rotater variables are used.
-func initLogRotator(logFile string) {
+// create roll files in the same directory.  logSize is the size in KiB after
+// which a log file will be rotated and compressed.
+//
+// This function must be called before the package-global log rotater variables
+// are used.
+func initLogRotator(logFile string, logSize int64) {
 	logDir, _ := filepath.Split(logFile)
 	err := os.MkdirAll(logDir, 0700)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 0)
+	r, err := rotator.New(logFile, logSize, false, 0)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
The logsize option enables configuration of the currently-hardcoded
value of 10MB log files before they are rotated and compressed.  The
default remains 10MB.

This is a string option and requires using a suffix such as KB, MB, or
GB to specify the units as kibibytes, mebibytes, or gibibytes.