### PR TITLE
Respect proxy config for SPV and seeder connections

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -523,6 +523,7 @@ func spvLoop(ctx context.Context, w *wallet.Wallet) {
 	amgrDir := filepath.Join(cfg.AppDataDir.Value, w.ChainParams().Name)
 	amgr := addrmgr.New(amgrDir, cfg.lookup)
 	lp := p2p.NewLocalPeer(w.ChainParams(), addr, amgr)
+	lp.SetDialFunc(cfg.dial)
 	syncer := spv.NewSyncer(w, lp)
 	if len(cfg.SPVConnect) > 0 {
 		syncer.SetPersistentPeers(cfg.SPVConnect)


### PR DESCRIPTION
Remove the address of the local peer from the handshake.  This is to prevent leaking internal network details and if a proxy is in use. Peers are also no longer informed of their external address if the address is loopback or a private or shared address.

Backport of 18d4c023835206e455b65a71df82df8fc28255b6.