### PR TITLE
Avoid spv data race on rescanned block hashes

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -1322,8 +1322,9 @@ func (rp *RemotePeer) Blocks(ctx context.Context, blockHashes []*chainhash.Hash)
 	rp.requestedBlocksMu.Unlock()
 
 	// Request any blocks which have not yet been requested.
-	doneRequests := make(chan struct{}, 1)
+	var doneRequests chan struct{}
 	if len(newReqs) > 0 {
+		doneRequests = make(chan struct{}, 1)
 		go func() {
 			rp.requestBlocks(newReqs)
 			doneRequests <- struct{}{}
@@ -1347,7 +1348,9 @@ func (rp *RemotePeer) Blocks(ctx context.Context, blockHashes []*chainhash.Hash)
 		}
 	}
 
-	<-doneRequests
+	if doneRequests != nil {
+		<-doneRequests
+	}
 	return blocks, nil
 }
 


### PR DESCRIPTION
p2p.RemotePeer.Blocks performs some internal management on requested block hashes that was continuing to execute after Blocks had returned. This caused a race to be exposed by the rescan code when running in SPV mode.

Fixes #2200.