### PR TITLE
rpc: Correct JSON-RPC and gRPC verifymessage.

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -5270,14 +5270,13 @@ func (s *Server) verifyMessage(ctx context.Context, icmd interface{}) (interface
 		return nil, err
 	}
 
-	// Addresses must have an associated secp256k1 private key and therefore
-	// must be P2PK or P2PKH (P2SH is not allowed).
+	// Addresses must have an associated secp256k1 private key and must be P2PKH
+	// (P2PK and P2SH is not allowed).
 	switch addr.(type) {
-	case *stdaddr.AddressPubKeyEcdsaSecp256k1V0:
 	case *stdaddr.AddressPubKeyHashEcdsaSecp256k1V0:
 	default:
 		return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
-			"address must be secp256k1 P2PK or P2PKH")
+			"address must be secp256k1 pay-to-pubkey-hash")
 	}
 
 	valid, err = wallet.VerifyMessage(cmd.Message, addr, sig, s.activeNet)

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -3505,14 +3505,13 @@ func (s *messageVerificationServer) VerifyMessage(ctx context.Context, req *pb.V
 		return nil, translateError(err)
 	}
 
-	// Addresses must have an associated secp256k1 private key and therefore
-	// must be P2PK or P2PKH (P2SH is not allowed).
+	// Addresses must have an associated secp256k1 private key and must be P2PKH
+	// (P2PK and P2SH is not allowed).
 	switch addr.(type) {
-	case *stdaddr.AddressPubKeyEcdsaSecp256k1V0:
 	case *stdaddr.AddressPubKeyHashEcdsaSecp256k1V0:
 	default:
 		return nil, status.Error(codes.InvalidArgument,
-			"address must be secp256k1 P2PK or P2PKH")
+			"address must be secp256k1 pay-to-pubkey-hash")
 	}
 
 	valid, err = wallet.VerifyMessage(req.Message, addr, req.Signature, s.chainParams)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2087,20 +2087,20 @@ func VerifyMessage(msg string, addr stdaddr.Address, sig []byte, params stdaddr.
 		return false, errors.E(op, err)
 	}
 
-	// Reconstruct the address from the recovered pubkey.
-	var serializedPK []byte
+	// Reconstruct the pubkey hash address from the recovered pubkey.
+	var pkHash []byte
 	if wasCompressed {
-		serializedPK = pk.SerializeCompressed()
+		pkHash = stdaddr.Hash160(pk.SerializeCompressed())
 	} else {
-		serializedPK = pk.SerializeUncompressed()
+		pkHash = stdaddr.Hash160(pk.SerializeUncompressed())
 	}
-	recoveredAddr, err := stdaddr.NewAddressPubKeyEcdsaSecp256k1V0Raw(serializedPK, params)
+	address, err := stdaddr.NewAddressPubKeyHashEcdsaSecp256k1V0(pkHash, params)
 	if err != nil {
 		return false, errors.E(op, err)
 	}
 
 	// Return whether addresses match.
-	return recoveredAddr.String() == addr.String(), nil
+	return address.String() == addr.String(), nil
 }
 
 // HaveAddress returns whether the wallet is the owner of the address a.


### PR DESCRIPTION
This corrects the main logic that verifies messages to create a p2pkh address from the recovered public key instead of a p2pk since p2pkh is what is produced when signing and therefore what is required when verifying (as can be verified in dcrd as well).

This also updates the call sites that decode the addresses to properly reject p2pk addresses for the same reason.