### PR TITLE
Remove sync mechanism which held wallet unlocked

### DIFF
--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -65,8 +65,6 @@ func (w *Wallet) MixOutput(ctx context.Context, dialTLS DialFunc, csppserver str
 		return errors.E(op, err)
 	}
 
-	defer w.holdUnlock().release()
-
 	w.lockedOutpointMu.Lock()
 	if _, exists := w.lockedOutpoints[outpoint{output.Hash, output.Index}]; exists {
 		w.lockedOutpointMu.Unlock()
@@ -266,8 +264,6 @@ SplitPoints:
 // function may throttle how many of the outputs are mixed each call.
 func (w *Wallet) MixAccount(ctx context.Context, dialTLS DialFunc, csppserver string, changeAccount, mixAccount, mixBranch uint32) error {
 	const op errors.Op = "wallet.MixAccount"
-
-	defer w.holdUnlock().release()
 
 	_, tipHeight := w.MainChainTip(ctx)
 	w.lockedOutpointMu.Lock()


### PR DESCRIPTION
This mechanism has not worked properly ever since accounts have been
able to be individually encrypted with a separate passphrase, as it
only applied to the accounts covered by the wallet's global
passphrase.  It also appears to be the cause of at best a bad UX and
at worst a deadlock whenever an unlocked mixing wallet is locked.

Probably fixes #1984.