### PR TITLE
Use DCP0010 activation for VSP fee calculations

### DIFF
--- a/config.go
+++ b/config.go
@@ -375,7 +375,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		},
 
 		VSPOpts: vspOptions{
-			MaxFee: cfgutil.NewAmountFlag(0.1e8),
+			MaxFee: cfgutil.NewAmountFlag(0.2e8),
 		},
 	}
 

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3383,7 +3383,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 			Dialer: s.cfg.Dial,
 			Wallet: w,
 			Policy: vsp.Policy{
-				MaxFee:     0.1e8,
+				MaxFee:     0.2e8,
 				FeeAcct:    account,
 				ChangeAcct: changeAccount,
 			},

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -299,7 +299,7 @@ func (w *Wallet) evaluateStakePoolTicket(rec *udb.TxRecord, blockHeight int32, p
 		// height and the required amount from the pool.
 		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
 			tx.TxOut[0].Value), fees, blockHeight, w.poolFees,
-			w.chainParams)
+			w.chainParams, false)
 		if commitAmt < feeNeeded {
 			log.Warnf("User %s submitted ticket %v which "+
 				"has less fees than are required to use this "+

--- a/wallet/txrules/poolfees.go
+++ b/wallet/txrules/poolfees.go
@@ -33,7 +33,8 @@ var initSubsidyCacheOnce sync.Once
 // See the included doc.go of this package for more information about the
 // calculation of this fee.
 func StakePoolTicketFee(stakeDiff dcrutil.Amount, relayFee dcrutil.Amount,
-	height int32, poolFee float64, params *chaincfg.Params) dcrutil.Amount {
+	height int32, poolFee float64, params *chaincfg.Params,
+	dcp0010Active bool) dcrutil.Amount {
 	// Shift the decimal two places, e.g. 1.00%
 	// to 100. This assumes that the proportion
 	// is already multiplied by 100 to give a
@@ -55,7 +56,8 @@ func StakePoolTicketFee(stakeDiff dcrutil.Amount, relayFee dcrutil.Amount,
 	initSubsidyCacheOnce.Do(func() {
 		subsidyCache = blockchain.NewSubsidyCache(params)
 	})
-	subsidy := subsidyCache.CalcStakeVoteSubsidy(int64(height))
+	subsidy := subsidyCache.CalcStakeVoteSubsidyV2(int64(height),
+		dcp0010Active)
 	for i := 0; i < adjs; i++ {
 		subsidy *= 100
 		subsidy /= 101

--- a/wallet/txrules/poolfees_test.go
+++ b/wallet/txrules/poolfees_test.go
@@ -24,7 +24,7 @@ func TestStakePoolTicketFee(t *testing.T) {
 	}
 	for i, test := range tests {
 		poolFeeAmt := StakePoolTicketFee(test.StakeDiff, test.Fee, test.Height,
-			test.PoolFee, params)
+			test.PoolFee, params, false)
 		if poolFeeAmt != test.Expected {
 			t.Errorf("Test %d: Got %v: Want %v", i, poolFeeAmt, test.Expected)
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1621,8 +1621,18 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 		return nil, err
 	}
 	_, height := w.MainChainTip(ctx)
+	dcp0010Active := true
+	switch n := n.(type) {
+	case *dcrd.RPC:
+		dcp0010Active, err = deployments.DCP0010Active(ctx,
+			height, w.chainParams, n)
+		if err != nil {
+			return nil, err
+		}
+	}
 	relayFee := w.RelayFee()
-	vspFee := txrules.StakePoolTicketFee(sdiff, relayFee, height, feePercent, w.chainParams)
+	vspFee := txrules.StakePoolTicketFee(sdiff, relayFee, height,
+		feePercent, w.chainParams, dcp0010Active)
 	a := &authorTx{
 		outputs:            make([]*wire.TxOut, 0, 2),
 		account:            req.SourceAccount,


### PR DESCRIPTION
The VSP fee is a proportion of the subsidy received due to voting.
This value should change if/when DCP0010 activates so VSPs continue to
take the proper percentage of their fees.

Old stakepoold vestige code will continue to use the original subsidy
split rules.  Nobody should be purchasing stakepoold tickets anymore,
and this code should be removed when possible.