### PR TITLE
wallet: Fix cfilter missing on 1-deep reorg

### DIFF
--- a/wallet/sidechains.go
+++ b/wallet/sidechains.go
@@ -73,10 +73,10 @@ func NewBlockNode(header *wire.BlockHeader, hash *chainhash.Hash, filter *gcs.Fi
 // duplicateNode checks if n, or another node which represents the same block,
 // is already contained in the tree.
 func (t *sidechainRootedTree) duplicateNode(n *BlockNode) bool {
-	if *t.root.Hash == *n.Hash {
-		return true
+	old, ok := t.root, *t.root.Hash == *n.Hash
+	if !ok {
+		old, ok = t.children[*n.Hash]
 	}
-	old, ok := t.children[*n.Hash]
 
 	// Copy the cfilter to the older node if it doesn't exist there yet.
 	// This happens when we received sidechains that are about to become a


### PR DESCRIPTION
When a sidechain header was previously received via a header
announcement msg but then the cfilter was fetched via a getheaders msg
with a different peer, the filter was not filled to the blocknode due to
a missing check on the duplicateNode() function to account for the root
of the sidechain forest.

This could cause issues with 1-deep reorgs due to the missing cfilter
later on when switching to the new sidechain as a best chain.

This fixes the issue by also testing the root of the sideforest for
duplicates and filling the fetched cfilter as needed.