### PR TITLE
Updates for Go 1.18

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.16, 1.17]
+        go: [1.17, 1.18]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ https://decred.org/downloads/
 
 ### Build from source (all platforms)
 
-- **Install Go 1.15 or 1.16**
+- **Install Go 1.17 or 1.18**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:
@@ -88,8 +88,7 @@ https://decred.org/downloads/
 - **Build or Update dcrwallet**
 
   Since dcrwallet is a single Go module, it's possible to use a single command
-  to download, build, and install without needing to clone the repo. If using Go
-  1.16, run
+  to download, build, and install without needing to clone the repo. Run:
 
   ```sh
   $ go install decred.org/dcrwallet/v2@master

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrwallet/v2
 
-go 1.16
+go 1.17
 
 require (
 	decred.org/cspp/v2 v2.0.0
@@ -38,4 +38,17 @@ require (
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	google.golang.org/grpc v1.32.0
 	google.golang.org/protobuf v1.23.0
+)
+
+require (
+	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/companyzero/sntrup4591761 v0.0.0-20200131011700-2b0d299dbd22 // indirect
+	github.com/dchest/siphash v1.2.2 // indirect
+	github.com/decred/base58 v1.0.3 // indirect
+	github.com/decred/dcrd/database/v3 v3.0.0 // indirect
+	github.com/decred/dcrd/dcrec/edwards/v2 v2.0.2 // indirect
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 // indirect
+	golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55 // indirect
 )

--- a/internal/rpchelp/genrpcserverhelp.go
+++ b/internal/rpchelp/genrpcserverhelp.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build generate
-// +build generate
 
 package main
 

--- a/internal/rpchelp/helpdescs_en_US.go
+++ b/internal/rpchelp/helpdescs_en_US.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !generate
-// +build !generate
 
 package rpchelp
 

--- a/internal/rpchelp/methods.go
+++ b/internal/rpchelp/methods.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !generate
-// +build !generate
 
 package rpchelp
 

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 

--- a/version/version_buildinfo.go
+++ b/version/version_buildinfo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build go1.18
-// +build go1.18
 
 package version
 

--- a/version/version_nobuildinfo.go
+++ b/version/version_nobuildinfo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !go1.18
-// +build !go1.18
 
 package version
 

--- a/wallet/udb/txexample_test.go
+++ b/wallet/udb/txexample_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package udb
 

--- a/wallet/udb/txquery_test.go
+++ b/wallet/udb/txquery_test.go
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package udb
 

--- a/wallet/walletdb/example_test.go
+++ b/wallet/walletdb/example_test.go
@@ -5,7 +5,6 @@
 
 // Test must be updated for API changes.
 //go:build disabled
-// +build disabled
 
 package walletdb_test
 


### PR DESCRIPTION
Bump module version to Go 1.17.

Remove all +build directives now that the minumum supported Go version
understands //go:build.

Run 'go mod tidy' to include all indirect requirements in the go.mod
file.

Remove references to older Go versions in the README.