### PR TITLE
spv: Process header batches in parallel

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -148,7 +148,7 @@ func (s *Syncer) cfiltersV2FromNodes(ctx context.Context, nodes []*wallet.BlockN
 	// watchdog interval means we'll try at least 4 different peers before
 	// resetting.
 	const watchdogTimeoutInterval = 2 * time.Minute
-	watchdogCtx, cancelWatchdog := context.WithTimeout(ctx, time.Minute)
+	watchdogCtx, cancelWatchdog := context.WithTimeout(ctx, watchdogTimeoutInterval)
 	defer cancelWatchdog()
 
 nextTry:
@@ -226,7 +226,7 @@ type headersBatch struct {
 //
 // This function returns a batch with the done flag set to true when no peers
 // have more recent blocks for syncing.
-func (s *Syncer) getHeaders(ctx context.Context) (*headersBatch, error) {
+func (s *Syncer) getHeaders(ctx context.Context, likelyBestChain []*wallet.BlockNode) (*headersBatch, error) {
 	cnet := s.wallet.ChainParams().Net
 
 nextbatch:
@@ -245,7 +245,7 @@ nextbatch:
 		log.Tracef("Attempting next batch of headers from %v", rp)
 
 		// Request headers from the selected peer.
-		locators, locatorHeight, err := s.wallet.BlockLocators(ctx, nil)
+		locators, locatorHeight, err := s.wallet.BlockLocators(ctx, likelyBestChain)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This switches the initial SPV header fetching process to process each batch of headers in parallel through its various stages.

The initial header sync process is split into a 3-stage pipeline, where batches of headers progress through. Each stage is run on a separate goroutine, providing some parallelism for the entire process.

The following is a rough comparison of sync times with/without this PR (all on mainnet, [reference master](https://github.com/decred/dcrwallet/commit/9873543d9880637f22978cfc47f83bf100f8d456)):

```
master
[DBG] SYNC: Initial sync completed in 13m3s
[DBG] SYNC: Initial sync completed in 13m2s
[DBG] SYNC: Initial sync completed in 13m34s

master, spvconnect to a known fast peer
[DBG] SYNC: Initial sync completed in 7m42s
[DBG] SYNC: Initial sync completed in 7m4s
[DBG] SYNC: Initial sync completed in 7m22s

this PR
[DBG] SYNC: Initial sync completed in 9m53s
[DBG] SYNC: Initial sync completed in 8m32s
[DBG] SYNC: Initial sync completed in 8m42s

this PR, spvconnect to a known fast peer
[DBG] SYNC: Initial sync completed in 4m49s
[DBG] SYNC: Initial sync completed in 4m46s
[DBG] SYNC: Initial sync completed in 4m43s
```

Part of #2289.