### PR TITLE
Update cspp module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module decred.org/dcrwallet/v2
 go 1.16
 
 require (
-	decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f
+	decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3
 	github.com/decred/dcrd/addrmgr/v2 v2.0.0
 	github.com/decred/dcrd/blockchain/stake/v4 v4.0.0
 	github.com/decred/dcrd/blockchain/standalone/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f h1:UOIoro9DWT3DnIufGVRmIaOqsx36lV8+B3nqW33abRg=
-decred.org/cspp/v2 v2.0.0-20211207170141-a6b5f958a91f/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
+decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3 h1:tG0oSis1lMSmLbBEnr21TmbmeULMtkZeiLAILWKedN0=
+decred.org/cspp/v2 v2.0.0-20220117153402-4f26c92d52a3/go.mod h1:USyJS44Kqxz2wT/VaNsf9iTAONegO/qKXRdLg1nvrWI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=


### PR DESCRIPTION
This fixes a protocol bug which caused signature validation failures
if the client and server used different sizes of the uint type, such
as a 32-bit client connecting to a 64-bit server.