### PR TITLE
[release-v1.8] p2p: update the required minimum protocol version

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -39,10 +39,10 @@ var uaVersion = version.String()
 
 // minPver is the minimum protocol version we require remote peers to
 // implement.
-const minPver = wire.CFilterV2Version
+const minPver = wire.RemoveRejectVersion
 
 // Pver is the maximum protocol version implemented by the LocalPeer.
-const Pver = wire.InitStateVersion
+const Pver = wire.RemoveRejectVersion
 
 // connectTimeout is the amount of time allowed before connecting, peering
 // handshake, and protocol negotiation is aborted.
@@ -757,8 +757,6 @@ func (rp *RemotePeer) readMessages(ctx context.Context) error {
 				if rp.lp.messageIsMasked(MaskInv) {
 					rp.lp.receivedInv <- newInMsg(rp, msg)
 				}
-			case *wire.MsgReject:
-				log.Warnf("%v reject(%v, %v, %v): %v", rp.raddr, m.Cmd, m.Code, &m.Hash, m.Reason)
 			case *wire.MsgGetMiningState:
 				rp.receivedGetMiningState(ctx)
 			case *wire.MsgGetInitState:


### PR DESCRIPTION
This is a backport of 92b6b88ab6f858eccd2627263c475e54b68d7f21.