### PR TITLE
chain: Request block ntfns only after initial sync

### DIFF
--- a/rpc/client/dcrd/calls.go
+++ b/rpc/client/dcrd/calls.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"decred.org/dcrwallet/v4/errors"
@@ -391,4 +392,12 @@ func (r *RPC) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error) {
 		return 0, errors.E(op, err)
 	}
 	return sdiff, nil
+}
+
+// String returns a string representation of the caller (if it exists).
+func (r *RPC) String() string {
+	if s, ok := r.Caller.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return "rpc"
 }


### PR DESCRIPTION
Previously, request for notifications about connected blocks were sent to the underlying dcrd instance before the chain was fully synced.  This could cause a race issue if the underlying dcrd instance was also performing an initial sync, causing blocks to be connected by the blockConnected handler before the active data filter was loaded, causing transactions to be missed and the wallet's balance to be wrong, requiring a rescan to be fixed.

This could happen, for example, if both the dcrd and dcrwallet processes were started at the same time or if dcrd took just enough time to connect to the network that the wallet was also initialized (for exemple, from within Decrediton).

This fixes the issue by refactoring the initial sync code to only request block notifications after the initial header sync has been completed by the wallet.

Note that, despite a large(ish) diff, this is mostly a code move PR.

One way to reproduce the above issue in simnet is the following:

- Run [dcrd's tmux script](https://github.com/decred/dcrd/blob/master/contrib/dcr_tmux_simnet_setup.sh) to setup a full simnet env
- Create a new, empty wallet (`wallet3`)
- Run, complete the initial sync and generate an address for `wallet3`
- Shutdown the wallet
- Send (but do not mine) 1 DCR from `wallet1` to the previously generated `wallet3` address
- Apply the diff below to the current master, to increase the odds of the issue happening
- Run `wallet3` with the diff applied
- Before the 5 second timeout added by the diff elapses, mine a block that includes the transaction generated above
- The wallet will **not** see the transaction and will remain with a zero balance

```diff
diff --git a/chain/sync.go b/chain/sync.go
index 0881e218..583cdcb2 100644
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -13,6 +13,7 @@ import (
 	"runtime/trace"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"decred.org/dcrwallet/v4/errors"
 	"decred.org/dcrwallet/v4/rpc/client/dcrd"
@@ -328,6 +329,12 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 		return err
 	}
 
+	log.Infof("XXXXXXXXXXXXXXX Gonna wait 5 seconds")
+	for i := 0; i < 5; i++ {
+		time.Sleep(time.Second)
+		log.Infof("XXXXXXXXXXXX %d", i+1)
+	}
+
 	cnet := s.wallet.ChainParams().Net
 	s.fetchHeadersStart()
 	for {
```