### PR TITLE
Add DisableDiscoverAccounts to syncers

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -94,6 +94,14 @@ func (s *Syncer) SetCallbacks(cb *Callbacks) {
 	s.cb = cb
 }
 
+// DisableDiscoverAccounts disables account discovery. This has an effect only
+// if called before the main Run() executes the account discovery process.
+func (s *Syncer) DisableDiscoverAccounts() {
+	s.mu.Lock()
+	s.discoverAccts = false
+	s.mu.Unlock()
+}
+
 // synced checks the atomic that controls wallet syncness and if previously
 // unsynced, updates to synced and notifies the callback, if set.
 func (s *Syncer) synced() {

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -137,6 +137,12 @@ func (s *Syncer) SetNotifications(ntfns *Notifications) {
 	s.notifications = ntfns
 }
 
+// DisableDiscoverAccounts disables account discovery. This has an effect only
+// if called before the main Run() executes the account discovery process.
+func (s *Syncer) DisableDiscoverAccounts() {
+	s.discoverAccounts = false
+}
+
 // synced checks the atomic that controls wallet syncness and if previously
 // unsynced, updates to synced and notifies the callback, if set.
 func (s *Syncer) synced() {


### PR DESCRIPTION
This allows client users of the wallet package to disable account
discovery if the syncer is started with the wallet already unlocked.

This happens (for example) in dcrlnd, where the wallet is always unlocked 
after being opened and thus the current code for the syncers
unconditionally performs account discovery every time.