### PR TITLE
dcrwallet: Add --cpuprofile option

### DIFF
--- a/config.go
+++ b/config.go
@@ -91,6 +91,7 @@ type config struct {
 	NoFileLogging      bool                    `long:"nofilelogging" description:"Disable file logging"`
 	Profile            []string                `long:"profile" description:"Enable HTTP profiling this interface/port"`
 	MemProfile         string                  `long:"memprofile" description:"Write mem profile to the specified file"`
+	CPUProfile         string                  `long:"cpuprofile" description:"Write cpu profile to the specified file"`
 
 	// Wallet options
 	WalletPass              string               `long:"walletpass" default-mask:"-" description:"Public wallet password; required when created with one"`


### PR DESCRIPTION
This generates a full CPU profile output.

It also changes the memory profile to not stop after 5 minutes and instead continue until the execution ends.