### PR TITLE
rpcserver: Reduce log level of canceled stream calls

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -121,6 +121,12 @@ func errorCode(err error) codes.Code {
 	if errors.Is(err, hdkeychain.ErrInvalidSeedLen) {
 		return codes.InvalidArgument
 	}
+	if errors.Is(errors.Cause(err), context.Canceled) {
+		return codes.Canceled
+	}
+	if code := status.Code(errors.Cause(err)); code != codes.OK && code != codes.Unknown {
+		return code
+	}
 	return codes.Unknown
 }
 


### PR DESCRIPTION
Streaming calls are supposed to be client controlled and can remain
active for a long time. When their underlying context is canceled, that
is not a client or server error: it's an expected condition to mark the
end of the streaming call.

This reduces the log level of canceled streaming calls to debug.

This is implemented by detecting the underlying context.Canceled error
(or the corresponding grpc status code of Canceled), then switching the
logging function appropriately.