### PR TITLE
Do not require additional newline prompting a hex seed

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -309,17 +309,25 @@ func Seed(reader *bufio.Reader) (seed []byte, imported bool, err error) {
 
 	for {
 		fmt.Print("Enter existing wallet seed " +
-			"(followed by a blank line): ")
+			"(follow seed words with additional blank line): ")
 
 		// Use scanner instead of buffio.Reader so we can choose choose
 		// more complicated ending condition rather than just a single
 		// newline.
 		var seedStr string
 		scanner := bufio.NewScanner(reader)
-		for scanner.Scan() {
+		for firstline := true; scanner.Scan(); {
 			line := scanner.Text()
 			if line == "" {
 				break
+			}
+			if firstline {
+				_, err := hex.DecodeString(line)
+				if err == nil {
+					seedStr = line
+					break
+				}
+				firstline = false
 			}
 			seedStr += " " + line
 		}


### PR DESCRIPTION
We currently require an extra blank line following the seed during creation of a restored wallet.  This is due to two factors:

* During creation of a new wallet, we print the seed in PGP word list encoding using multiple lines, and users copy and paste this as is, newlines included.  This means our prompt must support reading multiple lines of input.

* Because the seed length is not required to be exactly 32 bytes (33 words), we don't know when to stop prompting for seed words that are split across multiple lines.  An extra blank line after the seed is used to stop the prompting.

This prompting behavior is only needed for seeds encoded with the PGP word list, and not seeds encoded in hex.  If the first line of input is valid hex encoding, stop prompting immediately and do not require the additional blank line following the seed.