### PR TITLE
internal/vsp: Clean-up public API 

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -435,7 +435,7 @@ func run(ctx context.Context) error {
 
 		loader.RunAfterLoad(func(w *wallet.Wallet) {
 			if vspClient != nil && cfg.VSPOpts.Sync {
-				vspClient.ProcessManagedTickets(ctx, vspClient.Policy)
+				vspClient.ProcessManagedTickets(ctx)
 			}
 
 			if cfg.SPV {

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4703,7 +4703,7 @@ func (s *Server) setVoteChoice(ctx context.Context, icmd interface{}) (interface
 		ticketHash = hash
 	}
 
-	choice := []wallet.AgendaChoice{
+	choice := wallet.AgendaChoices{
 		{
 			AgendaID: cmd.AgendaID,
 			ChoiceID: cmd.ChoiceID,
@@ -4720,7 +4720,8 @@ func (s *Server) setVoteChoice(ctx context.Context, icmd interface{}) (interface
 }
 
 func (s *Server) updateVSPVoteChoices(ctx context.Context, w *wallet.Wallet, ticketHash *chainhash.Hash,
-	choices []wallet.AgendaChoice, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
+	choices wallet.AgendaChoices, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
+
 	if ticketHash != nil {
 		vspHost, err := w.VSPHostForTicket(ctx, ticketHash)
 		if err != nil {
@@ -4734,7 +4735,7 @@ func (s *Server) updateVSPVoteChoices(ctx context.Context, w *wallet.Wallet, tic
 		if err != nil {
 			return err
 		}
-		err = vspClient.SetVoteChoice(ctx, ticketHash, choices, tspendPolicy, treasuryPolicy)
+		err = vspClient.SetVoteChoice(ctx, ticketHash, choices.Map(), tspendPolicy, treasuryPolicy)
 		return err
 	}
 	var firstErr error
@@ -4755,7 +4756,7 @@ func (s *Server) updateVSPVoteChoices(ctx context.Context, w *wallet.Wallet, tic
 		}
 		// Never return errors here, so all tickets are tried.
 		// The first error will be returned to the user.
-		err = vspClient.SetVoteChoice(ctx, hash, choices, tspendPolicy, treasuryPolicy)
+		err = vspClient.SetVoteChoice(ctx, hash, choices.Map(), tspendPolicy, treasuryPolicy)
 		if err != nil && firstErr == nil {
 			firstErr = err
 		}

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -4153,7 +4153,7 @@ func (s *walletServer) SyncVSPFailedTickets(ctx context.Context, req *pb.SyncVSP
 	// process tickets fee if needed.
 	for _, ticketHash := range failedTicketsFee {
 		feeTx := new(wire.MsgTx)
-		err := vspClient.ProcessWithPolicy(ctx, &ticketHash, feeTx, policy)
+		err := vspClient.Process(ctx, &ticketHash, feeTx)
 		if err != nil {
 			// if it fails to process again, we log it and continue with
 			// the wallet start.
@@ -4191,7 +4191,7 @@ func (s *walletServer) ProcessManagedTickets(ctx context.Context, req *pb.Proces
 		return nil, status.Errorf(codes.Unknown, "VSPClient instance failed to start. Error: %v", err)
 	}
 
-	err = vspClient.ProcessManagedTickets(ctx, policy)
+	err = vspClient.ProcessManagedTickets(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Unknown, "ProcessManagedTickets failed. Error: %v", err)
 	}
@@ -4236,7 +4236,7 @@ func (s *walletServer) ProcessUnmanagedTickets(ctx context.Context, req *pb.Proc
 		return nil
 	})
 	if errors.Is(err, errUnmanagedTickets) {
-		vspClient.ProcessUnprocessedTickets(ctx, policy)
+		vspClient.ProcessUnprocessedTickets(ctx)
 	}
 
 	return &pb.ProcessUnmanagedTicketsResponse{}, nil

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -3354,7 +3354,7 @@ func (s *votingServer) SetVoteChoices(ctx context.Context, req *pb.SetVoteChoice
 			return nil, status.Errorf(codes.InvalidArgument, "%v", err)
 		}
 	}
-	choices := make([]wallet.AgendaChoice, len(req.Choices))
+	choices := make(wallet.AgendaChoices, len(req.Choices))
 	for i, c := range req.Choices {
 		choices[i] = wallet.AgendaChoice{
 			AgendaID: c.AgendaId,
@@ -4312,7 +4312,7 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 			return err
 		}
 		if ticketHost == vspHost {
-			_ = vspClient.SetVoteChoice(ctx, hash, choices, tSpendChoices, treasuryChoices)
+			_ = vspClient.SetVoteChoice(ctx, hash, choices.Map(), tSpendChoices, treasuryChoices)
 		}
 		return nil
 	})

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -215,7 +215,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pai
 		client:     c,
 		ctx:        ctx,
 		ticketHash: *ticketHash,
-		policy:     c.Policy,
+		policy:     c.policy,
 	}
 
 	// No VSP interaction is required for spent tickets.

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -138,13 +138,13 @@ func parseTicket(ticket *wire.MsgTx, params *chaincfg.Params) (
 func (fp *feePayment) ticketSpent() bool {
 	ctx := fp.ctx
 	ticketOut := wire.OutPoint{Hash: fp.ticketHash, Index: 0, Tree: 1}
-	_, _, err := fp.client.Wallet.Spender(ctx, &ticketOut)
+	_, _, err := fp.client.wallet.Spender(ctx, &ticketOut)
 	return err == nil
 }
 
 func (fp *feePayment) ticketExpired() bool {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 	_, tipHeight := w.MainChainTip(ctx)
 
 	fp.mu.Lock()
@@ -208,7 +208,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pol
 		}
 	}()
 
-	w := c.Wallet
+	w := c.wallet
 	params := w.ChainParams()
 
 	fp = &feePayment{
@@ -293,7 +293,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pol
 }
 
 func (c *Client) tx(ctx context.Context, hash *chainhash.Hash) (*wire.MsgTx, error) {
-	txs, _, err := c.Wallet.GetTransactionsByHashes(ctx, []*chainhash.Hash{hash})
+	txs, _, err := c.wallet.GetTransactionsByHashes(ctx, []*chainhash.Hash{hash})
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func (fp *feePayment) schedule(name string, method func() error) {
 }
 
 func (fp *feePayment) next() time.Duration {
-	w := fp.client.Wallet
+	w := fp.client.wallet
 	params := w.ChainParams()
 	_, tipHeight := w.MainChainTip(fp.ctx)
 
@@ -368,7 +368,7 @@ func (fp *feePayment) stop() {
 
 func (fp *feePayment) receiveFeeAddress() error {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 	params := w.ChainParams()
 
 	// stop processing if ticket is expired or spent
@@ -441,7 +441,7 @@ func (fp *feePayment) receiveFeeAddress() error {
 // be dereferenced.
 func (fp *feePayment) makeFeeTx(tx *wire.MsgTx) error {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 
 	fp.mu.Lock()
 	fee := fp.fee
@@ -594,7 +594,7 @@ func (fp *feePayment) makeFeeTx(tx *wire.MsgTx) error {
 }
 
 func (c *Client) status(ctx context.Context, ticketHash *chainhash.Hash) (*types.TicketStatusResponse, error) {
-	w := c.Wallet
+	w := c.wallet
 	params := w.ChainParams()
 
 	ticketTx, err := c.tx(ctx, ticketHash)
@@ -630,7 +630,7 @@ func (c *Client) status(ctx context.Context, ticketHash *chainhash.Hash) (*types
 
 func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
 	choices []wallet.AgendaChoice, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
-	w := c.Wallet
+	w := c.wallet
 	params := w.ChainParams()
 
 	ticketTx, err := c.tx(ctx, ticketHash)
@@ -678,7 +678,7 @@ func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
 
 func (fp *feePayment) reconcilePayment() error {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 
 	// stop processing if ticket is expired or spent
 	// XXX if ticket is no longer saved by wallet (because the tx expired,
@@ -788,7 +788,7 @@ func (fp *feePayment) reconcilePayment() error {
 
 func (fp *feePayment) submitPayment() (err error) {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 
 	// stop processing if ticket is expired or spent
 	if fp.removedExpiredOrSpent() {
@@ -869,7 +869,7 @@ func (fp *feePayment) submitPayment() (err error) {
 
 func (fp *feePayment) confirmPayment() (err error) {
 	ctx := fp.ctx
-	w := fp.client.Wallet
+	w := fp.client.wallet
 
 	// stop processing if ticket is expired or spent
 	if fp.removedExpiredOrSpent() {

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -180,7 +180,7 @@ func (fp *feePayment) remove(reason string) {
 
 // feePayment returns an existing managed fee payment, or creates and begins
 // processing a fee payment for a ticket.
-func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, policy Policy, paidConfirmed bool) (fp *feePayment) {
+func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, paidConfirmed bool) (fp *feePayment) {
 	c.mu.Lock()
 	fp = c.jobs[*ticketHash]
 	c.mu.Unlock()
@@ -215,7 +215,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pol
 		client:     c,
 		ctx:        ctx,
 		ticketHash: *ticketHash,
-		policy:     policy,
+		policy:     c.Policy,
 	}
 
 	// No VSP interaction is required for spent tickets.

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -629,7 +629,7 @@ func (c *Client) status(ctx context.Context, ticketHash *chainhash.Hash) (*types
 }
 
 func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
-	choices []wallet.AgendaChoice, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
+	choices map[string]string, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
 	w := c.wallet
 	params := w.ChainParams()
 
@@ -651,17 +651,10 @@ func (c *Client) setVoteChoices(ctx context.Context, ticketHash *chainhash.Hash,
 			ticketHash, err)
 	}
 
-	agendaChoices := make(map[string]string, len(choices))
-
-	// Prepare agenda choice
-	for _, c := range choices {
-		agendaChoices[c.AgendaID] = c.ChoiceID
-	}
-
 	req := types.SetVoteChoicesRequest{
 		Timestamp:      time.Now().Unix(),
 		TicketHash:     ticketHash.String(),
-		VoteChoices:    agendaChoices,
+		VoteChoices:    choices,
 		TSpendPolicy:   tspendPolicy,
 		TreasuryPolicy: treasuryPolicy,
 	}

--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -292,7 +292,7 @@ func (c *Client) Process(ctx context.Context, ticketHash *chainhash.Hash, feeTx 
 // the connected VSP. The status provides the current voting preferences so we
 // can just update from there if need be.
 func (c *Client) SetVoteChoice(ctx context.Context, hash *chainhash.Hash,
-	choices []wallet.AgendaChoice, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
+	choices map[string]string, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
 
 	// Retrieve current voting preferences from VSP.
 	status, err := c.status(ctx, hash)
@@ -309,19 +309,17 @@ func (c *Client) SetVoteChoice(ctx context.Context, hash *chainhash.Hash,
 	update := false
 
 	// Check consensus vote choices.
-	for _, newChoice := range choices {
-		vspChoice, ok := status.VoteChoices[newChoice.AgendaID]
+	for newAgenda, newChoice := range choices {
+		vspChoice, ok := status.VoteChoices[newAgenda]
 		if !ok {
 			update = true
 			break
 		}
-		if vspChoice != newChoice.ChoiceID {
+		if vspChoice != newChoice {
 			update = true
 			break
 		}
 	}
-
-	// Apply the above changes to the two checks below.
 
 	// Check tspend policies.
 	for newTSpend, newChoice := range tspendPolicy {

--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -29,7 +29,7 @@ type Policy struct {
 
 type Client struct {
 	wallet *wallet.Wallet
-	Policy Policy
+	policy Policy
 	*vspd.Client
 
 	mu   sync.Mutex
@@ -79,7 +79,7 @@ func New(cfg Config) (*Client, error) {
 
 	v := &Client{
 		wallet: cfg.Wallet,
-		Policy: cfg.Policy,
+		policy: cfg.Policy,
 		Client: client,
 		jobs:   make(map[chainhash.Hash]*feePayment),
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -398,18 +398,30 @@ type AgendaChoice struct {
 	ChoiceID string
 }
 
+type AgendaChoices []AgendaChoice
+
+// Map returns the agenda choices formatted as map["AgendaID"] = "ChoiceID".
+func (a AgendaChoices) Map() map[string]string {
+	choices := make(map[string]string, len(a))
+
+	for _, c := range a {
+		choices[c.AgendaID] = c.ChoiceID
+	}
+	return choices
+}
+
 // AgendaChoices returns the choice IDs for every agenda of the supported stake
 // version.  Abstains are included.  Returns choice IDs set for the specified
 // non-nil ticket hash, or the default choice IDs if the ticket hash is nil or
 // there are no choices set for the ticket.
-func (w *Wallet) AgendaChoices(ctx context.Context, ticketHash *chainhash.Hash) (choices []AgendaChoice, voteBits uint16, err error) {
+func (w *Wallet) AgendaChoices(ctx context.Context, ticketHash *chainhash.Hash) (choices AgendaChoices, voteBits uint16, err error) {
 	const op errors.Op = "wallet.AgendaChoices"
 	version, deployments := CurrentAgendas(w.chainParams)
 	if len(deployments) == 0 {
 		return nil, 0, nil
 	}
 
-	choices = make([]AgendaChoice, len(deployments))
+	choices = make(AgendaChoices, len(deployments))
 	for i := range choices {
 		choices[i].AgendaID = deployments[i].Vote.Id
 		choices[i].ChoiceID = "abstain"


### PR DESCRIPTION
The goal of this PR is to clean-up and simplify the public API of the `internal/vsp` package prior to it becoming an import from vspd. Purely refactoring with no functional changes.

I will rebase decred/vspd#382 on to this before merging it.