### PR TITLE
Backport VSP client fixes to 1.8 

### DIFF
--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -331,7 +331,7 @@ func (fp *feePayment) next() time.Duration {
 	var jitter time.Duration
 	switch {
 	case tipHeight < ticketLive: // immature, mined ticket
-		blocksUntilLive := ticketExpires - tipHeight
+		blocksUntilLive := ticketLive - tipHeight
 		jitter = params.TargetTimePerBlock * time.Duration(blocksUntilLive)
 		if jitter > immatureJitter {
 			jitter = immatureJitter

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -865,31 +865,7 @@ func (fp *feePayment) confirmPayment() (err error) {
 
 	status, err := fp.client.status(ctx, &fp.ticketHash)
 	if err != nil {
-
 		log.Warnf("Rescheduling status check for %v: %v", &fp.ticketHash, err)
-
-		// Stop processing if the status check cannot be performed, but
-		// a significant amount of confirmations are observed on the fee
-		// transaction.
-		//
-		// Otherwise, chedule another confirmation check, in case the
-		// status API can be performed at a later time or more
-		// confirmations are observed.
-		fp.mu.Lock()
-		feeHash := fp.feeHash
-		fp.mu.Unlock()
-		confs, err := w.TxConfirms(ctx, &feeHash)
-		if err != nil {
-			return err
-		}
-		if confs >= 6 {
-			fp.remove("confirmed")
-			err = w.UpdateVspTicketFeeToConfirmed(ctx, &fp.ticketHash, &feeHash, fp.client.URL, fp.client.PubKey)
-			if err != nil {
-				return err
-			}
-			return nil
-		}
 		fp.schedule("confirm payment", fp.confirmPayment)
 		return nil
 	}

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -248,10 +248,9 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pai
 		log.Errorf("%v is not a ticket: %v", ticketHash, err)
 		return nil
 	}
-	// Try to access the voting key, ignore error unless the wallet is
-	// locked.
+	// Try to access the voting key.
 	fp.votingKey, err = w.DumpWIFPrivateKey(ctx, fp.votingAddr)
-	if err != nil && !errors.Is(err, errors.Locked) {
+	if err != nil {
 		log.Errorf("no voting key for ticket %v: %v", ticketHash, err)
 		return nil
 	}
@@ -865,11 +864,10 @@ func (fp *feePayment) confirmPayment() (err error) {
 	}()
 
 	status, err := fp.client.status(ctx, &fp.ticketHash)
-	// Suppress log if the wallet is currently locked.
-	if err != nil && !errors.Is(err, errors.Locked) {
-		log.Warnf("Rescheduling status check for %v: %v", &fp.ticketHash, err)
-	}
 	if err != nil {
+
+		log.Warnf("Rescheduling status check for %v: %v", &fp.ticketHash, err)
+
 		// Stop processing if the status check cannot be performed, but
 		// a significant amount of confirmations are observed on the fee
 		// transaction.

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -212,7 +212,7 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pai
 
 	fp = &feePayment{
 		client:     c,
-		ctx:        ctx,
+		ctx:        context.Background(),
 		ticketHash: *ticketHash,
 		policy:     c.policy,
 	}

--- a/internal/vsp/feepayment.go
+++ b/internal/vsp/feepayment.go
@@ -134,6 +134,49 @@ func parseTicket(ticket *wire.MsgTx, params *chaincfg.Params) (
 	return
 }
 
+// calcHeights checks if the ticket has been mined, and if so, sets the live
+// height and expiry height fields. Should be called with mutex already held.
+func (fp *feePayment) calcHeights() {
+	_, minedHeight, err := fp.client.wallet.TxBlock(fp.ctx, &fp.ticketHash)
+	if err != nil {
+		// This is not expected to ever error, as the ticket has already been
+		// fetched from the wallet at least one before this point is reached.
+		log.Errorf("Failed to query block which mines ticket: %v", err)
+		return
+	}
+
+	if minedHeight < 2 {
+		return
+	}
+
+	params := fp.client.wallet.ChainParams()
+
+	// Note the off-by-one; this is correct. Tickets become live one block after
+	// the params would indicate.
+	fp.ticketLive = minedHeight + int32(params.TicketMaturity) + 1
+	fp.ticketExpires = fp.ticketLive + int32(params.TicketExpiry)
+}
+
+// expiryHeight returns the height at which the ticket expires. Returns zero if
+// the block is not yet mined. Should be called with mutex already held.
+func (fp *feePayment) expiryHeight() int32 {
+	if fp.ticketExpires == 0 {
+		fp.calcHeights()
+	}
+
+	return fp.ticketExpires
+}
+
+// liveHeight returns the height at which the ticket becomes live. Returns zero
+// if the block is not yet mined. Should be called with mutex already held.
+func (fp *feePayment) liveHeight() int32 {
+	if fp.ticketLive == 0 {
+		fp.calcHeights()
+	}
+
+	return fp.ticketLive
+}
+
 func (fp *feePayment) ticketSpent() bool {
 	ctx := fp.ctx
 	ticketOut := wire.OutPoint{Hash: fp.ticketHash, Index: 0, Tree: 1}
@@ -147,7 +190,7 @@ func (fp *feePayment) ticketExpired() bool {
 	_, tipHeight := w.MainChainTip(ctx)
 
 	fp.mu.Lock()
-	expires := fp.ticketExpires
+	expires := fp.expiryHeight()
 	fp.mu.Unlock()
 
 	return expires > 0 && tipHeight >= expires
@@ -227,20 +270,6 @@ func (c *Client) feePayment(ctx context.Context, ticketHash *chainhash.Hash, pai
 	if err != nil {
 		log.Warnf("no ticket found for %v", ticketHash)
 		return nil
-	}
-
-	_, ticketHeight, err := w.TxBlock(ctx, ticketHash)
-	if err != nil {
-		// This is not expected to ever error, as the ticket was fetched
-		// from the wallet in the above call.
-		log.Errorf("failed to query block which mines ticket: %v", err)
-		return nil
-	}
-	if ticketHeight >= 2 {
-		// Note the off-by-one; this is correct.  Tickets become live
-		// one block after the params would indicate.
-		fp.ticketLive = ticketHeight + int32(params.TicketMaturity) + 1
-		fp.ticketExpires = fp.ticketLive + int32(params.TicketExpiry)
 	}
 
 	fp.votingAddr, fp.commitmentAddr, err = parseTicket(ticket, params)
@@ -324,8 +353,8 @@ func (fp *feePayment) next() time.Duration {
 	_, tipHeight := w.MainChainTip(fp.ctx)
 
 	fp.mu.Lock()
-	ticketLive := fp.ticketLive
-	ticketExpires := fp.ticketExpires
+	ticketLive := fp.liveHeight()
+	ticketExpires := fp.expiryHeight()
 	fp.mu.Unlock()
 
 	var jitter time.Duration


### PR DESCRIPTION
Backporting various fixes for the VSP client to 1.8 release branch. Most important of these is the hard-coded background context which fixes an issue where VSP client is unable to retry failed fee payments. Without this fix, the only work-around is to re-register tickets with failed fee payments to another VSP via manual intervention. Thanks to @kandiru for help investigating and testing this.