### PR TITLE
multi: Hard-code background context for vsp client

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3491,7 +3491,7 @@ func (s *Server) processUnmanagedTicket(ctx context.Context, icmd interface{}) (
 		return nil, err
 	}
 
-	err = vspClient.ProcessTicket(ctx, ticketHash)
+	err = vspClient.Process(ctx, ticketHash, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -3420,7 +3420,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd interface{}) (interfac
 
 	if vspClient != nil {
 		request.VSPFeePaymentProcess = vspClient.Process
-		request.VSPFeeProcess = vspClient.FeePercentage
+		request.VSPFeePercent = vspClient.FeePercentage
 	}
 
 	ticketsResponse, err := w.PurchaseTickets(ctx, n, request)

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2015-2016 The btcsuite developers
-// Copyright (c) 2016-2021 The Decred developers
+// Copyright (c) 2016-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1922,7 +1922,7 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 
 	if vspClient != nil {
 		request.VSPFeePaymentProcess = vspClient.Process
-		request.VSPFeeProcess = vspClient.FeePercentage
+		request.VSPFeePercent = vspClient.FeePercentage
 	}
 
 	// If dontSignTx is false we unlock the wallet so we can sign the tx.

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -214,7 +214,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pai
 
 	fp = &feePayment{
 		client:     c,
-		ctx:        ctx,
+		ctx:        context.Background(),
 		ticketHash: *ticketHash,
 		policy:     c.policy,
 		params:     c.params,

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package vsp
 
 import (

--- a/internal/vsp/vsp.go
+++ b/internal/vsp/vsp.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2023 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package vsp
 
 import (
@@ -104,8 +108,9 @@ func (c *Client) FeePercentage(ctx context.Context) (float64, error) {
 	return resp.FeePercentage, nil
 }
 
-// ProcessUnprocessedTickets processes all tickets that don't currently have
-// any association with a VSP.
+// ProcessUnprocessedTickets queries the wallet for all immature/live tickets
+// that don't currently have any association with a VSP. A background goroutine
+// is started to process the fee payment for each ticket.
 func (c *Client) ProcessUnprocessedTickets(ctx context.Context) {
 	var wg sync.WaitGroup
 	c.wallet.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
@@ -146,11 +151,6 @@ func (c *Client) ProcessUnprocessedTickets(ctx context.Context) {
 		return nil
 	})
 	wg.Wait()
-}
-
-// ProcessTicket attempts to process a given ticket based on the hash provided.
-func (c *Client) ProcessTicket(ctx context.Context, hash *chainhash.Hash) error {
-	return c.Process(ctx, hash, nil)
 }
 
 // ProcessManagedTickets discovers tickets which were previously registered with
@@ -221,10 +221,10 @@ func (c *Client) ProcessManagedTickets(ctx context.Context) error {
 // inputs, is used to pay the VSP fee.  Otherwise, new inputs are selected and
 // locked to prevent double spending the fee.
 //
-// feeTx must not be nil, but may point to an empty transaction, and is modified
-// with the inputs and the fee and change outputs before returning without an
-// error.  The fee transaction is also recorded as unpublised in the wallet, and
-// the fee hash is associated with the ticket.
+// feeTx may be nil or may point to an empty transaction. It is modified with
+// the inputs and the fee and change outputs before returning without an error.
+// The fee transaction is also recorded as unpublised in the wallet, and the fee
+// hash is associated with the ticket.
 func (c *Client) Process(ctx context.Context, ticketHash *chainhash.Hash, feeTx *wire.MsgTx) error {
 	vspTicket, err := c.wallet.VSPTicketInfo(ctx, ticketHash)
 	if err != nil && !errors.Is(err, errors.NotExist) {

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018-2020 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -313,7 +313,7 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	// If VSP is configured, we need to set the methods for vsp fee processment.
 	if tb.cfg.VSP != nil {
 		purchaseTicketReq.VSPFeePaymentProcess = tb.cfg.VSP.Process
-		purchaseTicketReq.VSPFeeProcess = tb.cfg.VSP.FeePercentage
+		purchaseTicketReq.VSPFeePercent = tb.cfg.VSP.FeePercentage
 	}
 	tix, err := w.PurchaseTickets(ctx, n, purchaseTicketReq)
 	if tix != nil {

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1406,11 +1406,11 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		return
 	}
 	if req.VSPFeePaymentProcess != nil {
-		if req.VSPFeeProcess == nil {
+		if req.VSPFeePercent == nil {
 			return nil, errors.E(op, errors.Bug, "VSPFeeProcess "+
 				"may not be nil if VSPServerProcess is non-nil")
 		}
-		feePrice, err := req.VSPFeeProcess(ctx)
+		feePrice, err := req.VSPFeePercent(ctx)
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
+// Copyright (c) 2015-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1615,11 +1615,11 @@ type PurchaseTicketsRequest struct {
 	// VSPServer methods
 	// XXX this should be an interface
 
-	// VSPFeeProcessFunc Process the fee price for the vsp to register a ticket
-	// so we can reserve the amount.
-	VSPFeeProcess func(context.Context) (float64, error)
-	// VSPFeePaymentProcess processes the payment of the vsp fee and returns
-	// the paid fee tx.
+	// VSPFeePercent returns the VSPs fee as a percentage of the vote reward.
+	VSPFeePercent func(context.Context) (float64, error)
+	// VSPFeePaymentProcess checks the fee payment status for the specified
+	// ticket and, if necessary, starts a long-lived handler to process the fee
+	// payment.
 	VSPFeePaymentProcess func(context.Context, *chainhash.Hash, *wire.MsgTx) error
 
 	// extraSplitOutput is an additional transaction output created during
@@ -1657,7 +1657,7 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 		return nil, errors.E(op, errors.InsufficientBalance)
 	}
 
-	feePercent, err := req.VSPFeeProcess(ctx)
+	feePercent, err := req.VSPFeePercent(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The VSP client code was not handling contexts correctly. It was receiving short-lived contexts bound to the lifespan of a single RPC request, and using them for long-lived tasks.

This change fixes that specific problem by hard-coding the VSP client code to use context.Background everywhere.

Closes #2239 