### PR TITLE
wallet: Remove mainchain tip check on NeedsAccountsSync

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5243,11 +5243,6 @@ func (w *Wallet) ChainParams() *chaincfg.Params {
 // should be performed to restore, per BIP0044, any generated accounts and
 // addresses from a restored seed.
 func (w *Wallet) NeedsAccountsSync(ctx context.Context) (bool, error) {
-	_, tipHeight := w.MainChainTip(ctx)
-	if tipHeight != 0 {
-		return false, nil
-	}
-
 	needsSync := true
 	err := walletdb.View(ctx, w.db, func(tx walletdb.ReadTx) error {
 		addrmgrNs := tx.ReadBucket(waddrmgrNamespaceKey)


### PR DESCRIPTION
This check could prevent a wallet from going through address discovery if it had not completed the initial chain sync prior to being restarted.

One instance this could happen is when restoring SPV wallets under an instable network connection or having a power loss during the initial sync of a restored wallet.

Detected while debugging issues with #2318.