### PR TITLE
Do not send reject messages for bad services

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -259,11 +259,8 @@ func (lp *LocalPeer) ConnectOutbound(ctx context.Context, addr string, reqSvcs w
 	// Disconnect from the peer if it does not specify all required services.
 	if rp.services&reqSvcs != reqSvcs {
 		op := errors.Opf(opf, rp.raddr)
-		reason := errors.Errorf("missing required service flags %v", reqSvcs&^rp.services)
-		reject := wire.NewMsgReject(wire.CmdVersion, wire.RejectNonstandard, reason.Error())
-		rp.sendMessageAck(ctx, reject)
-
-		err := errors.E(op, reason)
+		err := errors.E(op, errors.Errorf("missing required service flags %v",
+			reqSvcs&^rp.services))
 		rp.Disconnect(err)
 		return nil, err
 	}


### PR DESCRIPTION
The reject message is deprecated, and has also been removed from the most recent protocol version entirely.

Although the reject could be sent after a check of the negotiated pver, there's no value to sending a reject to a peer for bad advertised services. No message was ever rejected from being received by the remote peer.