### PR TITLE
multi: Select unmanaged tickets outside VSP client

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -4234,34 +4234,7 @@ func (s *walletServer) ProcessUnmanagedTickets(ctx context.Context, req *pb.Proc
 		return nil, status.Errorf(codes.Unknown, "VSPClient instance failed to start. Error: %v", err)
 	}
 
-	unmanagedTickets := make([]*chainhash.Hash, 0)
-
-	err = s.wallet.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
-		// Skip tickets which have a fee tx already associated with
-		// them; they are already processed by some vsp.
-		_, err := s.wallet.VSPFeeHashForTicket(ctx, hash)
-		if err == nil {
-			return nil
-		}
-
-		// Skip tickets which already have a confirmed VSP fee.
-		confirmed, err := s.wallet.IsVSPTicketConfirmed(ctx, hash)
-		if err != nil {
-			// NotExist error is expected for unmanaged tickets, it can be
-			// ignored. Any other errors should propagate upwards.
-			if !errors.Is(err, errors.NotExist) {
-				return err
-			}
-		}
-
-		if confirmed {
-			return nil
-		}
-
-		unmanagedTickets = append(unmanagedTickets, hash)
-		return nil
-	})
-
+	unmanagedTickets, err := s.wallet.UnprocessedTickets(ctx)
 	if err != nil {
 		status.Errorf(codes.Unknown, "failed to retrieve unmanaged tickets. Error: %v", err)
 	}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5912,3 +5912,36 @@ func (w *Wallet) ForUnspentUnexpiredTickets(ctx context.Context,
 	endBlock := NewBlockIdentifierFromHeight(blockHeight)
 	return w.GetTickets(ctx, iter, startBlock, endBlock)
 }
+
+// UnprocessedTickets returns the hash of every live/immature ticket in the
+// wallet database which is not currently being processed by a VSP.
+func (w *Wallet) UnprocessedTickets(ctx context.Context) ([]*chainhash.Hash, error) {
+	unmanagedTickets := make([]*chainhash.Hash, 0)
+	err := w.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
+		// Skip tickets which have a fee tx already associated with
+		// them; they are already processed by some vsp.
+		_, err := w.VSPFeeHashForTicket(ctx, hash)
+		if err == nil {
+			return nil
+		}
+
+		// Skip tickets which already have a confirmed VSP fee.
+		confirmed, err := w.IsVSPTicketConfirmed(ctx, hash)
+		if err != nil {
+			// NotExist error is expected for unmanaged tickets, it can be
+			// ignored. Any other errors should propagate upwards.
+			if !errors.Is(err, errors.NotExist) {
+				return err
+			}
+		}
+
+		if confirmed {
+			return nil
+		}
+
+		unmanagedTickets = append(unmanagedTickets, hash)
+		return nil
+	})
+
+	return unmanagedTickets, err
+}


### PR DESCRIPTION
Move the logic to select unmanaged tickets from the wallet database up into the wallet code. No need for this to be done in the VSP client.

This also saves on database access by running ForUnspentUnexpiredTickets only once.