### PR TITLE
Move sample config comments to their own lines

### DIFF
--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -139,21 +139,33 @@
 ; By default, the JSON-RPC server listens on localhost addresses on port
 ; 9110, and the gRPC server listens on localhost addresses on port 9111.
 ;
-; rpclisten=                ; all interfaces on default port
-; rpclisten=0.0.0.0         ; all ipv4 interfaces on default port
-; rpclisten=::              ; all ipv6 interfaces on default port
-; rpclisten=:9110          ; all interfaces on port 9110
-; rpclisten=0.0.0.0:9110   ; all ipv4 interfaces on port 9110
-; rpclisten=[::]:9110      ; all ipv6 interfaces on port 9110
-; rpclisten=127.0.0.1:9110 ; only ipv4 localhost on port 9110 (this is a default)
-; rpclisten=[::1]:9110     ; only ipv6 localhost on port 9110 (this is a default)
-; rpclisten=127.0.0.1:18337 ; only ipv4 localhost on non-standard port 18337
-; rpclisten=:18337          ; all interfaces on non-standard port 18337
-; rpclisten=0.0.0.0:18337   ; all ipv4 interfaces on non-standard port 18337
-; rpclisten=[::]:18337      ; all ipv6 interfaces on non-standard port 18337
+; all interfaces on default port:
+;   rpclisten=
+; all ipv4 interfaces on default port:
+;   rpclisten=0.0.0.0
+; all ipv6 interfaces on default port:
+;   rpclisten=::
+; all interfaces on port 9110:
+;   rpclisten=:9110
+; all ipv4 interfaces on port 9110:
+;   rpclisten=0.0.0.0:9110
+; all ipv6 interfaces on port 9110:
+;   rpclisten=[::]:9110
+; only ipv4 localhost on port 9110 (this is a default):
+;   rpclisten=127.0.0.1:9110
+; only ipv6 localhost on port 9110 (this is a default):
+;   rpclisten=[::1]:9110
+; only ipv4 localhost on non-standard port 18337:
+;   rpclisten=127.0.0.1:18337
+; all interfaces on non-standard port 18337:
+;   rpclisten=:18337
+; all ipv4 interfaces on non-standard port 18337:
+;   rpclisten=0.0.0.0:18337
+; all ipv6 interfaces on non-standard port 18337:
+;   rpclisten=[::]:18337
 
-; Disable the JSON-RPC server or gRPC servers
-; nolegacyrpc=0 ; JSON-RPC
+; Disable the JSON-RPC (nolegacyrpc) or gRPC (nogrpc) servers
+; nolegacyrpc=0
 ; nogrpc=0
 
 ; JSON-RPC (Bitcoin Core-compatible) RPC listener addresses.  Addresses without a
@@ -195,9 +207,13 @@
 ; server will only be enabled if any listen addresses are specified.  The
 ; profile information can be accessed at http://<address>/debug/pprof once
 ; running.
-; profile=:6062             ; listen on port 6062 on all interfaces (NOT recommended)
-; profile=127.0.0.1:6062    ; listen on port 6062 on IPv4 loopback
-; profile=[::1]:6062        ; listen on port 6062 on IPv6 loopback
+;
+; listen on port 6062 on all interfaces (NOT recommended):
+;   profile=:6062
+; listen on port 6062 on IPv4 loopback:
+;   profile=127.0.0.1:6062
+; listen on port 6062 on IPv6 loopback:
+;   profile=[::1]:6062
 
 [Ticket Buyer Options]
 


### PR DESCRIPTION
The config parser parses options until the end of the line, so
uncommenting a commented out config value which contains another
comment on the same line would result in parsing errors or trying to
use bogus values.