### PR TITLE
Remove extra ticketbuying error log

### DIFF
--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -315,9 +315,6 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 			log.Infof("Purchased ticket %v at stake difficulty %v", hash, sdiff)
 		}
 	}
-	if err != nil {
-		log.Errorf("BUY: %v", err)
-	}
 	return err
 }
 


### PR DESCRIPTION
Errors when purchasing tickets through the automated ticketbuyer are
already logged provided that they are not one of the various expected
errors.  However an additional log message was introduced before this
which would log these anyways, and result in other errors being logged
twice.  Remove this extra log statement.