### PR TITLE
spv: Refactor initial cfilter fetching to be done in smaller batches

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1358,6 +1358,10 @@ nextbatch:
 				batch.rp, err)
 			continue nextbatch
 		}
+		if len(missingCfilter) > 0 {
+			log.Debugf("Fetched %d new cfilters(s) ending at height %d",
+				len(missingCfilter), missingCfilter[len(missingCfilter)-1].Header.Height)
+		}
 
 		// Switch the best chain, now that all cfilters have been
 		// fetched for it.


### PR DESCRIPTION
This refactors the initial cfilter fetching to be based around requesting smaller batches of cfilters from the lower p2p level.

While this does not make any functional difference at the moment, in the future, when a P2P protocol with batched CFilter is supported (https://github.com/decred/dcrd/pull/3211 or equivalent), it will be trivial to switch to using it for remote peers that support it.

Additionally, this reduces the total number of goroutines used for the underlying `CFiltersV2()` call from the p2p package, which is useful in slightly reducing the total cpu and memory loads during initial sync.