### PR TITLE
udb: Remove redundant VSP pubkey check.

### DIFF
--- a/wallet/udb/vsp.go
+++ b/wallet/udb/vsp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -97,7 +97,6 @@ func SetVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash *chainhash.Hash, record 
 	bucket := dbtx.ReadWriteBucket(vspBucketKey)
 	serializedRecord := serializeVSPTicket(record)
 
-	// Save the creation date of the store.
 	return bucket.Put(ticketHash[:], serializedRecord)
 }
 

--- a/wallet/udb/vsp.go
+++ b/wallet/udb/vsp.go
@@ -5,8 +5,6 @@
 package udb
 
 import (
-	"bytes"
-
 	"decred.org/dcrwallet/v4/errors"
 	"decred.org/dcrwallet/v4/wallet/walletdb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
@@ -75,23 +73,10 @@ func SetVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash *chainhash.Hash, record 
 		if err != nil {
 			return err
 		}
-		record.VSPHostID = vspHostID
 	} else if err != nil {
 		return err
 	}
 
-	// If the pubkey from the record in the request differs from the pubkey
-	// in the database that is saved for the host, update the pubkey in the
-	// db but keep the vsphost id intact.
-	if !bytes.Equal(pubkey.PubKey, record.PubKey) {
-		err = SetVSPPubKey(dbtx, []byte(record.Host), &VSPPubKey{
-			ID:     pubkey.ID,
-			PubKey: record.PubKey,
-		})
-		if err != nil {
-			return err
-		}
-	}
 	record.VSPHostID = pubkey.ID
 
 	bucket := dbtx.ReadWriteBucket(vspBucketKey)


### PR DESCRIPTION
Remove the mismatched pubkey check from SetVSPTicket. This check is totally redundant - the VSP pubkey is checked every time a reponse is received from VSP,  so the process would have already errored out long before this condition was
ever hit.