### PR TITLE
Fix compatibility with latest development dcrd

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -25,7 +25,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-var requiredAPIVersion = semver{Major: 7, Minor: 0, Patch: 0}
+var requiredAPIVersion = semver{Major: 8, Minor: 0, Patch: 0}
 
 // Syncer implements wallet synchronization services by processing
 // notifications from a dcrd JSON-RPC server.
@@ -530,10 +530,6 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	}
 
 	err = s.rpc.Call(ctx, "rebroadcastwinners", nil)
-	if err != nil {
-		return err
-	}
-	err = s.rpc.Call(ctx, "rebroadcastmissed", nil)
 	if err != nil {
 		return err
 	}

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -54,9 +54,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "8.9.0"
-	jsonrpcSemverMajor  = 8
-	jsonrpcSemverMinor  = 9
+	jsonrpcSemverString = "9.0.0"
+	jsonrpcSemverMajor  = 9
+	jsonrpcSemverMinor  = 0
 	jsonrpcSemverPatch  = 0
 )
 

--- a/rpc/client/dcrd/notifications.go
+++ b/rpc/client/dcrd/notifications.go
@@ -67,6 +67,9 @@ func RelevantTxAccepted(params json.RawMessage) (tx *wire.MsgTx, err error) {
 
 // MissedTickets extracts the missed ticket hashes from the parameters of a
 // spentandmissedtickets JSON-RPC notification.
+//
+// Deprecated: The missedtickets notification was removed from dcrd and this
+// function will be removed in the next major version.
 func MissedTickets(params json.RawMessage) (missed []*chainhash.Hash, err error) {
 	// Parameters (array):
 	// 0: Block hash (reversed hex)


### PR DESCRIPTION
dcrd's JSON-RPC version received a major version bump for the removal
of several RPCs related to querying expired and missed tickets.  With
the activation of DCP0009 and the revocations of all older unspent
tickets, these methods are no longer needed by the wallet.

The "revoked" status for getstakeinfo is no longer used, and instead,
a status of "expired" or "missed" is used (which also implies that the
ticket has been revoked).  For this subtle breaking change,
dcrwallet's JSON-RPC API version also receives a major bump.