### PR TITLE
Follow DCP0010 once activated

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"time"
 
+	"decred.org/dcrwallet/v2/deployments"
 	"decred.org/dcrwallet/v2/errors"
 	"decred.org/dcrwallet/v2/wallet/txrules"
 	"decred.org/dcrwallet/v2/wallet/udb"
@@ -817,6 +818,11 @@ func (w *Wallet) VoteOnOwnedTickets(ctx context.Context, winningTicketHashes []*
 	if err != nil {
 		return errors.E(op, err)
 	}
+	dcp0010Active, err := deployments.DCP0010Active(ctx, blockHeight,
+		w.chainParams, n)
+	if err != nil {
+		return errors.E(op, err)
+	}
 
 	// TODO The behavior of this is not quite right if tons of blocks
 	// are coming in quickly, because the transaction store will end up
@@ -894,7 +900,7 @@ func (w *Wallet) VoteOnOwnedTickets(ctx context.Context, winningTicketHashes []*
 			// Dealwith consensus votes
 			vote, err := createUnsignedVote(ticketHash, ticketPurchase,
 				blockHeight, blockHash, ticketVoteBits, w.subsidyCache,
-				w.chainParams)
+				w.chainParams, dcp0010Active)
 			if err != nil {
 				log.Errorf("Failed to create vote transaction for ticket "+
 					"hash %v: %v", ticketHash, err)

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -2123,7 +2123,8 @@ func newVoteScript(voteBits stake.VoteBits) ([]byte, error) {
 // is voting on.
 func createUnsignedVote(ticketHash *chainhash.Hash, ticketPurchase *wire.MsgTx,
 	blockHeight int32, blockHash *chainhash.Hash, voteBits stake.VoteBits,
-	subsidyCache *blockchain.SubsidyCache, params *chaincfg.Params) (*wire.MsgTx, error) {
+	subsidyCache *blockchain.SubsidyCache, params *chaincfg.Params,
+	dcp0010Active bool) (*wire.MsgTx, error) {
 
 	// Parse the ticket purchase transaction to determine the required output
 	// destinations for vote rewards or revocations.
@@ -2131,7 +2132,8 @@ func createUnsignedVote(ticketHash *chainhash.Hash, ticketPurchase *wire.MsgTx,
 		stake.TxSStxStakeOutputInfo(ticketPurchase)
 
 	// Calculate the subsidy for votes at this height.
-	subsidy := subsidyCache.CalcStakeVoteSubsidy(int64(blockHeight))
+	subsidy := subsidyCache.CalcStakeVoteSubsidyV2(int64(blockHeight),
+		dcp0010Active)
 
 	// Calculate the output values from this vote using the subsidy.
 	voteRewardValues := stake.CalculateRewards(ticketValues,

--- a/wallet/tickets.go
+++ b/wallet/tickets.go
@@ -23,11 +23,15 @@ import (
 // GenerateVoteTx creates a vote transaction for a chosen ticket purchase hash
 // using the provided votebits.  The ticket purchase transaction must be stored
 // by the wallet.
+//
+// Deprecated: This method will not produce the proper vote subsidy after
+// DCP0010 activation.
 func (w *Wallet) GenerateVoteTx(ctx context.Context, blockHash *chainhash.Hash, height int32,
 	ticketHash *chainhash.Hash, voteBits stake.VoteBits) (*wire.MsgTx, error) {
 	const op errors.Op = "wallet.GenerateVoteTx"
 
 	var vote *wire.MsgTx
+	const dcp0010Active = false
 	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
@@ -36,7 +40,8 @@ func (w *Wallet) GenerateVoteTx(ctx context.Context, blockHash *chainhash.Hash, 
 			return err
 		}
 		vote, err = createUnsignedVote(ticketHash, ticketPurchase,
-			height, blockHash, voteBits, w.subsidyCache, w.chainParams)
+			height, blockHash, voteBits, w.subsidyCache, w.chainParams,
+			dcp0010Active)
 		if err != nil {
 			return errors.E(op, err)
 		}


### PR DESCRIPTION
This is currently being done using an extra getblockchaininfo RPC call
any time votes may need to be created.  While not ideal, and caching
of previously observed active and lockedin statuses could be utilized,
this is the bare minimum needed to make wallet follow the DCP0010 hard
fork if it is approved.