### PR TITLE
rpc: Don't use deprecated ioutil.

### DIFF
--- a/rpc/documentation/clientusage.md
+++ b/rpc/documentation/clientusage.md
@@ -53,7 +53,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	pb "decred.org/dcrwallet/v4/rpc/walletrpc"
@@ -71,7 +71,7 @@ var (
 
 func main() {
 	serverCAs := x509.NewCertPool()
-	serverCert, err := ioutil.ReadFile(certificateFile)
+	serverCert, err := os.ReadFile(certificateFile)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/rpc/grpc_example/main.go
+++ b/rpc/grpc_example/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -40,7 +39,7 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serverCAs := x509.NewCertPool()
-	serverCert, err := ioutil.ReadFile(certificateFile)
+	serverCert, err := os.ReadFile(certificateFile)
 	if err != nil {
 		return err
 	}

--- a/rpc/rpc_example/main.go
+++ b/rpc/rpc_example/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -36,7 +35,7 @@ func main() {
 }
 
 func connectWallet(host, user, pass, certFile string) (*dcrwallet.Client, error) {
-	cert, err := ioutil.ReadFile(certFile)
+	cert, err := os.ReadFile(certFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
os.ReadFile is a direct replacement for ioutil.Readfile.