### PR TITLE
rpcserver: Allow signrawtransaction private keys.

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4904,6 +4904,11 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd interface{}) (inte
 				}
 			}
 			keys[addr.String()] = wif
+
+			// Add the pubkey hash variant for supported addresses as well.
+			if pkH, ok := addr.(stdaddr.AddressPubKeyHasher); ok {
+				keys[pkH.AddressPubKeyHash().String()] = wif
+			}
 		}
 	}
 


### PR DESCRIPTION
When the wallet was updated to use `stdaddr` it did not account for the fact that p2pk addresses no longer automatically convert their stringized output to p2pkh addresses, so only the p2pk address ends up in the map while utxos are often p2pkh address.

As a result, the signing code attempts to look up the key based on the p2pkh address which is not in the map and errors despite the private key being provided.

This resolves the issues by additionally adding the p2pkh variant to the keys map for address that support it.