### PR TITLE
Fetch tspends in SPV mode

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -881,19 +881,6 @@ func (lp *LocalPeer) ReceiveHeadersAnnouncement(ctx context.Context) (*RemotePee
 	}
 }
 
-// ReceiveInitState waits for an init state message from a remote peer, returning the
-// peer that sent the message, and the message itself.
-func (lp *LocalPeer) ReceiveInitState(ctx context.Context) (*RemotePeer, *wire.MsgInitState, error) {
-	select {
-	case <-ctx.Done():
-		return nil, nil, ctx.Err()
-	case r := <-lp.receivedInitState:
-		rp, msg := r.rp, r.msg.(*wire.MsgInitState)
-		recycleInMsg(r)
-		return rp, msg, nil
-	}
-}
-
 func (rp *RemotePeer) pingPong(ctx context.Context) {
 	nonce, err := wire.RandomUint64()
 	if err != nil {

--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -1725,10 +1725,8 @@ func (rp *RemotePeer) SendHeadersSent() bool {
 }
 
 // GetInitState attempts to get initial state by sending a GetInitState message.
-func (rp *RemotePeer) GetInitState(ctx context.Context) (*wire.MsgInitState, error) {
+func (rp *RemotePeer) GetInitState(ctx context.Context, msg *wire.MsgGetInitState) (*wire.MsgInitState, error) {
 	const opf = "remotepeer(%v).GetInitState"
-	msg := wire.NewMsgGetInitState()
-	msg.AddTypes(wire.InitStateTSpends)
 
 	c := make(chan *wire.MsgInitState, 1)
 	newRequest := rp.addRequestedInitState(c)

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -350,7 +350,7 @@ func (s *Syncer) Run(ctx context.Context) error {
 	g.Go(func() error { return s.receiveGetData(ctx) })
 	g.Go(func() error { return s.receiveInv(ctx) })
 	g.Go(func() error { return s.receiveHeadersAnnouncements(ctx) })
-	s.lp.AddHandledMessages(p2p.MaskGetData | p2p.MaskInv | p2p.MaskInitState)
+	s.lp.AddHandledMessages(p2p.MaskGetData | p2p.MaskInv)
 
 	if len(s.persistentPeers) != 0 {
 		for i := range s.persistentPeers {
@@ -780,7 +780,7 @@ func (s *Syncer) checkTSpend(ctx context.Context, tx *wire.MsgTx) bool {
 func (s *Syncer) GetInitState(ctx context.Context, rp *p2p.RemotePeer) error {
 	msg, err := rp.GetInitState(ctx)
 	if err != nil {
-		log.Errorf("Failed to get init state", err)
+		return err
 	}
 
 	unseenTSpends := make([]*chainhash.Hash, 0)

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -905,6 +905,12 @@ func (s *Syncer) handleTxInvs(ctx context.Context, rp *p2p.RemotePeer, hashes []
 		s.seenTxs.Add(*h)
 	}
 
+	for _, tx := range txs {
+		if s.checkTSpend(ctx, tx) {
+			s.wallet.AddTSpend(*tx)
+		}
+	}
+
 	// Save any relevant transaction.
 	relevant := s.filterRelevant(txs)
 	for _, tx := range relevant {
@@ -915,9 +921,6 @@ func (s *Syncer) handleTxInvs(ctx context.Context, rp *p2p.RemotePeer, hashes []
 		if err != nil {
 			op := errors.Opf(opf, rp.RemoteAddr())
 			log.Warn(errors.E(op, err))
-		}
-		if s.checkTSpend(ctx, tx) {
-			s.wallet.AddTSpend(*tx)
 		}
 	}
 	s.mempoolTxs(relevant)

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1527,9 +1527,11 @@ func (s *Syncer) startupSync(ctx context.Context, rp *p2p.RemotePeer) error {
 		}
 	}
 
-	err = s.GetInitState(ctx, rp)
-	if err != nil {
-		log.Errorf("Failed to get init state", err)
+	if rp.Pver() >= wire.InitStateVersion {
+		err = s.GetInitState(ctx, rp)
+		if err != nil {
+			log.Errorf("Failed to get init state", err)
+		}
 	}
 
 	unminedTxs, err := s.wallet.UnminedTransactions(ctx)

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -722,18 +722,9 @@ func (s *Syncer) receiveInitState(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 
-			cachedTspends := s.wallet.GetAllTSpends(ctx)
 			unseenTSpends := make([]*chainhash.Hash, 0)
-
 			for h := range msg.TSpendHashes {
-				found := false
-				for _, v := range cachedTspends {
-					if v.TxHash() == msg.TSpendHashes[h] {
-						found = true
-						break
-					}
-				}
-				if !found {
+				if !s.wallet.IsTSpendCached(&msg.TSpendHashes[h]) {
 					unseenTSpends = append(unseenTSpends, &msg.TSpendHashes[h])
 				}
 			}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -232,6 +232,13 @@ func (w *Wallet) VotingEnabled() bool {
 	return enabled
 }
 
+func (w *Wallet) IsTSpendCached(hash *chainhash.Hash) bool {
+	if _, ok := w.tspends[*hash]; ok {
+		return true
+	}
+	return false
+}
+
 // AddTSpend adds a tspend to the cache.
 func (w *Wallet) AddTSpend(tx wire.MsgTx) error {
 	hash := tx.TxHash()

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -232,7 +232,7 @@ func (w *Wallet) VotingEnabled() bool {
 	return enabled
 }
 
-// IsTSpendCached returns wheater the given hash is already cached
+// IsTSpendCached returns whether the given hash is already cached.
 func (w *Wallet) IsTSpendCached(hash *chainhash.Hash) bool {
 	if _, ok := w.tspends[*hash]; ok {
 		return true

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -232,6 +232,7 @@ func (w *Wallet) VotingEnabled() bool {
 	return enabled
 }
 
+// IsTSpendCached returns wheater the given hash is already cached
 func (w *Wallet) IsTSpendCached(hash *chainhash.Hash) bool {
 	if _, ok := w.tspends[*hash]; ok {
 		return true


### PR DESCRIPTION
This fetches tspends via the p2p network in SPV mode using a `getinitstate` message and adds them to the tspends cache.