### PR TITLE
Change ticketbuyer.limit default to 1

### DIFF
--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ const (
 
 	// ticket buyer options
 	defaultBalanceToMaintainAbsolute = 0
+	defaultTicketbuyerLimit          = 1
 
 	walletDbName = "wallet.db"
 )
@@ -173,7 +174,7 @@ type ticketBuyerOptions struct {
 	BalanceToMaintainAbsolute *cfgutil.AmountFlag  `long:"balancetomaintainabsolute" description:"Amount of funds to keep in wallet when purchasing tickets"`
 	VotingAddress             *cfgutil.AddressFlag `long:"votingaddress" description:"Purchase tickets with voting rights assigned to this address"`
 	votingAddress             stdaddr.StakeAddress
-	Limit                     uint   `long:"limit" description:"Buy no more than specified number of tickets per block (0 disables limit)"`
+	Limit                     uint   `long:"limit" description:"Buy no more than specified number of tickets per block"`
 	VotingAccount             string `long:"votingaccount" description:"Account used to derive addresses specifying voting rights"`
 }
 
@@ -367,6 +368,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		TBOpts: ticketBuyerOptions{
 			BalanceToMaintainAbsolute: cfgutil.NewAmountFlag(defaultBalanceToMaintainAbsolute),
 			VotingAddress:             cfgutil.NewAddressFlag(),
+			Limit:                     defaultTicketbuyerLimit,
 		},
 
 		VSPOpts: vspOptions{


### PR DESCRIPTION
The previous default of 0 now prevents any ticketbuying from occurring
at all, due to changes with how multiple tickets bought per block are
done with separate CSPP clients and with separate UTXO sets.  Set this
to 1 so at least some ticketbuying still happens.  Increasing this
further will require users to increase the limit in their configs.