### PR TITLE
spv: Move validate header chain difficulties to earlier point in startup sync

### DIFF
--- a/internal/loggers/loggers.go
+++ b/internal/loggers/loggers.go
@@ -48,6 +48,7 @@ var (
 	WalletLog  = backendLog.Logger("WLLT")
 	TkbyLog    = backendLog.Logger("TKBY")
 	SyncLog    = backendLog.Logger("SYNC")
+	PeerLog    = backendLog.Logger("PEER")
 	GrpcLog    = backendLog.Logger("GRPC")
 	JsonrpcLog = backendLog.Logger("RPCS")
 	CmgrLog    = backendLog.Logger("CMGR")

--- a/log.go
+++ b/log.go
@@ -32,7 +32,7 @@ func init() {
 	ticketbuyer.UseLogger(loggers.TkbyLog)
 	chain.UseLogger(loggers.SyncLog)
 	spv.UseLogger(loggers.SyncLog)
-	p2p.UseLogger(loggers.SyncLog)
+	p2p.UseLogger(loggers.PeerLog)
 	rpcserver.UseLogger(loggers.GrpcLog)
 	jsonrpc.UseLogger(loggers.JsonrpcLog)
 	connmgr.UseLogger(loggers.CmgrLog)
@@ -45,6 +45,7 @@ var subsystemLoggers = map[string]slog.Logger{
 	"WLLT": loggers.WalletLog,
 	"TKBY": loggers.TkbyLog,
 	"SYNC": loggers.SyncLog,
+	"PEER": loggers.PeerLog,
 	"GRPC": loggers.GrpcLog,
 	"RPCS": loggers.JsonrpcLog,
 	"CMGR": loggers.CmgrLog,


### PR DESCRIPTION
This moves the header chain difficulty validation to an earlier point in time of the initial sync process.

This is preferable so that less work is performed in case invalid headers are received.

This PR includes a commit to move the p2p package logs to a separate subsystem, so that the syncing process can be logged with a higher logging level while not producing significant log spam due to individually logging each peer message.

Part of #2289 