### PR TITLE
gRPC: Update docker image for protobuf-builder.

### DIFF
--- a/rpc/Dockerfile
+++ b/rpc/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14-buster
+FROM golang:1.21.0-bookworm
 
 RUN apt-get update && apt-get install -y protobuf-compiler
 


### PR DESCRIPTION
This updates the docker image used to regenerate the gRPC files to use go1.21.0-bookworm as the base image which in turn uses protoc v3.21.12 and matches the latest checked in generated code.