### PR TITLE
Wallet configured voting preference for the Treasury votes

### DIFF
--- a/config.go
+++ b/config.go
@@ -99,6 +99,8 @@ type config struct {
 	PromptPublicPass        bool                 `long:"promptpublicpass" description:"Prompt for public passphrase from terminal"`
 	EnableTicketBuyer       bool                 `long:"enableticketbuyer" description:"Enable the automatic ticket buyer"`
 	EnableVoting            bool                 `long:"enablevoting" description:"Automatically create votes and revocations"`
+	TreasuryPolicyYesVote   float64              `long:"tpolicyyesvote" description:"Specify percentage of treasury yes votes"`
+	TreasuryPolicyNoVote    float64              `long:"tpolicynovote" description:"Specify percentage of treasury no votes"`
 	PurchaseAccount         string               `long:"purchaseaccount" description:"Account to autobuy tickets from"`
 	PoolAddress             *cfgutil.AddressFlag `long:"pooladdress" description:"VSP fee address"`
 	poolAddress             stdaddr.StakeAddress
@@ -673,6 +675,12 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 			fmt.Fprintln(os.Stderr, usageMessage)
 			return loadConfigError(err)
 		}
+	}
+
+	if cfg.TreasuryPolicyYesVote+cfg.TreasuryPolicyNoVote >= 1 {
+		err := errors.Errorf("tpolicyyesvote + tpolicynovote must be less than 1")
+		fmt.Fprintln(os.Stderr, err)
+		return loadConfigError(err)
 	}
 
 	ipNet := func(cidr string) net.IPNet {

--- a/config.go
+++ b/config.go
@@ -677,8 +677,15 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		}
 	}
 
-	if cfg.TreasuryPolicyYesVote+cfg.TreasuryPolicyNoVote >= 1 {
+	if cfg.TreasuryPolicyYesVote+cfg.TreasuryPolicyNoVote > 1 {
 		err := errors.Errorf("tpolicyyesvote + tpolicynovote must be less than 1")
+		fmt.Fprintln(os.Stderr, err)
+		return loadConfigError(err)
+	}
+
+	prdct := cfg.TreasuryPolicyYesVote * cfg.TreasuryPolicyNoVote
+	if prdct*-1 != prdct {
+		err := errors.Errorf("tpolicyyesvote or tpolicynovote must not be negative")
 		fmt.Fprintln(os.Stderr, err)
 		return loadConfigError(err)
 	}

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -163,6 +163,7 @@ func run(ctx context.Context) error {
 		StakePoolColdExtKey: cfg.StakePoolColdExtKey,
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
+		cfg.TreasuryPolicyYesVote, cfg.TreasuryPolicyNoVote,
 		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets,
 		cfg.MixSplitLimit)

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -40,6 +40,8 @@ type Loader struct {
 	db          wallet.DB
 
 	stakeOptions            *StakeOptions
+	tspendPolicyYesVote     float64
+	tspendPolicyNoVote      float64
 	gapLimit                uint32
 	accountGapLimit         int
 	disableCoinTypeUpgrades bool
@@ -69,13 +71,16 @@ type StakeOptions struct {
 type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
 // NewLoader constructs a Loader.
-func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit uint32,
-	allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int, disableCoinTypeUpgrades bool, manualTickets bool, mixSplitLimit int) *Loader {
+func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions,
+	tspendPolicyYesVote float64, tspendPolicyNoVote float64, gapLimit uint32, allowHighFees bool,
+	relayFee dcrutil.Amount, accountGapLimit int, disableCoinTypeUpgrades bool, manualTickets bool, mixSplitLimit int) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
 		dbDirPath:               dbDirPath,
 		stakeOptions:            stakeOptions,
+		tspendPolicyYesVote:     tspendPolicyYesVote,
+		tspendPolicyNoVote:      tspendPolicyNoVote,
 		gapLimit:                gapLimit,
 		accountGapLimit:         accountGapLimit,
 		disableCoinTypeUpgrades: disableCoinTypeUpgrades,
@@ -185,6 +190,8 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
+		TreasuryPolicyYesVote:   l.tspendPolicyYesVote,
+		TreasuryPolicyNoVote:    l.tspendPolicyNoVote,
 		GapLimit:                l.gapLimit,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
@@ -277,6 +284,8 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
+		TreasuryPolicyYesVote:   l.tspendPolicyYesVote,
+		TreasuryPolicyNoVote:    l.tspendPolicyNoVote,
 		GapLimit:                l.gapLimit,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
@@ -338,6 +347,8 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
+		TreasuryPolicyYesVote:   l.tspendPolicyYesVote,
+		TreasuryPolicyNoVote:    l.tspendPolicyNoVote,
 		GapLimit:                l.gapLimit,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -124,8 +124,10 @@ type Wallet struct {
 	vspTSpendKeyPolicy map[udb.VSPTreasuryKey]stake.TreasuryVoteT
 
 	// Start up flags/settings
-	gapLimit        uint32
-	accountGapLimit int
+	tspendPolicyYesVote float64
+	tspendPolicyNoVote  float64
+	gapLimit            uint32
+	accountGapLimit     int
 
 	// initialHeight is the wallet's tip height prior to syncing with the
 	// network. Useful for calculating or estimating headers fetch progress
@@ -176,6 +178,8 @@ type Config struct {
 	PoolAddress   stdaddr.StakeAddress
 	PoolFees      float64
 
+	TreasuryPolicyYesVote   float64
+	TreasuryPolicyNoVote    float64
 	GapLimit                uint32
 	AccountGapLimit         int
 	MixSplitLimit           int
@@ -5342,6 +5346,8 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 		vspTSpendKeyPolicy: make(map[udb.VSPTreasuryKey]stake.TreasuryVoteT),
 
 		// LoaderOptions
+		tspendPolicyYesVote:     cfg.TreasuryPolicyYesVote,
+		tspendPolicyNoVote:      cfg.TreasuryPolicyNoVote,
 		gapLimit:                cfg.GapLimit,
 		allowHighFees:           cfg.AllowHighFees,
 		accountGapLimit:         cfg.AccountGapLimit,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -52,6 +52,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 		VotingAddress: cfg.TBOpts.votingAddress,
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
+		cfg.TreasuryPolicyYesVote, cfg.TreasuryPolicyNoVote,
 		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets,
 		cfg.MixSplitLimit)


### PR DESCRIPTION
`So if an exchange has a single wallet with tickets for all the users, the users can specify their voting preference, and then the exchange can specific as parameters to their wallet what the voting preferences should be based on the collective preferences of the users. It could end up like 36.6% Approve, 2.86% Disapprove, the rest no preference.`

How the above is implemented is:
- The list of all tspends picked from the cache is shuffled using https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
- The first batch of tickets to Vote yes is Selected, then No votes and the last batch defaults to Abstain.
- If the voting preference isn't provided, it defaults to the original implementation.
