### PR TITLE
spv: Move getheaders stage to global syncer instead of per-peer

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -708,6 +708,11 @@ func (rp *RemotePeer) Err() error {
 	return rp.err
 }
 
+// Done returns a channel that is closed once the peer disconnects.
+func (rp *RemotePeer) Done() <-chan struct{} {
+	return rp.errc
+}
+
 // RemoteAddr returns the remote address of the peer's TCP connection.
 func (rp *RemotePeer) RemoteAddr() net.Addr {
 	return rp.c.RemoteAddr()

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -29,6 +29,17 @@ var _ wallet.NetworkBackend = (*Syncer)(nil)
 
 func pickAny(*p2p.RemotePeer) bool { return true }
 
+// pickForGetHeaders returns a function to use in waitForRemotes which selects
+// peers that may have headers that are more recent than the passed tipHeight.
+func pickForGetHeaders(tipHeight int32) func(rp *p2p.RemotePeer) bool {
+	return func(rp *p2p.RemotePeer) bool {
+		// We are interested in this peer's headers if they announced a
+		// height greater than the current tip height and if we haven't
+		// yet fetched all the headers that it announced.
+		return rp.InitialHeight() > tipHeight && rp.LastHeight() < rp.InitialHeight()
+	}
+}
+
 // Blocks implements the Blocks method of the wallet.Peer interface.
 func (s *Syncer) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error) {
 	for {


### PR DESCRIPTION
This moves the fetch headers and cfilters stage from the per-peer startup function to the main syncer startup function.

This avoids wasting duplicate effort for every peer. In the future, this will allow using multiple peers to fetch headers and cfilters from, as well as allowing asynchronous fetching.

This change significantly reduces the amount of resources (cpu, ram, goroutines) used during the initial sync at the cost of increasing the sync time. The sync time will be reduced in the future as well, after parallelizing the headers/cfilters/chainswitch stages and after [batched cfilter fetching](https://github.com/decred/dcrd/pull/3211) is implemented and deployed.

Part of #2289