### PR TITLE
Add checkpointing and enforce testnet3 hard fork

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -392,6 +392,9 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				}
 
 				nodes[i] = wallet.NewBlockNode(header, &hash, filter)
+				if wallet.BadCheckpoint(cnet, &hash, int32(header.Height)) {
+					nodes[i].BadCheckpoint()
+				}
 				return nil
 			})
 		}
@@ -632,6 +635,9 @@ func (s *Syncer) blockConnected(ctx context.Context, params json.RawMessage) err
 	defer s.sidechainsMu.Unlock()
 
 	blockNode := wallet.NewBlockNode(header, &blockHash, filter)
+	if wallet.BadCheckpoint(cnet, &blockHash, int32(header.Height)) {
+		blockNode.BadCheckpoint()
+	}
 	s.sidechains.AddBlockNode(blockNode)
 	s.relevantTxs[blockHash] = relevant
 

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1220,6 +1220,9 @@ func (s *Syncer) getHeaders(ctx context.Context, rp *p2p.RemotePeer) error {
 				}
 
 				nodes[i] = wallet.NewBlockNode(header, &hash, filter)
+				if wallet.BadCheckpoint(cnet, &hash, int32(header.Height)) {
+					nodes[i].BadCheckpoint()
+				}
 				return nil
 			})
 		}

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -32,6 +32,16 @@ func (w *Wallet) extendMainChain(ctx context.Context, op errors.Op, dbtx walletd
 
 	blockHash := header.BlockHash()
 
+	// Enforce checkpoints
+	height := int32(header.Height)
+	ckpt := CheckpointHash(w.chainParams.Net, height)
+	if ckpt != nil && blockHash != *ckpt {
+		err := errors.Errorf("block hash %v does not satisify "+
+			"checkpoint hash %v for height %v", blockHash,
+			ckpt, height)
+		return nil, errors.E(errors.Consensus, err)
+	}
+
 	// Propagate the error unless this block is already included in the main
 	// chain.
 	err := w.txStore.ExtendMainChain(txmgrNs, header, f)

--- a/wallet/checkpoints.go
+++ b/wallet/checkpoints.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"decred.org/dcrwallet/v2/errors"
+	"decred.org/dcrwallet/v2/wallet/walletdb"
+	"github.com/decred/dcrd/chaincfg/chainhash"
+	"github.com/decred/dcrd/wire"
+)
+
+func mustParseHash(s string) chainhash.Hash {
+	h, err := chainhash.NewHashFromStr(s)
+	if err != nil {
+		panic(err)
+	}
+	return *h
+}
+
+var testnet3block962928Hash = mustParseHash("0000004fd1b267fd39111d456ff557137824538e6f6776168600e56002e23b93")
+
+// CheckpointHash returns the block hash of a checkpoint block for the network
+// and height, or nil if there is no checkpoint.
+func CheckpointHash(network wire.CurrencyNet, height int32) *chainhash.Hash {
+	if network == wire.TestNet3 {
+		switch height {
+		case 962928:
+			return &testnet3block962928Hash
+		}
+	}
+	return nil
+}
+
+// BadCheckpoint returns whether a block hash violates a checkpoint rule for the
+// network and block height.
+func BadCheckpoint(network wire.CurrencyNet, hash *chainhash.Hash, height int32) bool {
+	ckpt := CheckpointHash(network, height)
+	if ckpt != nil && *ckpt != *hash {
+		return true
+	}
+	return false
+}
+
+func (w *Wallet) rollbackInvalidCheckpoints(dbtx walletdb.ReadWriteTx) error {
+	txmgrNs := dbtx.ReadWriteBucket(wtxmgrNamespaceKey)
+	var checkpoints []int32
+	if w.chainParams.Net == wire.TestNet3 {
+		checkpoints = []int32{962928}
+	}
+	for _, height := range checkpoints {
+		h, err := w.txStore.GetMainChainBlockHashForHeight(txmgrNs, height)
+		if errors.Is(err, errors.NotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		ckpt := CheckpointHash(w.chainParams.Net, height)
+		if h != *ckpt {
+			err := w.txStore.Rollback(dbtx, height)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5407,6 +5407,13 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 	}
 	log.Infof("Opened wallet") // TODO: log balance? last sync height?
 
+	err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
+		return w.rollbackInvalidCheckpoints(dbtx)
+	})
+	if err != nil {
+		return nil, errors.E(op, err)
+	}
+
 	var vb stake.VoteBits
 	var tspendPolicy map[chainhash.Hash]stake.TreasuryVoteT
 	var treasuryKeyPolicy map[string]stake.TreasuryVoteT


### PR DESCRIPTION
In order to follow the intended chain after the unvoted testnet3 hard
fork, we implement checkpointing and require a block from the fork to
be present in the main chain.  This is performed by rollbacking the
main chain at startup if an invalid checkpoint is detected, and
refusing to extend the main chain unless a checkpoint rule is
satisfied.  We use checkpoints to push wallet onto the intended
unvoted chain due to it having significantly less total work than the
chain being reorged.