### PR TITLE
Fix grpc log prefix stripping

### DIFF
--- a/internal/rpc/rpcserver/log.go
+++ b/internal/rpc/rpcserver/log.go
@@ -42,7 +42,7 @@ func stripGrpcPrefix(logstr string) string {
 // stripGrpcPrefixArgs removes the package prefix from the first argument, if it
 // exists and is a string, returning the same arg slice after reassigning the
 // first arg.
-func stripGrpcPrefixArgs(args ...any) []any {
+func stripGrpcPrefixArgs(args []any) []any {
 	if len(args) == 0 {
 		return args
 	}


### PR DESCRIPTION
A typing error was preventing stripGrpcPrefixArgs from working as intended. Before, the type check for args[0] to be a string type would always fail, and no prefix stripping occurred.

Fixes #2169.