### PR TITLE
wallet: Fix off-by-one in addr discovery

### DIFF
--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -184,7 +184,7 @@ func (a *addrFinder) find(ctx context.Context, start *chainhash.Hash, p Peer) er
 			return err
 		}
 		_, tipHeight := a.w.txStore.MainChainTip(dbtx)
-		storage := make([]*udb.BlockCFilter, tipHeight-int32(h.Height))
+		storage := make([]*udb.BlockCFilter, tipHeight-int32(h.Height)+1)
 		fs, err = a.w.txStore.GetMainChainCFilters(dbtx, start, true, storage)
 		return err
 	})


### PR DESCRIPTION
This fixes an off-by-one in sizing the backing array for cfilter data during address discovery.

During address discovery, the GetMainChainCFilters call to fetch cfilters from the DB uses an array sized by the caller to put the data. However, due to being an inclusive fetch, the call in the address finder is not correctly sized, missing one (i.e. the last) block.

This could cause an issue when the wallet had a single address used and that address was used on a transaction on the wallet's tip, causing the wallet to miss that address being used.

Required by #2318.

This was uncovered while debugging [this test](https://github.com/decred/dcrwallet/pull/2318/files#diff-0acd0b60cd995be3ef8f885d942a9fd509ffd3375f3486a31a29d3e1846843a9R183-R200)