### PR TITLE
rpc: Only set vote vsp choices for known tickets

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -4064,7 +4064,13 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 		if err != nil {
 			return nil
 		}
-		_ = vspClient.SetVoteChoice(ctx, hash, choices...)
+		ticketHost, err := s.wallet.VSPHostForTicket(ctx, hash)
+		if err != nil {
+			return err
+		}
+		if ticketHost == vspHost {
+			_ = vspClient.SetVoteChoice(ctx, hash, choices...)
+		}
 		return nil
 	})
 


### PR DESCRIPTION
Now only update vote choices for the vsps that are associated with that ticket.