### PR TITLE
spv: Remove SFNodeCF from required services

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -339,7 +339,7 @@ func (s *Syncer) Run(ctx context.Context) error {
 
 	// Seed peers over DNS when not disabled by persistent peers.
 	if len(s.persistentPeers) == 0 {
-		s.lp.SeedPeers(ctx, wire.SFNodeNetwork|wire.SFNodeCF)
+		s.lp.SeedPeers(ctx, wire.SFNodeNetwork)
 	}
 
 	// Start background handlers to read received messages from remote peers


### PR DESCRIPTION
This removes the SFNodeCF from the required services for nodes when
querying for nodes in the https seeder.

This service was removed from dcrd on commit
b04e2456c8dc842b285b509b8fe1e6f7f8306aa7 as part of the work to
deprecate V1 CFilters.

V1 CFilters are no longer used by dcrwallet, and the fact that nodes
no longer advertise support for this service, means the list of nodes
returned by the seeders to dcrwallet is severely limited. In particular,
for testnet as of this writing only a single (outdated) node is
returned, making it harder to sync testnet nodes.