### PR TITLE
Set tspend & treasury policies on VSP

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4650,7 +4650,7 @@ func (s *Server) setVoteChoice(ctx context.Context, icmd interface{}) (interface
 			ChoiceID: cmd.ChoiceID,
 		},
 	}
-	_, err := w.SetAgendaChoices(ctx, ticketHash, choice)
+	_, err := w.SetAgendaChoices(ctx, ticketHash, choice...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -3342,7 +3342,7 @@ func (s *votingServer) SetVoteChoices(ctx context.Context, req *pb.SetVoteChoice
 			ChoiceID: c.ChoiceId,
 		}
 	}
-	voteBits, err := s.wallet.SetAgendaChoices(ctx, ticketHash, choices...)
+	voteBits, err := s.wallet.SetAgendaChoices(ctx, ticketHash, choices)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -4069,7 +4069,10 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 			return err
 		}
 		if ticketHost == vspHost {
-			_ = vspClient.SetVoteChoice(ctx, hash, choices...)
+			tSpendChoices := s.wallet.TSpendPolicyForTicket(hash)
+			treasuryChoices := s.wallet.TreasuryKeyPolicyForTicket(hash)
+
+			_ = vspClient.SetVoteChoice(ctx, hash, choices, tSpendChoices, treasuryChoices)
 		}
 		return nil
 	})

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -3342,7 +3342,7 @@ func (s *votingServer) SetVoteChoices(ctx context.Context, req *pb.SetVoteChoice
 			ChoiceID: c.ChoiceId,
 		}
 	}
-	voteBits, err := s.wallet.SetAgendaChoices(ctx, ticketHash, choices)
+	voteBits, err := s.wallet.SetAgendaChoices(ctx, ticketHash, choices...)
 	if err != nil {
 		return nil, translateError(err)
 	}

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -611,6 +611,8 @@ type ticketStatus struct {
 	FeeTxStatus     string            `json:"feetxstatus"`
 	FeeTxHash       string            `json:"feetxhash"`
 	VoteChoices     map[string]string `json:"votechoices"`
+	TSpendPolicy    map[string]string `json:"tspendpolicy"`
+	TreasuryPolicy  map[string]string `json:"treasurypolicy"`
 	Request         []byte            `json:"request"`
 }
 
@@ -662,7 +664,8 @@ func (c *Client) status(ctx context.Context, ticketHash *chainhash.Hash) (*ticke
 	return &resp, nil
 }
 
-func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash, choices []wallet.AgendaChoice) error {
+func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
+	choices []wallet.AgendaChoice, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
 	w := c.Wallet
 	params := w.ChainParams()
 
@@ -693,13 +696,17 @@ func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
 
 	var resp ticketStatus
 	requestBody, err := json.Marshal(&struct {
-		Timestamp   int64             `json:"timestamp"`
-		TicketHash  string            `json:"tickethash"`
-		VoteChoices map[string]string `json:"votechoices"`
+		Timestamp      int64             `json:"timestamp"`
+		TicketHash     string            `json:"tickethash"`
+		VoteChoices    map[string]string `json:"votechoices"`
+		TSpendPolicy   map[string]string `json:"tspendpolicy"`
+		TreasuryPolicy map[string]string `json:"treasurypolicy"`
 	}{
-		Timestamp:   time.Now().Unix(),
-		TicketHash:  ticketHash.String(),
-		VoteChoices: agendaChoices,
+		Timestamp:      time.Now().Unix(),
+		TicketHash:     ticketHash.String(),
+		VoteChoices:    agendaChoices,
+		TSpendPolicy:   tspendPolicy,
+		TreasuryPolicy: treasuryPolicy,
 	})
 	if err != nil {
 		return err

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -882,17 +882,21 @@ func (fp *feePayment) submitPayment() (err error) {
 		Request   []byte `json:"request"`
 	}
 	requestBody, err := json.Marshal(&struct {
-		Timestamp   int64             `json:"timestamp"`
-		TicketHash  string            `json:"tickethash"`
-		FeeTx       json.Marshaler    `json:"feetx"`
-		VotingKey   string            `json:"votingkey"`
-		VoteChoices map[string]string `json:"votechoices"`
+		Timestamp      int64             `json:"timestamp"`
+		TicketHash     string            `json:"tickethash"`
+		FeeTx          json.Marshaler    `json:"feetx"`
+		VotingKey      string            `json:"votingkey"`
+		VoteChoices    map[string]string `json:"votechoices"`
+		TSpendPolicy   map[string]string `json:"tspendpolicy"`
+		TreasuryPolicy map[string]string `json:"treasurypolicy"`
 	}{
-		Timestamp:   time.Now().Unix(),
-		TicketHash:  fp.ticketHash.String(),
-		FeeTx:       txMarshaler(feeTx),
-		VotingKey:   votingKey,
-		VoteChoices: voteChoices,
+		Timestamp:      time.Now().Unix(),
+		TicketHash:     fp.ticketHash.String(),
+		FeeTx:          txMarshaler(feeTx),
+		VotingKey:      votingKey,
+		VoteChoices:    voteChoices,
+		TSpendPolicy:   w.TSpendPolicyForTicket(&fp.ticketHash),
+		TreasuryPolicy: w.TreasuryKeyPolicyForTicket(&fp.ticketHash),
 	})
 	if err != nil {
 		return err

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -549,6 +549,30 @@ func (w *Wallet) SetAgendaChoices(ctx context.Context, ticketHash *chainhash.Has
 	return voteBits, nil
 }
 
+// TreasuryKeyPolicyForTicket returns all of the treasury key policies set for a
+// single ticket. It does not consider the global wallet setting.
+func (w *Wallet) TreasuryKeyPolicyForTicket(ticketHash *chainhash.Hash) map[string]string {
+	w.stakeSettingsLock.Lock()
+	defer w.stakeSettingsLock.Unlock()
+
+	policies := make(map[string]string)
+	for key, value := range w.vspTSpendKeyPolicy {
+		if key.Ticket.IsEqual(ticketHash) {
+			var choice string
+			switch value {
+			case stake.TreasuryVoteYes:
+				choice = "yes"
+			case stake.TreasuryVoteNo:
+				choice = "no"
+			default:
+				choice = "abstain"
+			}
+			policies[key.TreasuryKey] = choice
+		}
+	}
+	return policies
+}
+
 // TreasuryKeyPolicy returns a vote policy for provided Pi key. If there is
 // no policy this method returns TreasuryVoteInvalid.
 // A non-nil ticket hash may be used by a VSP to return per-ticket policies.
@@ -564,6 +588,30 @@ func (w *Wallet) TreasuryKeyPolicy(pikey []byte, ticket *chainhash.Hash) stake.T
 		}]
 	}
 	return w.tspendKeyPolicy[string(pikey)]
