### PR TITLE
multi: Return error when sending existing tx.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -7,6 +7,7 @@ package wallet
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -62,7 +63,7 @@ func (w *Wallet) extendMainChain(ctx context.Context, op errors.Op, dbtx walletd
 			return nil, errors.E(op, err)
 		}
 		ops, err := w.processTransactionRecord(ctx, dbtx, rec, header, &blockMeta)
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.Exist) {
 			return nil, errors.E(op, err)
 		}
 		watch = append(watch, ops...)
@@ -386,6 +387,9 @@ func (w *Wallet) AddTransaction(ctx context.Context, tx *wire.MsgTx, blockHash *
 		}
 
 		watchOutPoints, err = w.processTransactionRecord(ctx, dbtx, rec, header, meta)
+		if errors.Is(err, errors.Exist) {
+			return nil
+		}
 		return err
 	})
 	w.lockedOutpointMu.Unlock()
@@ -428,9 +432,11 @@ func (w *Wallet) processTransactionRecord(ctx context.Context, dbtx walletdb.Rea
 	if header == nil {
 		err = w.txStore.InsertMemPoolTx(dbtx, rec)
 		if errors.Is(err, errors.Exist) {
-			log.Warnf("Refusing to add unmined transaction %v since same "+
-				"transaction already exists mined", &rec.Hash)
-			return nil, nil
+			msg := fmt.Sprintf("Refusing to add unmined transaction "+
+				"%v since same transaction already exists mined",
+				&rec.Hash)
+			log.Warnf(msg)
+			return nil, errors.E(op, errors.Exist, msg)
 		}
 	} else {
 		err = w.txStore.InsertMinedTx(dbtx, rec, &blockMeta.Hash)
@@ -1031,7 +1037,7 @@ func (w *Wallet) VoteOnOwnedTickets(ctx context.Context, winningTicketHashes []*
 	err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 		for i := range voteRecords {
 			_, err := w.processTransactionRecord(ctx, dbtx, voteRecords[i], nil, nil)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return err
 			}
 		}
@@ -1172,7 +1178,7 @@ func (w *Wallet) RevokeOwnedTickets(ctx context.Context, missedTicketHashes []*c
 	err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 		for i := range revocationRecords {
 			_, err := w.processTransactionRecord(ctx, dbtx, revocationRecords[i], nil, nil)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return err
 			}
 		}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -501,6 +501,9 @@ func (w *Wallet) recordAuthoredTx(ctx context.Context, op errors.Op, a *authorTx
 		// relevant transactions, since this does a lot of extra work.
 		var err error
 		watch, err = w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
+		if errors.Is(err, errors.Exist) {
+			return nil
+		}
 		return err
 	})
 	if err != nil {
@@ -1583,6 +1586,9 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 			watch, err := w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
 			watchOutPoints = append(watchOutPoints, watch...)
+			if errors.Is(err, errors.Exist) {
+				return nil
+			}
 			return err
 		})
 		w.lockedOutpointMu.Unlock()
@@ -1712,7 +1718,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 
 			watch, err := w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
 			watchOutPoints = append(watchOutPoints, watch...)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return err
 			}
 

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -241,7 +241,7 @@ SplitPoints:
 			return errors.E(op, err)
 		}
 		watch, err = w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.Exist) {
 			return err
 		}
 		return nil

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -175,7 +175,7 @@ func (w *Wallet) SaveRescanned(ctx context.Context, hash *chainhash.Hash, txs []
 				return err
 			}
 			_, err = w.processTransactionRecord(context.Background(), dbtx, rec, header, &blockMeta)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return err
 			}
 		}

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -303,7 +303,7 @@ func (w *Wallet) RevokeTickets(ctx context.Context, rpcCaller Caller) error {
 			// Could be more efficient by avoiding processTransaction, as we
 			// know it is a revocation.
 			watch, err = w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return errors.E(op, err)
 			}
 			return rpc.PublishTransaction(ctx, revocation)
@@ -415,7 +415,7 @@ func (w *Wallet) RevokeExpiredTickets(ctx context.Context, p Peer) (err error) {
 				&rec.Hash)
 
 			watch, err := w.processTransactionRecord(ctx, dbtx, rec, nil, nil)
-			if err != nil {
+			if err != nil && !errors.Is(err, errors.Exist) {
 				return err
 			}
 			watchOutPoints = append(watchOutPoints, watch...)
@@ -495,7 +495,7 @@ func (w *Wallet) RevokeTicket(ctx context.Context, ticketHash *chainhash.Hash, p
 		// know it is a revocation.
 		watchOutPoints, err = w.processTransactionRecord(ctx, dbtx, rec, nil,
 			nil)
-		if err != nil {
+		if err != nil && !errors.Is(err, errors.Exist) {
 			return err
 		}
 		return nil


### PR DESCRIPTION
    In chainntfns return an error after logging when a processed transaction
    already exists. Change all call sites except the wallet publish
    transaction to ignore these errors to ensure previous behavior of
    ignoring.

closes #2080