### PR TITLE
config: Add `purchaseaccount` to sample config.

### DIFF
--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -23,6 +23,9 @@
 ; flag.
 ; enablevoting=0
 
+; Account to autobuy tickets from.
+; purchaseaccount=
+
 ; The directory to open and save wallet, transaction, and unspent transaction
 ; output files.  Two directories, `mainnet` and `testnet` are used in this
 ; directory for mainnet and testnet wallets, respectively.


### PR DESCRIPTION
This diff adds missing `purchaseaccount` to `sample-dcrwallet.conf`.