+}
+
+// TSpendPolicyForTicket returns all of the tspend policies set for a single
+// ticket. It does not consider the global wallet setting.
+func (w *Wallet) TSpendPolicyForTicket(ticketHash *chainhash.Hash) map[string]string {
+	w.stakeSettingsLock.Lock()
+	defer w.stakeSettingsLock.Unlock()
+
+	policies := make(map[string]string)
+	for key, value := range w.vspTSpendPolicy {
+		if key.Ticket.IsEqual(ticketHash) {
+			var choice string
+			switch value {
+			case stake.TreasuryVoteYes:
+				choice = "yes"
+			case stake.TreasuryVoteNo:
+				choice = "no"
+			default:
+				choice = "abstain"
+			}
+			policies[key.TSpend.String()] = choice
+		}
+	}
+	return policies
 }
 
 // TSpendPolicy returns a vote policy for a tspend.  If a policy is set for a

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -456,7 +456,7 @@ func (w *Wallet) AgendaChoices(ctx context.Context, ticketHash *chainhash.Hash) 
 // new votebits after each change is made are returned.
 // If a ticketHash is provided, agenda choices are only set for that ticket and
 // the new votebits for that ticket is returned.
-func (w *Wallet) SetAgendaChoices(ctx context.Context, ticketHash *chainhash.Hash, choices ...AgendaChoice) (voteBits uint16, err error) {
+func (w *Wallet) SetAgendaChoices(ctx context.Context, ticketHash *chainhash.Hash, choices []AgendaChoice) (voteBits uint16, err error) {
 	const op errors.Op = "wallet.SetAgendaChoices"
 	version, deployments := CurrentAgendas(w.chainParams)
 	if len(deployments) == 0 {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -456,7 +456,7 @@ func (w *Wallet) AgendaChoices(ctx context.Context, ticketHash *chainhash.Hash) 
 // new votebits after each change is made are returned.
 // If a ticketHash is provided, agenda choices are only set for that ticket and
 // the new votebits for that ticket is returned.
-func (w *Wallet) SetAgendaChoices(ctx context.Context, ticketHash *chainhash.Hash, choices []AgendaChoice) (voteBits uint16, err error) {
+func (w *Wallet) SetAgendaChoices(ctx context.Context, ticketHash *chainhash.Hash, choices ...AgendaChoice) (voteBits uint16, err error) {
 	const op errors.Op = "wallet.SetAgendaChoices"
 	version, deployments := CurrentAgendas(w.chainParams)
 	if len(deployments) == 0 {


### PR DESCRIPTION
This PR ensures tspend and treasury voting preferences are sent to VSPs. This occurs when tickets are initially purchased, or when preferences are changed via RPC.