### PR TITLE
Allow passphrase confirmation to be read from non-tty

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -147,7 +147,15 @@ func PassPrompt(reader *bufio.Reader, prefix string, confirm bool) ([]byte, erro
 		}
 
 		fmt.Print("Confirm passphrase: ")
-		confirm, err := term.ReadPassword(int(os.Stdin.Fd()))
+		var confirm []byte
+		if term.IsTerminal(fd) {
+			confirm, err = term.ReadPassword(fd)
+		} else {
+			confirm, err = reader.ReadBytes('\n')
+			if errors.Is(err, io.EOF) {
+				err = nil
+			}
+		}
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This allows piping the answers to the --create prompts to work properly for not only the initial passphrase prompt, but the confirmation as well.  Seems to have been missed the last time this code was touched.

```
$ cat answers.txt                                                                                                                     
banana
banana
no
yes
0001020304050607080910111213141516171819202122232425262728293031
$ dcrwallet --appdata=/tmp/tmpwallet --create <answers.txt 
2022-11-09 10:41:30.988 [WRN] DCRW: open /tmp/tmpwallet/dcrwallet.conf: no such file or directory
Enter the private passphrase for your new wallet: 
Confirm passphrase: 
Do you want to add an additional layer of encryption for public data? (n/no/y/yes) [no]: Do you have an existing wallet seed you want to use? (n/no/y/yes) [no]: Enter existing wallet seed (followed by a blank line): 
Seed input successful. 
Hex: 0102030405060708091011121314151617181920212223242526272829303132
Creating the wallet...
2022-11-09 10:41:33.307 [INF] WLLT: Upgrading database from version 1 to 25
2022-11-09 10:41:36.617 [INF] WLLT: Opened wallet
The wallet has been created successfully.
```