### PR TITLE
Add watchlast option to limit initially watched addresses

### DIFF
--- a/config.go
+++ b/config.go
@@ -105,6 +105,7 @@ type config struct {
 	poolAddress             stdaddr.StakeAddress
 	PoolFees                float64             `long:"poolfees" description:"VSP fee percentage (1.00 equals 1.00% fee)"`
 	GapLimit                uint32              `long:"gaplimit" description:"Allowed unused address gap between used addresses of accounts"`
+	WatchLast               uint32              `long:"watchlast" description:"Limit watched previous addresses of each HD account branch"`
 	StakePoolColdExtKey     string              `long:"stakepoolcoldextkey" description:"xpub:maxindex for fee addresses (VSP-only option)"`
 	ManualTickets           bool                `long:"manualtickets" description:"Do not discover new tickets through network synchronization"`
 	AllowHighFees           bool                `long:"allowhighfees" description:"Do not perform high fee checks"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -178,7 +178,7 @@ func run(ctx context.Context) error {
 		StakePoolColdExtKey: cfg.StakePoolColdExtKey,
 	}
 	loader := ldr.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
+		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets,
 		cfg.MixSplitLimit)
 	loader.DialCSPPServer = cfg.dialCSPPServer

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -41,6 +41,7 @@ type Loader struct {
 
 	stakeOptions            *StakeOptions
 	gapLimit                uint32
+	watchLast               uint32
 	accountGapLimit         int
 	disableCoinTypeUpgrades bool
 	allowHighFees           bool
@@ -70,13 +71,15 @@ type DialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
 
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, stakeOptions *StakeOptions, gapLimit uint32,
-	allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int, disableCoinTypeUpgrades bool, manualTickets bool, mixSplitLimit int) *Loader {
+	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int,
+	disableCoinTypeUpgrades bool, manualTickets bool, mixSplitLimit int) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
 		dbDirPath:               dbDirPath,
 		stakeOptions:            stakeOptions,
 		gapLimit:                gapLimit,
+		watchLast:               watchLast,
 		accountGapLimit:         accountGapLimit,
 		disableCoinTypeUpgrades: disableCoinTypeUpgrades,
 		allowHighFees:           allowHighFees,
@@ -186,6 +189,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
 		GapLimit:                l.gapLimit,
+		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
 		StakePoolColdExtKey:     so.StakePoolColdExtKey,
@@ -278,6 +282,7 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
 		GapLimit:                l.gapLimit,
+		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
 		StakePoolColdExtKey:     so.StakePoolColdExtKey,
@@ -339,6 +344,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
 		GapLimit:                l.gapLimit,
+		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
 		StakePoolColdExtKey:     so.StakePoolColdExtKey,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -52,7 +52,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 		VotingAddress: cfg.TBOpts.votingAddress,
 	}
 	loader := loader.NewLoader(activeNet.Params, dbDir, stakeOptions,
-		cfg.GapLimit, cfg.AllowHighFees, cfg.RelayFee.Amount,
+		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, cfg.ManualTickets,
 		cfg.MixSplitLimit)
 


### PR DESCRIPTION
Very large wallets have many addresses that may not be needed anymore, but these addresses were always being loaded into the address transaction filters (cfilters in SPV mode, and given to dcrd to watch when running in full node mode).  To improve startup resource usage and performance, add a new watchlast option that counts backwards from the current address index of every HD account branch, and ignores loading addresses prior to the cutoff during the initial sync.

Future iterations on this idea may allow custom values for different accounts and branches, or perhaps something automatic for mixed accounts where we don't expect old addresses to ever be used again, but for now this seems good enough.