### PR TITLE
Fix tests to account for Go 1.21 changes

### DIFF
--- a/x509_test.go
+++ b/x509_test.go
@@ -197,7 +197,8 @@ func TestUntrustedClientCert(t *testing.T) {
 				// Retry.
 				continue
 			}
-			if !strings.HasSuffix(err.Error(), "tls: bad certificate") {
+			if !(strings.HasSuffix(err.Error(), "tls: bad certificate") ||
+				strings.HasSuffix(err.Error(), "tls: unknown certificate authority")) {
 				t.Fatalf("server did not report bad certificate error; "+
 					"instead errored with: %v (%T)", err, err)
 			}


### PR DESCRIPTION
An error that could only be detected through string parsing needed to be updated for the new error message.