### PR TITLE
Use Go 1.19 atomic types

### DIFF
--- a/internal/rpc/jsonrpc/server.go
+++ b/internal/rpc/jsonrpc/server.go
@@ -279,11 +279,11 @@ func throttledFn(threshold int64, f http.HandlerFunc) http.Handler {
 // throttled wraps an http.Handler with throttling of concurrent active
 // clients by responding with an HTTP 429 when the threshold is crossed.
 func throttled(threshold int64, h http.Handler) http.Handler {
-	var active int64
+	var active atomic.Int64
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		current := atomic.AddInt64(&active, 1)
-		defer atomic.AddInt64(&active, -1)
+		current := active.Add(1)
+		defer active.Add(-1)
 
 		if current-1 >= threshold {
 			log.Warnf("Reached threshold of %d concurrent active clients", threshold)

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -36,7 +36,7 @@ const reqSvcs = wire.SFNodeNetwork
 // protocol using Simplified Payment Verification (SPV) with compact filters.
 type Syncer struct {
 	// atomics
-	atomicWalletSynced uint32 // CAS (synced=1) when wallet syncing complete
+	atomicWalletSynced atomic.Uint32 // CAS (synced=1) when wallet syncing complete
 
 	wallet *wallet.Wallet
 	lp     *p2p.LocalPeer
@@ -149,7 +149,7 @@ func (s *Syncer) DisableDiscoverAccounts() {
 // synced checks the atomic that controls wallet syncness and if previously
 // unsynced, updates to synced and notifies the callback, if set.
 func (s *Syncer) synced() {
-	if atomic.CompareAndSwapUint32(&s.atomicWalletSynced, 0, 1) &&
+	if s.atomicWalletSynced.CompareAndSwap(0, 1) &&
 		s.notifications != nil &&
 		s.notifications.Synced != nil {
 		s.notifications.Synced(true)
@@ -158,7 +158,7 @@ func (s *Syncer) synced() {
 
 // Synced returns whether this wallet is completely synced to the network.
 func (s *Syncer) Synced() bool {
-	return atomic.LoadUint32(&s.atomicWalletSynced) == 1
+	return s.atomicWalletSynced.Load() == 1
 }
 
 // EstimateMainChainTip returns an estimated height for the current tip of the

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -101,7 +101,7 @@ type outpoint struct {
 type Wallet struct {
 	// disapprovePercent is an atomic. It sets the percentage of blocks to
 	// disapprove on simnet or testnet.
-	disapprovePercent uint32
+	disapprovePercent atomic.Uint32
 
 	// Data stores
 	db       walletdb.DB
@@ -201,13 +201,13 @@ type Config struct {
 
 // DisapprovePercent returns the wallet's block disapproval percentage.
 func (w *Wallet) DisapprovePercent() uint32 {
-	return atomic.LoadUint32(&w.disapprovePercent)
+	return w.disapprovePercent.Load()
 }
 
 // SetDisapprovePercent sets the wallet's block disapproval percentage. Do not
 // set on mainnet.
 func (w *Wallet) SetDisapprovePercent(percent uint32) {
-	atomic.StoreUint32(&w.disapprovePercent, percent)
+	w.disapprovePercent.Store(percent)
 }
 
 // FetchOutput fetches the associated transaction output given an outpoint.


### PR DESCRIPTION
These types prevent atomic misuse by only allowing access through the provided methods and guarantee proper alignment even if the variables are moved in the struct layout.