### PR TITLE
vsp: Reduce dependencies on wallet packages.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -283,11 +283,12 @@ func run(ctx context.Context) error {
 				PubKey: cfg.VSPOpts.PubKey,
 				Dialer: cfg.dial,
 				Wallet: w,
-				Policy: vsp.Policy{
+				Policy: &vsp.Policy{
 					MaxFee:     cfg.VSPOpts.MaxFee.Amount,
 					FeeAcct:    purchaseAcct,
 					ChangeAcct: changeAcct,
 				},
+				Params: w.ChainParams(),
 			}
 			vspClient, err = ldr.VSP(vspCfg)
 			if err != nil {


### PR DESCRIPTION
The goal of this PR is to reduce dependencies between the VSP client and other wallet code.

The first 3 commits are bringing the dcrwallet client up-to-date with some changes made in decred/vspd#382.

As a result of this PR, `feepayment.go` no longer has any dependency on `decred.org/dcrwallet`, and the [interface](https://github.com/decred/vspd/blob/203bf7d2e62f0e263740b36552c33fb4689bcd60/client/autoclient.go#L39C3-L68) between dcrwallet and vspd can be reduced by 6 funcs.