### PR TITLE
p2p: trigger disconnect with group context cancellation

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -606,8 +606,8 @@ func (lp *LocalPeer) serveUntilError(ctx context.Context, rp *RemotePeer) {
 
 	g, gctx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		<-ctx.Done()
-		rp.Disconnect(ctx.Err())
+		<-gctx.Done()
+		rp.Disconnect(gctx.Err())
 		rp.c.Close()
 		return nil
 	})


### PR DESCRIPTION
The error `Group` that disconnects and allows `serveUntilError` to return must be triggered by cancellation of the `gctx`, not it's parent.