### PR TITLE
Check hash lengths before storing tspend/treasury policies.

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3936,6 +3936,12 @@ func (s *Server) setTSpendPolicy(ctx context.Context, icmd interface{}) (interfa
 		return nil, errUnloadedWallet
 	}
 
+	if len(cmd.Hash) != chainhash.HashSize {
+		err := fmt.Errorf("invalid tspend hash length, expected %d got %d",
+			chainhash.HashSize, len(cmd.Hash))
+		return nil, rpcError(dcrjson.ErrRPCDecodeHexString, err)
+	}
+
 	hash, err := chainhash.NewHashFromStr(cmd.Hash)
 	if err != nil {
 		return nil, rpcError(dcrjson.ErrRPCDecodeHexString, err)
@@ -3943,6 +3949,11 @@ func (s *Server) setTSpendPolicy(ctx context.Context, icmd interface{}) (interfa
 
 	var ticketHash *chainhash.Hash
 	if cmd.Ticket != nil && *cmd.Ticket != "" {
+		if len(*cmd.Ticket) != chainhash.HashSize {
+			err := fmt.Errorf("invalid ticket hash length, expected %d got %d",
+				chainhash.HashSize, len(*cmd.Ticket))
+			return nil, rpcError(dcrjson.ErrRPCDecodeHexString, err)
+		}
 		var err error
 		ticketHash, err = chainhash.NewHashFromStr(*cmd.Ticket)
 		if err != nil {

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3820,6 +3820,11 @@ func (s *Server) setTreasuryPolicy(ctx context.Context, icmd interface{}) (inter
 
 	var ticketHash *chainhash.Hash
 	if cmd.Ticket != nil && *cmd.Ticket != "" {
+		if len(*cmd.Ticket) != chainhash.HashSize {
+			err := fmt.Errorf("invalid ticket hash length, expected %d got %d",
+				chainhash.HashSize, len(*cmd.Ticket))
+			return nil, rpcError(dcrjson.ErrRPCDecodeHexString, err)
+		}
 		var err error
 		ticketHash, err = chainhash.NewHashFromStr(*cmd.Ticket)
 		if err != nil {

--- a/rpc/jsonrpc/types/methods.go
+++ b/rpc/jsonrpc/types/methods.go
@@ -927,6 +927,16 @@ type SetTreasuryPolicyCmd struct {
 	Ticket *string
 }
 
+// NewSetTreasuryPolicyCmd returns a new instance which can be used to issue a settreasurypolicy
+// JSON-RPC command.
+func NewSetTreasuryPolicyCmd(key string, policy string, ticket *string) *SetTreasuryPolicyCmd {
+	return &SetTreasuryPolicyCmd{
+		Key:    key,
+		Policy: policy,
+		Ticket: ticket,
+	}
+}
+
 // TSpendPolicyCmd defines the parameters for the tspendpolicy JSON-RPC
 // command.
 type TSpendPolicyCmd struct {
@@ -940,6 +950,16 @@ type SetTSpendPolicyCmd struct {
 	Hash   string
 	Policy string
 	Ticket *string
+}
+
+// NewSetTSpendPolicyCmd returns a new instance which can be used to issue a settspendpolicy
+// JSON-RPC command.
+func NewSetTSpendPolicyCmd(hash string, policy string, ticket *string) *SetTSpendPolicyCmd {
+	return &SetTSpendPolicyCmd{
+		Hash:   hash,
+		Policy: policy,
+		Ticket: ticket,
+	}
 }
 
 // SetTxFeeCmd defines the settxfee JSON-RPC command.

--- a/rpc/jsonrpc/types/methods_test.go
+++ b/rpc/jsonrpc/types/methods_test.go
@@ -964,6 +964,66 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "settspendpolicy",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("settspendpolicy"), "hash", "policy")
+			},
+			staticCmd: func() interface{} {
+				return NewSetTSpendPolicyCmd("hash", "policy", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"settspendpolicy","params":["hash","policy"],"id":1}`,
+			unmarshalled: &SetTSpendPolicyCmd{
+				Hash:   "hash",
+				Policy: "policy",
+				Ticket: nil,
+			},
+		},
+		{
+			name: "settspendpolicy optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("settspendpolicy"), "hash", "policy", "ticket")
+			},
+			staticCmd: func() interface{} {
+				return NewSetTSpendPolicyCmd("hash", "policy", dcrjson.String("ticket"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"settspendpolicy","params":["hash","policy","ticket"],"id":1}`,
+			unmarshalled: &SetTSpendPolicyCmd{
+				Hash:   "hash",
+				Policy: "policy",
+				Ticket: dcrjson.String("ticket"),
+			},
+		},
+		{
+			name: "settreasurypolicy",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("settreasurypolicy"), "key", "policy")
+			},
+			staticCmd: func() interface{} {
+				return NewSetTreasuryPolicyCmd("key", "policy", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"settreasurypolicy","params":["key","policy"],"id":1}`,
+			unmarshalled: &SetTreasuryPolicyCmd{
+				Key:    "key",
+				Policy: "policy",
+				Ticket: nil,
+			},
+		},
+		{
+			name: "settreasurypolicy optional",
+			newCmd: func() (interface{}, error) {
+				return dcrjson.NewCmd(Method("settreasurypolicy"), "key", "policy", "ticket")
+			},
+			staticCmd: func() interface{} {
+				return NewSetTreasuryPolicyCmd("key", "policy", dcrjson.String("ticket"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"settreasurypolicy","params":["key","policy","ticket"],"id":1}`,
+			unmarshalled: &SetTreasuryPolicyCmd{
+				Key:    "key",
+				Policy: "policy",
+				Ticket: dcrjson.String("ticket"),
+			},
+		},
+		{
 			name: "settxfee",
 			newCmd: func() (interface{}, error) {
 				return dcrjson.NewCmd(Method("settxfee"), 0.0001)


### PR DESCRIPTION
dcrwallet was depending on `chainhash.NewHashFromStr` to validate ticket and tspend hashes provided to `settspendpolicy` and `settreasurypolicy` RPCs. This function checks that hashes do not exceed the expected hash length, but does not check for strings below the expected length.

This result is that all of the following commands were being accepted as valid by dcrwallet, and the values were being stored in the DB:

```
dcrctl --wallet settspendpolicy  "" "yes"
dcrctl --wallet settspendpolicy  "a" "yes"
dcrctl --wallet settspendpolicy  "a" "yes" "a"
```

This PR adds explicit checks to ensure that provided hashes are of the expected length. A descriptive error is returned if the hash is of incorrect length. For example:

```
dcrctl --wallet settspendpolicy  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "yes"
-22: invalid tspend hash length, expected 32 got 39

dcrctl --wallet settspendpolicy  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" "yes" "abcd"
-22: invalid ticket hash length, expected 32 got 4
```