### PR TITLE
Remove errors.Cause, rely on Is/As instead

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -34,8 +34,7 @@ type Error struct {
 	Kind Kind
 	Err  error
 
-	stack  []byte
-	bottom bool
+	stack []byte
 }
 
 // Op describes the operation, method, or RPC in which an error condition was
@@ -191,7 +190,6 @@ func E(args ...interface{}) error {
 	}
 
 	var e Error
-	e.bottom = true
 	var prev *Error
 	for _, arg := range args {
 		switch arg := arg.(type) {
@@ -201,17 +199,14 @@ func E(args ...interface{}) error {
 			e.Kind = arg
 		case string:
 			e.Err = New(arg)
-			e.bottom = true
 		case *Error:
 			prev = arg
 			if e.Kind == 0 {
 				e.Kind = arg.Kind
 			}
 			e.Err = arg
-			e.bottom = false
 		case error:
 			e.Err = arg
-			e.bottom = false
 		}
 	}
 
@@ -231,7 +226,6 @@ func E(args ...interface{}) error {
 		// unique fields.
 		if (prev.Op == "" || e.Op == prev.Op) && (prev.Kind == 0 || e.Kind == prev.Kind) {
 			e.Err = prev.Err
-			e.bottom = prev.bottom
 			if e.stack == nil {
 				e.stack = prev.stack
 			}

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -380,22 +380,6 @@ func match(err1, err2 error) bool {
 	return e1.Err.Error() == e2.Err.Error()
 }
 
-// Cause returns the most deeply-nested error from an error chain.
-// Cause never returns nil unless the argument is nil.
-func Cause(err error) error {
-	for {
-		wrapper, ok := err.(interface{ Unwrap() error })
-		if !ok {
-			return err
-		}
-		e := wrapper.Unwrap()
-		if e == nil {
-			return err
-		}
-		err = e
-	}
-}
-
 // Stacks extracts all stacktraces from err, sorted from top-most to bottom-most
 // error.
 func Stacks(err error) [][]byte {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -69,27 +69,6 @@ func TestIs(t *testing.T) {
 	}
 }
 
-func TestCause(t *testing.T) {
-	inner := New("inner")
-	outer := E(inner)
-	if Cause(outer) != inner {
-		t.Fatal("Cause is not equal to inner error")
-	}
-	if Cause(nil) != nil {
-		t.Fatal("Cause(nil) must be nil")
-	}
-	bottom := std.New("bottom")
-	for _, e := range []error{
-		E(bottom),
-		E(Passphrase, E(Invalid, bottom)),
-	} {
-		c := Cause(e)
-		if c != bottom {
-			t.Fatalf("wrong bottom error %v", c)
-		}
-	}
-}
-
 func TestDoubleWrappedErrorWithKind(t *testing.T) {
 	err := E(Invalid, "abc")
 	// Wrap the error again

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -122,11 +122,17 @@ func errorCode(err error) codes.Code {
 	if errors.Is(err, hdkeychain.ErrInvalidSeedLen) {
 		return codes.InvalidArgument
 	}
-	if errors.Is(errors.Cause(err), context.Canceled) {
+	if errors.Is(err, context.Canceled) {
 		return codes.Canceled
 	}
-	if code := status.Code(errors.Cause(err)); code != codes.OK && code != codes.Unknown {
-		return code
+	var grpcStatusError interface {
+		error
+		GRPCStatus() *status.Status
+	}
+	if errors.As(err, &grpcStatusError) {
+		if code := status.Code(grpcStatusError); code != codes.OK && code != codes.Unknown {
+			return code
+		}
 	}
 	return codes.Unknown
 }


### PR DESCRIPTION
It's not clear how errors.Cause should behave if it encounters an error returned
by errors.Join.