### PR TITLE
vsp: Dont remove payments unless confirmed by VSP. 

### DIFF
--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -654,10 +654,6 @@ func (fp *feePayment) reconcilePayment() error {
 		return err
 	}
 
-	// confirmPayment will remove the fee payment processing when the fee
-	// has reached sufficient confirmations, and reschedule itself if the
-	// fee is not confirmed yet.  If the fee tx is ever removed from the
-	// wallet, this will schedule another reconcile.
 	return fp.confirmPayment()
 
 	/*
@@ -747,6 +743,10 @@ func (fp *feePayment) submitPayment() (err error) {
 	return nil
 }
 
+// confirmPayment will remove the fee payment processing when the fee has
+// reached sufficient confirmations, and reschedule itself if the fee is not
+// confirmed yet.  If the fee tx is ever removed from the wallet, this will
+// schedule another reconcile.
 func (fp *feePayment) confirmPayment() (err error) {
 	ctx := fp.ctx
 	w := fp.client.wallet

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -799,8 +799,8 @@ func (fp *feePayment) confirmPayment() (err error) {
 		return nil
 	default:
 		// XXX put in unknown state
-		fp.client.log.Warnf("VSP responded with %v for %v", status.FeeTxStatus,
-			&fp.ticketHash)
+		fp.client.log.Warnf("VSP responded with unknown FeeTxStatus %q for %v",
+			status.FeeTxStatus, &fp.ticketHash)
 	}
 
 	return nil

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -765,31 +765,7 @@ func (fp *feePayment) confirmPayment() (err error) {
 
 	status, err := fp.client.status(ctx, &fp.ticketHash)
 	if err != nil {
-
 		fp.client.log.Warnf("Rescheduling status check for %v: %v", &fp.ticketHash, err)
-
-		// Stop processing if the status check cannot be performed, but
-		// a significant amount of confirmations are observed on the fee
-		// transaction.
-		//
-		// Otherwise, chedule another confirmation check, in case the
-		// status API can be performed at a later time or more
-		// confirmations are observed.
-		fp.mu.Lock()
-		feeHash := fp.feeHash
-		fp.mu.Unlock()
-		confs, err := w.TxConfirms(ctx, &feeHash)
-		if err != nil {
-			return err
-		}
-		if confs >= 6 {
-			fp.remove("confirmed")
-			err = w.UpdateVspTicketFeeToConfirmed(ctx, &fp.ticketHash, &feeHash, fp.client.URL, fp.client.PubKey)
-			if err != nil {
-				return err
-			}
-			return nil
-		}
 		fp.schedule("confirm payment", fp.confirmPayment)
 		return nil
 	}


### PR DESCRIPTION
The only way to be certain a VSP has acknowledged a fee tx and added a ticket to its voting wallets is to check FeeTxStatus == "confirmed". Checking for 6 confirmations on the fee tx is not an adequate substitute.

For example, if a client has broadcast it's own fee tx rather than waiting for the VSP to do it, it's possible that the tx could be mined and have 6+ confs, but the amount paid is not enough, or the payment is sent to the wrong address.