### PR TITLE
jsonrpc: calculate mediantime in getblock and fix panic

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -1346,7 +1346,7 @@ func (s *Server) getBlock(ctx context.Context, icmd interface{}) (interface{}, e
 	}
 
 	// The coinbase must be version 3 once the treasury agenda is active.
-	isTreasuryEnabled := blk.Transactions[0].Version == wire.TxVersionTreasury
+	isTreasuryEnabled := blk.Transactions[0].Version >= wire.TxVersionTreasury
 
 	if cmd.VerboseTx == nil || !*cmd.VerboseTx {
 		transactions := blk.Transactions


### PR DESCRIPTION
In the `getblock` handler, this computes the `MedianTime` field for the block.

This also fixes a panic when detecting treasury activation prior to `StakeValidationHeight` when there are no stake transactions. It also now uses the coinbase transaction version as an indicator.