### PR TITLE
Parameterize run_tests.sh go executable with GO env var

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
-go version
+GO=${GO:-go}
 
-go test -short -vet=all "$@" ./...
+${GO} version
+
+${GO} test -short -vet=all "$@" ./...


### PR DESCRIPTION
Default to 'go' to retain existing behavior.

This more easily allows to run all tests with other supported or
upcoming Go versions, e.g.

$ GO=go1.16.10 ./run_tests.sh

or

$ GO=gotip ./run_tests.sh