### PR TITLE
wallet: Make validateHeaderChainDifficulties fulfill contract

### DIFF
--- a/wallet/difficulty.go
+++ b/wallet/difficulty.go
@@ -873,7 +873,7 @@ func (w *Wallet) validateHeaderChainDifficulties(dbtx walletdb.ReadTx, chain []*
 		// Validate advertised and performed work
 		err := w.checkDifficultyPositional(dbtx, h, parent, chain)
 		if err != nil {
-			return nil, errors.E(op, err)
+			return chain[idx:], errors.E(op, err)
 		}
 		// Check V1 Proof of Work
 		err = blockchain.CheckProofOfWork(hash, h.Bits, w.chainParams.PowLimit)


### PR DESCRIPTION
This makes the branch that handles the error for
checkDifficultyPositional() return the invalid chain in validateHeaderChainDifficulties.

Previously this branch failed to fulfill the contract of the function.