### PR TITLE
Always avoid creating small mix change

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1055,6 +1055,9 @@ func (w *Wallet) mixedSplit(ctx context.Context, req *PurchaseTicketsRequest, ne
 	if atx.ChangeIndex >= 0 {
 		change = atx.Tx.TxOut[atx.ChangeIndex]
 	}
+	if change != nil && dcrutil.Amount(change.Value) < smallestMixChange(relayFee) {
+		change = nil
+	}
 	const (
 		txVersion = 1
 		locktime  = 0


### PR DESCRIPTION
The mix with the smallest denomination never creates change; instead, the extra value is rolled into the transaction fee.  Do the same for all other mixing (ticket splitting, and the larger denominations of account mixing) so that the unmixed account is not filled with these outputs that are too small to mix, and too tempting to spend together.