### PR TITLE
version: Include VCS build info in version string

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2014 The btcsuite developers
-// Copyright (c) 2015-2017 The Decred developers
+// Copyright (c) 2015-2021 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,6 +35,12 @@ var PreRelease = "pre"
 // for official releases.  It must only contain characters from the semantic
 // version alphabet.
 var BuildMetadata = ""
+
+func init() {
+	if BuildMetadata == "" {
+		BuildMetadata = vcsCommitID()
+	}
+}
 
 // String returns the application version as a properly formed string per the
 // semantic versioning 2.0.0 spec (https://semver.org/).

--- a/version/version_buildinfo.go
+++ b/version/version_buildinfo.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build go1.18
+// +build go1.18
+
+package version
+
+import "runtime/debug"
+
+func vcsCommitID() string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var vcs, revision string
+	for _, bs := range bi.Settings {
+		switch bs.Key {
+		case "vcs":
+			vcs = bs.Value
+		case "vcs.revision":
+			revision = bs.Value
+		}
+	}
+	if vcs == "" {
+		return ""
+	}
+	if vcs == "git" && len(revision) > 9 {
+		revision = revision[:9]
+	}
+	return revision
+}

--- a/version/version_nobuildinfo.go
+++ b/version/version_nobuildinfo.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build !go1.18
+// +build !go1.18
+
+package version
+
+func vcsCommitID() string {
+	return ""
+}


### PR DESCRIPTION
VCS build info is only available when built from a VCS checkout using
Go 1.18 or later.