### PR TITLE
multi: Always iterate over all VSP tickets.

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -4311,22 +4311,25 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 	}
 
 	err = s.wallet.ForUnspentUnexpiredTickets(ctx, func(hash *chainhash.Hash) error {
-		// Skip errors here, but should we log at least?
 		choices, _, err := s.wallet.AgendaChoices(ctx, hash)
 		if err != nil {
-			return nil
+			return err
 		}
 		ticketHost, err := s.wallet.VSPHostForTicket(ctx, hash)
 		if err != nil {
 			return err
 		}
 		if ticketHost == vspHost {
-			_ = vspClient.SetVoteChoice(ctx, hash, choices, tSpendChoices, treasuryChoices)
+			err = vspClient.SetVoteChoice(ctx, hash, choices, tSpendChoices, treasuryChoices)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, status.Errorf(codes.Unknown, "ForUnspentUnexpiredTickets failed. Error: %v", err)
+		return nil, status.Errorf(codes.Unknown, "ForUnspentUnexpiredTickets failed. Error: %v",
+			err)
 	}
 
 	return &pb.SetVspdVoteChoicesResponse{}, nil

--- a/wallet/udb/txquery.go
+++ b/wallet/udb/txquery.go
@@ -205,8 +205,8 @@ type TicketDetails struct {
 // TicketDetails looks up all recorded details regarding a ticket with some
 // hash.
 //
-// Not finding a ticket with this hash is not an error.  In this case,
-// a nil TicketDetiails is returned.
+// Not finding a ticket with this hash is not an error.  In this case, a nil
+// TicketDetails is returned.
 func (s *Store) TicketDetails(ns walletdb.ReadBucket, txDetails *TxDetails) (*TicketDetails, error) {
 	var ticketDetails = &TicketDetails{}
 	if !stake.IsSStx(&txDetails.MsgTx) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -3212,7 +3212,8 @@ func (w *Wallet) GetTicketsPrecise(ctx context.Context, rpcCaller Caller,
 // The arguments to f may be reused and should not be kept by the caller.
 //
 // Because this function does not have any chain client argument, tickets are
-// unable to be determined whether or not they have been missed, simply unspent.
+// unable to be determined whether or not they have been missed or simply
+// unspent.
 func (w *Wallet) GetTickets(ctx context.Context,
 	f func([]*TicketSummary, *wire.BlockHeader) (bool, error),
 	startBlock, endBlock *BlockIdentifier) error {
@@ -3237,7 +3238,7 @@ func (w *Wallet) GetTickets(ctx context.Context,
 					return false, errors.Errorf("%v while trying to get "+
 						"ticket details for txhash: %v", err, &details[i].Hash)
 				}
-				// Continue if not a ticket
+				// Continue if not a ticket.
 				if ticketInfo == nil {
 					continue
 				}
@@ -5894,7 +5895,7 @@ func (w *Wallet) ForUnspentUnexpiredTickets(ctx context.Context,
 			ticketHash := *ticketSummary.Ticket.Hash
 			err := f(&ticketHash)
 			if err != nil {
-				return false, err
+				continue
 			}
 		}
 


### PR DESCRIPTION
First commit contains a bug fix which I think was preventing all tickets from being iterated over.