### PR TITLE
Set complete=false in redeemmultisigout on invalid sigs

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4946,10 +4946,7 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd any) (any, error) 
 	// `complete' denotes that we successfully signed all outputs and that
 	// all scripts will run to completion. This is returned as part of the
 	// reply.
-	signErrs, err := w.SignTransaction(ctx, tx, hashType, inputs, keys, scripts)
-	if err != nil {
-		return nil, err
-	}
+	signErrs, signErr := w.SignTransaction(ctx, tx, hashType, inputs, keys, scripts)
 
 	var b strings.Builder
 	b.Grow(2 * tx.SerializeSize())
@@ -4972,7 +4969,7 @@ func (s *Server) signRawTransaction(ctx context.Context, icmd any) (any, error) 
 
 	return types.SignRawTransactionResult{
 		Hex:      b.String(),
-		Complete: len(signErrors) == 0,
+		Complete: len(signErrors) == 0 && signErr == nil,
 		Errors:   signErrors,
 	}, nil
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4833,6 +4833,7 @@ func (w *Wallet) SignTransaction(ctx context.Context, tx *wire.MsgTx, hashType t
 	err := walletdb.View(ctx, w.db, func(dbtx walletdb.ReadTx) error {
 		addrmgrNs := dbtx.ReadBucket(waddrmgrNamespaceKey)
 		txmgrNs := dbtx.ReadBucket(wtxmgrNamespaceKey)
+		var errEval error
 
 		for i, txIn := range tx.TxIn {
 			// For an SSGen tx, skip the first input as it is a stake base
@@ -4931,6 +4932,8 @@ func (w *Wallet) SignTransaction(ctx context.Context, tx *wire.MsgTx, hashType t
 							multisigNotEnoughSigs = true
 						}
 					}
+				} else {
+					errEval = err
 				}
 				// Only report an error for the script engine in the event
 				// that it's not a multisignature underflow, indicating that
@@ -4944,10 +4947,10 @@ func (w *Wallet) SignTransaction(ctx context.Context, tx *wire.MsgTx, hashType t
 				}
 			}
 		}
-		return nil
+		return errEval
 	})
 	if err != nil {
-		return nil, errors.E(op, err)
+		return signErrors, errors.E(op, err)
 	}
 	return signErrors, nil
 }


### PR DESCRIPTION
If the raw transaction provided by the caller contains invalid signatures, set complete=false to indicate that the transaction is not ready to send.

This situation (where the user has manually modified the transaction after a previous redeemmultisigout call, which may add some of the required signatures) is unfortunate and there are possibly better ways we could deal with this, such as removing the invalid signature, or returning a more descriptive error for the failed script evaluation.

Refs #2273 