### PR TITLE
Move initial rescan to global syncer loop

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -46,12 +46,13 @@ func (s *Syncer) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		rp, err := s.pickRemote(pickAny)
+		rp, err := s.waitForRemote(ctx, pickAny, true)
 		if err != nil {
 			return nil, err
 		}
 		blocks, err := rp.Blocks(ctx, blockHashes)
 		if err != nil {
+			log.Debugf("unable to fetch blocks from %v: %v", rp, err)
 			continue
 		}
 		return blocks, nil

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -89,24 +89,6 @@ func (s *Syncer) CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) 
 	}
 }
 
-// Headers implements the Headers method of the wallet.Peer interface.
-func (s *Syncer) Headers(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error) {
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-		rp, err := s.pickRemote(pickAny)
-		if err != nil {
-			return nil, err
-		}
-		hs, err := rp.Headers(ctx, blockLocators, hashStop)
-		if err != nil {
-			continue
-		}
-		return hs, nil
-	}
-}
-
 func (s *Syncer) String() string {
 	// This method is part of the wallet.Peer interface and will typically
 	// specify the remote address of the peer.  Since the syncer can encompass

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -243,23 +243,18 @@ FilterLoop:
 		wg.Wait()
 
 		if len(fmatches) != 0 {
-			var rp *p2p.RemotePeer
 		PickPeer:
 			for {
 				if err := ctx.Err(); err != nil {
 					return err
 				}
-				if rp == nil {
-					var err error
-					rp, err = s.pickRemote(pickAny)
-					if err != nil {
-						return err
-					}
+				rp, err := s.waitForRemote(ctx, pickAny, true)
+				if err != nil {
+					return err
 				}
 
 				blocks, err := rp.Blocks(ctx, fmatches)
 				if err != nil {
-					rp = nil
 					continue PickPeer
 				}
 

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -554,18 +554,6 @@ func (s *Syncer) forRemotes(f func(rp *p2p.RemotePeer) error) error {
 	return nil
 }
 
-func (s *Syncer) pickRemote(pick func(*p2p.RemotePeer) bool) (*p2p.RemotePeer, error) {
-	defer s.remotesMu.Unlock()
-	s.remotesMu.Lock()
-
-	for _, rp := range s.remotes {
-		if pick(rp) {
-			return rp, nil
-		}
-	}
-	return nil, errors.E(errors.NoPeers)
-}
-
 // waitForAnyRemote blocks until there is one or more remote peers available or
 // the context is canceled.
 //

--- a/wallet/network.go
+++ b/wallet/network.go
@@ -33,7 +33,6 @@ type FilterProof = struct {
 type Peer interface {
 	Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error)
 	CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) ([]FilterProof, error)
-	Headers(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error)
 	PublishTransactions(ctx context.Context, txs ...*wire.MsgTx) error
 }
 

--- a/wallet/network_test.go
+++ b/wallet/network_test.go
@@ -24,9 +24,6 @@ func (mockNetwork) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([
 func (mockNetwork) CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) ([]FilterProof, error) {
 	return nil, nil
 }
-func (mockNetwork) Headers(ctx context.Context, blockLocators []*chainhash.Hash, hashStop *chainhash.Hash) ([]*wire.BlockHeader, error) {
-	return nil, nil
-}
 func (mockNetwork) PublishTransactions(ctx context.Context, txs ...*wire.MsgTx) error { return nil }
 func (mockNetwork) LoadTxFilter(ctx context.Context, reload bool, addrs []stdaddr.Address, outpoints []wire.OutPoint) error {
 	return nil


### PR DESCRIPTION
This moves the initial account and address discovery and rescan from the per-peer startup procedure to the global syncer startup sync procedure.

This makes the code easier to reason about and removes the need for the atomic lock to the discoverAccounts field.

The previous code would execute a rescan after every connected peer, if it had any new headers that connected to the main chain.  With the changes in this commit, the syncer now only performs the full rescan once at startup and relies on the header announcement logic to scan when new blocks are relayed from peers after the initial sync.


It also finishes switching all backend functions in SPV to use `waitForRemotes` and removes unneeded functions.

Part of #2289 
