### PR TITLE
Avoid context cancellation race

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1378,9 +1378,11 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 	// relevant transactions
 	var watchOutPoints []wire.OutPoint
 	defer func() {
-		if ctx.Err() != nil {
-			return
-		}
+		// Cancellation of the request context should not prevent the
+		// watching of addresses and outpoints that need to be watched.
+		// A better solution would be to watch for the data first,
+		// before publishing transactions.
+		ctx := context.TODO()
 		_, err := w.watchHDAddrs(ctx, false, n)
 		if err != nil {
 			log.Errorf("Failed to watch for future addresses after ticket "+


### PR DESCRIPTION
In the event that a purchase tickets request context from the ticket autobuyer is cancelled due to the changing sdiff window, addresses and outpoints must still be watched.  Not doing so eventually leads to an invalid UTXO set as relevant transactions become missed.

There is a small chance that this change may cause a hang during process shutdown.  A better solution for this is included in a comment.