### PR TITLE
Log transaction changes for non-initial rescans

### DIFF
--- a/wallet/udb/txquery.go
+++ b/wallet/udb/txquery.go
@@ -276,17 +276,19 @@ func (s *Store) Tx(ns walletdb.ReadBucket, txHash *chainhash.Hash) (*wire.MsgTx,
 
 // ExistsTx checks to see if a transaction exists in the database.
 func (s *Store) ExistsTx(ns walletdb.ReadBucket, txHash *chainhash.Hash) bool {
-	// First, check whether there exists an unmined transaction with this
-	// hash.  Use it if found.
+	mined, unmined := s.ExistsTxMinedOrUnmined(ns, txHash)
+	return mined || unmined
+}
+
+// ExistsTxMinedOrUnmined checks if a transaction is recorded as a mined or
+// unmined transaction.
+func (s *Store) ExistsTxMinedOrUnmined(ns walletdb.ReadBucket, txHash *chainhash.Hash) (mined, unmined bool) {
 	v := existsRawUnmined(ns, txHash[:])
 	if v != nil {
-		return true
+		return false, true
 	}
-
-	// Otherwise, if there exists a mined transaction with this matching
-	// hash, skip over to the newest and begin fetching the msgTx.
 	_, v = latestTxRecord(ns, txHash[:])
-	return v != nil
+	return v != nil, false
 }
 
 // ExistsUTXO checks to see if op refers to an unspent transaction output or a

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -141,12 +141,14 @@ type Wallet struct {
 	lockedOutpoints  map[outpoint]struct{}
 	lockedOutpointMu sync.Mutex
 
-	relayFee                dcrutil.Amount
-	relayFeeMu              sync.Mutex
-	allowHighFees           bool
-	disableCoinTypeUpgrades bool
-	recentlyPublished       map[chainhash.Hash]struct{}
-	recentlyPublishedMu     sync.Mutex
+	relayFee                   dcrutil.Amount
+	relayFeeMu                 sync.Mutex
+	allowHighFees              bool
+	disableCoinTypeUpgrades    bool
+	recentlyPublished          map[chainhash.Hash]struct{}
+	recentlyPublishedMu        sync.Mutex
+	logRescannedTransactions   bool
+	logRescannedTransactionsMu sync.Mutex
 
 	// Internal address handling.
 	ticketAddress    stdaddr.StakeAddress


### PR DESCRIPTION
For all rescans except for the initial one when a wallet is first synced (during reseed, or after process restart), log those transactions that are changed status from unmined to mined in a block, and any newly-observed transaction that is added to the wallet.

These later rescans are typically done to fix a problem syncing blocks and/or transactions, and these transaction hashes should be useful information to discover what previously went wrong.