### PR TITLE
txrules: Consider DCP0012 in VSP fee calculations.

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -307,9 +307,11 @@ func (w *Wallet) evaluateStakePoolTicket(rec *udb.TxRecord, blockHeight int32, p
 
 		// Calculate the fee required based on the current
 		// height and the required amount from the pool.
+		const dcp0010Active = false
+		const dcp0012Active = false
 		feeNeeded := txrules.StakePoolTicketFee(dcrutil.Amount(
 			tx.TxOut[0].Value), fees, blockHeight, w.poolFees,
-			w.chainParams, false)
+			w.chainParams, dcp0010Active, dcp0012Active)
 		if commitAmt < feeNeeded {
 			log.Warnf("User %s submitted ticket %v which "+
 				"has less fees than are required to use this "+

--- a/wallet/txrules/poolfees.go
+++ b/wallet/txrules/poolfees.go
@@ -34,7 +34,7 @@ var initSubsidyCacheOnce sync.Once
 // calculation of this fee.
 func StakePoolTicketFee(stakeDiff dcrutil.Amount, relayFee dcrutil.Amount,
 	height int32, poolFee float64, params *chaincfg.Params,
-	dcp0010Active bool) dcrutil.Amount {
+	dcp0010Active bool, dcp0012Active bool) dcrutil.Amount {
 	// Shift the decimal two places, e.g. 1.00%
 	// to 100. This assumes that the proportion
 	// is already multiplied by 100 to give a
@@ -56,8 +56,15 @@ func StakePoolTicketFee(stakeDiff dcrutil.Amount, relayFee dcrutil.Amount,
 	initSubsidyCacheOnce.Do(func() {
 		subsidyCache = blockchain.NewSubsidyCache(params)
 	})
-	subsidy := subsidyCache.CalcStakeVoteSubsidyV2(int64(height),
-		dcp0010Active)
+
+	ssv := blockchain.SSVOriginal
+	switch {
+	case dcp0012Active:
+		ssv = blockchain.SSVDCP0012
+	case dcp0010Active:
+		ssv = blockchain.SSVDCP0010
+	}
+	subsidy := subsidyCache.CalcStakeVoteSubsidyV3(int64(height), ssv)
 	for i := 0; i < adjs; i++ {
 		subsidy *= 100
 		subsidy /= 101

--- a/wallet/txrules/poolfees_test.go
+++ b/wallet/txrules/poolfees_test.go
@@ -11,20 +11,81 @@ import (
 func TestStakePoolTicketFee(t *testing.T) {
 	params := chaincfg.MainNetParams()
 	tests := []struct {
-		StakeDiff dcrutil.Amount
-		Fee       dcrutil.Amount
-		Height    int32
-		PoolFee   float64
-		Expected  dcrutil.Amount
+		StakeDiff       dcrutil.Amount
+		Fee             dcrutil.Amount
+		Height          int32
+		PoolFee         float64
+		Expected        dcrutil.Amount
+		IsDCP0010Active bool
+		IsDCP0012Active bool
 	}{
-		0: {10 * 1e8, 0.01 * 1e8, 25000, 1.00, 0.01500463 * 1e8},
-		1: {20 * 1e8, 0.01 * 1e8, 25000, 1.00, 0.01621221 * 1e8},
-		2: {5 * 1e8, 0.05 * 1e8, 50000, 2.59, 0.03310616 * 1e8},
-		3: {15 * 1e8, 0.05 * 1e8, 50000, 2.59, 0.03956376 * 1e8},
+		0: {
+			StakeDiff:       10 * 1e8,
+			Fee:             0.01 * 1e8,
+			Height:          25000,
+			PoolFee:         1.00,
+			Expected:        0.01500463 * 1e8,
+			IsDCP0010Active: false,
+			IsDCP0012Active: false,
+		},
+		1: {
+			StakeDiff:       20 * 1e8,
+			Fee:             0.01 * 1e8,
+			Height:          25000,
+			PoolFee:         1.00,
+			Expected:        0.01621221 * 1e8,
+			IsDCP0010Active: false,
+			IsDCP0012Active: false,
+		},
+		2: {
+			StakeDiff:       5 * 1e8,
+			Fee:             0.05 * 1e8,
+			Height:          50000,
+			PoolFee:         2.59,
+			Expected:        0.03310616 * 1e8,
+			IsDCP0010Active: false,
+			IsDCP0012Active: false,
+		},
+		3: {
+			StakeDiff:       15 * 1e8,
+			Fee:             0.05 * 1e8,
+			Height:          50000,
+			PoolFee:         2.59,
+			Expected:        0.03956376 * 1e8,
+			IsDCP0010Active: false,
+			IsDCP0012Active: false,
+		},
+		4: {
+			StakeDiff:       15 * 1e8,
+			Fee:             0.05 * 1e8,
+			Height:          50000,
+			PoolFee:         2.59,
+			Expected:        0.09023823 * 1e8,
+			IsDCP0010Active: true,
+			IsDCP0012Active: false,
+		},
+		5: {
+			StakeDiff:       15 * 1e8,
+			Fee:             0.05 * 1e8,
+			Height:          50000,
+			PoolFee:         2.59,
+			Expected:        0.09784185 * 1e8,
+			IsDCP0010Active: false,
+			IsDCP0012Active: true,
+		},
+		6: {
+			StakeDiff:       15 * 1e8,
+			Fee:             0.05 * 1e8,
+			Height:          50000,
+			PoolFee:         2.59,
+			Expected:        0.09784185 * 1e8,
+			IsDCP0010Active: true,
+			IsDCP0012Active: true,
+		},
 	}
 	for i, test := range tests {
 		poolFeeAmt := StakePoolTicketFee(test.StakeDiff, test.Fee, test.Height,
-			test.PoolFee, params, false)
+			test.PoolFee, params, test.IsDCP0010Active, test.IsDCP0012Active)
 		if poolFeeAmt != test.Expected {
 			t.Errorf("Test %d: Got %v: Want %v", i, poolFeeAmt, test.Expected)
 		}


### PR DESCRIPTION
Update StakePoolTicketFee so it considers whether DCP0012 is active. This is acheived by swapping the deprecated CalcStakeVoteSubsidyV2 for its replacement CalcStakeVoteSubsidyV3.

Extra test cases are added to validate that the dcp0010Active and dcp0012Active flags work as expected.