### PR TITLE
race: reusing slice across different rescan iterations

### DIFF
--- a/wallet/internal/bdb/driver_test.go
+++ b/wallet/internal/bdb/driver_test.go
@@ -12,8 +12,8 @@ import (
 	"os"
 	"testing"
 
-	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/errors"
+	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/wallet/walletdb"
 )
 

--- a/wallet/rescan.go
+++ b/wallet/rescan.go
@@ -194,7 +194,6 @@ func (w *Wallet) SaveRescanned(ctx context.Context, hash *chainhash.Hash, txs []
 func (w *Wallet) rescan(ctx context.Context, n NetworkBackend,
 	startHash *chainhash.Hash, height int32, p chan<- RescanProgress) error {
 
-	blockHashStorage := make([]chainhash.Hash, maxBlocksPerRescan)
 	rescanFrom := *startHash
 	inclusive := true
 	for {
@@ -204,6 +203,7 @@ func (w *Wallet) rescan(ctx context.Context, n NetworkBackend,
 		default:
 		}
 
+		blockHashStorage := make([]chainhash.Hash, maxBlocksPerRescan)
 		var rescanBlocks []chainhash.Hash
 		err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 			txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)

--- a/wallet/udb/testdata/v11.db.go
+++ b/wallet/udb/testdata/v11.db.go
@@ -45,8 +45,8 @@ import (
 	"os"
 	"time"
 
-	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/errors"
+	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/wallet/udb"
 	"decred.org/dcrwallet/v3/wallet/walletdb"
 	"github.com/decred/dcrd/blockchain/stake"

--- a/wallet/walletdb/db_test.go
+++ b/wallet/walletdb/db_test.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"testing"
 
-	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/errors"
+	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/wallet/walletdb"
 )
 

--- a/wallet/walletdb/example_test.go
+++ b/wallet/walletdb/example_test.go
@@ -14,8 +14,8 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/errors"
+	_ "decred.org/dcrwallet/v3/wallet/internal/bdb"
 	"decred.org/dcrwallet/v3/wallet/walletdb"
 )
 


### PR DESCRIPTION
Maybe resolves https://github.com/decred/dcrwallet/issues/2200.

From what I figured, the issue seems to be happening due to "unprotected" re-use of `blockHashStorage` slice across different `for` iterations in `Wallet.rescan` func:
- `GetMainChainBlockHashes` rewrites slice entries (which are themselves `chainhash.Hash` = array) with `copy` on each iteration
- `Syncer.Rescan` results into `RemotePeer.Blocks` call that spawns a goroutine like `go rp.requestBlocks(newReqs)` which is reading those same array entries ^ mentioned above

In this PR I'm trying to resolve this race by allocating new slice on each `for` iteration, instead of allocating it once and reusing. Not sure whether there is a viable alternative here, if there is it will probably not look pretty ...