### PR TITLE
spv: Fetch cfilters from multiple remote peers

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1352,7 +1352,7 @@ nextbatch:
 		s.sidechainMu.Unlock()
 
 		// Fetch Missing CFilters.
-		err = s.cfiltersV2FromNodes(ctx, batch.rp, missingCfilter)
+		err = s.cfiltersV2FromNodes(ctx, missingCfilter)
 		if err != nil {
 			log.Debugf("Unable to fetch missing cfilters from %v: %v",
 				batch.rp, err)

--- a/wallet/sidechains.go
+++ b/wallet/sidechains.go
@@ -244,6 +244,11 @@ func (f *SidechainForest) AddBlockNode(n *BlockNode) bool {
 	return true
 }
 
+// PruneAll removes all sidechains.
+func (f *SidechainForest) PruneAll() {
+	f.trees = nil
+}
+
 // Prune removes any sidechain trees which contain a root that is significantly
 // behind the current main chain tip block.
 func (f *SidechainForest) Prune(mainChainHeight int32, params *chaincfg.Params) {


### PR DESCRIPTION
This modifies the cfilter fetching stage of the initial sync process to request cfilters from multiple peers instead of a single one.

This spreads the load across multiple peers, making the initial sync process (on average) slightly faster due to lower remote peer resource usage.