### PR TITLE
Remove AddressReuse from wallet config

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -57,7 +57,6 @@ type Loader struct {
 // StakeOptions contains the various options necessary for stake mining.
 type StakeOptions struct {
 	VotingEnabled       bool
-	AddressReuse        bool
 	VotingAddress       stdaddr.StakeAddress
 	PoolAddress         stdaddr.StakeAddress
 	PoolFees            float64
@@ -184,7 +183,6 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		DB:                      db,
 		PubPassphrase:           pubPass,
 		VotingEnabled:           so.VotingEnabled,
-		AddressReuse:            so.AddressReuse,
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
@@ -277,7 +275,6 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		DB:                      db,
 		PubPassphrase:           pubPassphrase,
 		VotingEnabled:           so.VotingEnabled,
-		AddressReuse:            so.AddressReuse,
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,
@@ -339,7 +336,6 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		DB:                      db,
 		PubPassphrase:           pubPassphrase,
 		VotingEnabled:           so.VotingEnabled,
-		AddressReuse:            so.AddressReuse,
 		VotingAddress:           so.VotingAddress,
 		PoolAddress:             so.PoolAddress,
 		PoolFees:                so.PoolFees,

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1268,22 +1268,6 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		}
 	}
 
-	if w.addressReuse && req.CSPPServer == "" {
-		xpub := w.addressBuffers[udb.DefaultAccountNum].albExternal.branchXpub
-		addr, err := deriveChildAddress(xpub, 0, w.chainParams)
-		if err != nil {
-			err = errors.E(op, err)
-		}
-		stakeAddr, ok := addr.(stdaddr.StakeAddress)
-		if !ok {
-			err = errors.E(op, errors.Invalid, "account does not return "+
-				"compatible stake addresses")
-		}
-		stakeAddrFunc = func(errors.Op, uint32, uint32) (stdaddr.StakeAddress, uint32, error) {
-			return stakeAddr, 0, err
-		}
-	}
-
 	// Calculate the current ticket price.  If the DCP0001 deployment is not
 	// active, fallback to querying the ticket price over RPC.
 	ticketPrice, err := w.NextStakeDifficulty(ctx)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -149,7 +149,6 @@ type Wallet struct {
 	recentlyPublishedMu     sync.Mutex
 
 	// Internal address handling.
-	addressReuse     bool
 	ticketAddress    stdaddr.StakeAddress
 	addressBuffers   map[uint32]*bip0044AccountData
 	addressBuffersMu sync.Mutex
@@ -181,7 +180,6 @@ type Config struct {
 	PubPassphrase []byte
 
 	VotingEnabled bool
-	AddressReuse  bool
 	VotingAddress stdaddr.StakeAddress
 	PoolAddress   stdaddr.StakeAddress
 	PoolFees      float64
@@ -5489,7 +5487,6 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 
 		// StakeOptions
 		votingEnabled:      cfg.VotingEnabled,
-		addressReuse:       cfg.AddressReuse,
 		ticketAddress:      cfg.VotingAddress,
 		poolAddress:        cfg.PoolAddress,
 		poolFees:           cfg.PoolFees,


### PR DESCRIPTION
This had been previously removed from the main package's application config but was left in the wallet package to preserve API compatibility at the time.