### PR TITLE
spv: Track requested block locator height

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -345,7 +345,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	}
 
 	// Fetch new headers and cfilters from the server.
-	locators, err := s.wallet.BlockLocators(ctx, nil)
+	locators, _, err := s.wallet.BlockLocators(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -461,7 +461,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 				len(bestChain), tip.Hash, tip.Header.Height, tip.Header.Timestamp)
 		}
 
-		locators, err = s.wallet.BlockLocators(ctx, nil)
+		locators, _, err = s.wallet.BlockLocators(ctx, nil)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This makes the wallet BlockLocators function return the height of the first (i.e. most recent) block locator.

This makes checking if the peer failed to provide headers independent of the state of the db.

While this makes no functional difference at the moment, in the future, when fetching headers and updating the db from different goroutines, this makes it easier to reason that the check is being done correctly.