### PR TITLE
spv: Move FetchMissingCFilter step to syncer startup

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -56,17 +56,21 @@ type filterProof = struct {
 }
 
 // CFiltersV2 implements the CFiltersV2 method of the wallet.Peer interface.
+// This function blocks until a valid peer in the syncer returns the
+// appropriate CFilters.
 func (s *Syncer) CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) ([]filterProof, error) {
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		rp, err := s.pickRemote(pickAny)
+		rp, err := s.waitForRemote(ctx, pickAny, true)
 		if err != nil {
 			return nil, err
 		}
 		fs, err := rp.CFiltersV2(ctx, blockHashes)
 		if err != nil {
+			log.Debugf("Error while fetching cfilters from %v: %v",
+				rp, err)
 			continue
 		}
 		return fs, nil


### PR DESCRIPTION
This moves the "fetching missing cfilters" stage of syncing from individual peer startup to the syncer startup.

This reduces the overall load by ensuring this stage is only done once instead of being done for each new peer.

Future PRs will continue the process of moving syncing stages from the per-peer `startupSync()` function to the global syncer `Run()` function, removing duplicate work that is currently done by the wallet.