### PR TITLE
wallet: Avoid multiple BlockHash() calculations

### DIFF
--- a/wallet/udb/stakevalidation_test.go
+++ b/wallet/udb/stakevalidation_test.go
@@ -30,7 +30,8 @@ func insertMainChainHeaders(s *Store, dbtx walletdb.ReadWriteTx,
 		if err != nil {
 			return err
 		}
-		err = s.ExtendMainChain(ns, header, f)
+		blockHash := header.BlockHash()
+		err = s.ExtendMainChain(ns, header, &blockHash, f)
 		if err != nil {
 			return err
 		}

--- a/wallet/udb/txmined.go
+++ b/wallet/udb/txmined.go
@@ -201,7 +201,7 @@ func (s *Store) MainChainTip(dbtx walletdb.ReadTx) (chainhash.Hash, int32) {
 //
 // The main chain tip may not be extended unless compact filters have been saved
 // for all existing main chain blocks.
-func (s *Store) ExtendMainChain(ns walletdb.ReadWriteBucket, header *wire.BlockHeader, f *gcs2.FilterV2) error {
+func (s *Store) ExtendMainChain(ns walletdb.ReadWriteBucket, header *wire.BlockHeader, blockHash *chainhash.Hash, f *gcs2.FilterV2) error {
 	height := int32(header.Height)
 	if height < 1 {
 		return errors.E(errors.Invalid, "block 0 cannot be added")
@@ -212,8 +212,6 @@ func (s *Store) ExtendMainChain(ns walletdb.ReadWriteBucket, header *wire.BlockH
 	}
 
 	headerBucket := ns.NestedReadWriteBucket(bucketHeaders)
-
-	blockHash := header.BlockHash()
 
 	currentTipHash := ns.Get(rootTipBlock)
 	if !bytes.Equal(header.PrevBlock[:], currentTipHash) {


### PR DESCRIPTION
This PR makes some changes to the wallet, spv syncing and peer packages to avoid having to hash the exact same header multiple times.

This improves both cpu and memory allocation performance during the initial sync process.

On an informal sync on mainnet using spvconnect, this reduces the space allocated by `BlockHash()` calls by ~60% and the time spent in these functions by ~72%.