### PR TITLE
wallet: Remove duplication from testing code.

### DIFF
--- a/wallet/discovery_test.go
+++ b/wallet/discovery_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 The Decred developers
+// Copyright (c) 2020-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -21,7 +21,7 @@ func TestDiscoveryCursorPos(t *testing.T) {
 	// off-by-ones after the upgrade.  will be fixed in a later commit.
 	cfg.DisableCoinTypeUpgrades = true
 
-	w, teardown := testWallet(ctx, t, &cfg)
+	w, teardown := testWallet(ctx, t, &cfg, nil)
 	defer teardown()
 
 	/*

--- a/wallet/locking_test.go
+++ b/wallet/locking_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 The Decred developers
+// Copyright (c) 2019-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -12,12 +12,10 @@ import (
 	"decred.org/dcrwallet/v4/errors"
 )
 
-var testPrivPass = []byte("private")
-
 func TestLocking(t *testing.T) {
 	ctx := context.Background()
 
-	w, teardown := testWallet(ctx, t, &basicWalletConfig)
+	w, teardown := testWallet(ctx, t, &basicWalletConfig, nil)
 	defer teardown()
 
 	var tests = []func(ctx context.Context, t *testing.T, w *Wallet){

--- a/wallet/reorg_test.go
+++ b/wallet/reorg_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -157,7 +157,7 @@ func TestReorg(t *testing.T) {
 	ctx := context.Background()
 
 	cfg := basicWalletConfig
-	w, teardown := testWallet(ctx, t, &cfg)
+	w, teardown := testWallet(ctx, t, &cfg, nil)
 	defer teardown()
 
 	tg := maketg(t, cfg.Params)

--- a/wallet/setup_test.go
+++ b/wallet/setup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2023 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -15,6 +15,8 @@ import (
 	"github.com/decred/dcrd/dcrutil/v4"
 )
 
+var testPrivPass = []byte("private")
+
 var basicWalletConfig = Config{
 	PubPassphrase: []byte(InsecurePubPassphrase),
 	GapLimit:      20,
@@ -22,7 +24,7 @@ var basicWalletConfig = Config{
 	Params:        chaincfg.SimNetParams(),
 }
 
-func testWallet(ctx context.Context, t *testing.T, cfg *Config) (w *Wallet, teardown func()) {
+func testWallet(ctx context.Context, t *testing.T, cfg *Config, seed []byte) (w *Wallet, teardown func()) {
 	f, err := os.CreateTemp("", "dcrwallet.testdb")
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +38,7 @@ func testWallet(ctx context.Context, t *testing.T, cfg *Config) (w *Wallet, tear
 		db.Close()
 		os.Remove(f.Name())
 	}
-	err = Create(ctx, opaqueDB{db}, []byte(InsecurePubPassphrase), []byte("private"), nil, cfg.Params)
+	err = Create(ctx, opaqueDB{db}, []byte(InsecurePubPassphrase), testPrivPass, seed, cfg.Params)
 	if err != nil {
 		rm()
 		t.Fatal(err)


### PR DESCRIPTION
Make address_test.go use the existing testWallet func rather than unnecessarily defining a separate version named setupWallet. Also reuse some of the existing test values (public/private passphrase, cfg).