### PR TITLE
[release-v1.7] rpcserver: Allow signrawtransaction private keys.

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4904,6 +4904,11 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd interface{}) (inte
 				}
 			}
 			keys[addr.String()] = wif
+
+			// Add the pubkey hash variant for supported addresses as well.
+			if pkH, ok := addr.(stdaddr.AddressPubKeyHasher); ok {
+				keys[pkH.AddressPubKeyHash().String()] = wif
+			}
 		}
 	}
 


### PR DESCRIPTION
This is a backport of #2173 to the 1.7 release branch.