### PR TITLE
chain: Wait for dcrd to sync before starting RPC sync

### DIFF
--- a/config.go
+++ b/config.go
@@ -133,6 +133,9 @@ type config struct {
 	dial         func(ctx context.Context, network, address string) (net.Conn, error)
 	lookup       func(name string) ([]net.IP, error)
 
+	// Offline mode.
+	Offline bool `long:"offline" description:"Do not sync the wallet"`
+
 	// SPV options
 	SPV        bool     `long:"spv" description:"Sync using simplified payment verification"`
 	SPVConnect []string `long:"spvconnect" description:"SPV sync only with specified peers; disables DNS seeding"`
@@ -867,6 +870,12 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 				}
 			}
 		}
+	}
+
+	if cfg.SPV && cfg.Offline {
+		err := errors.E("SPV and Offline mode cannot be specified at the same time")
+		fmt.Fprintln(os.Stderr, err)
+		return loadConfigError(err)
 	}
 
 	if cfg.SPV && cfg.EnableVoting {

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -443,9 +443,12 @@ func run(ctx context.Context) error {
 				}
 			}
 
-			if cfg.SPV {
+			switch {
+			case cfg.Offline:
+				w.SetNetworkBackend(wallet.OfflineNetworkBackend{})
+			case cfg.SPV:
 				spvLoop(ctx, w)
-			} else {
+			default:
 				rpcSyncLoop(ctx, w)
 			}
 		})

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -53,6 +53,9 @@
 ; File containing root certificates to authenticate TLS connections with dcrd
 ; cafile=~/.dcrwallet/dcrd.cert
 
+; When enabled, do not perform any sync with the network, either through RPC or
+; SPV modes. Useful when this is an air-gapped wallet.
+; offline=0
 
 
 ; ------------------------------------------------------------------------------

--- a/wallet/network.go
+++ b/wallet/network.go
@@ -81,3 +81,41 @@ type Caller interface {
 	// a result (if any), or nil if no result is needed.
 	Call(ctx context.Context, method string, res any, args ...any) error
 }
+
+var errOfflineNetworkBackend = errors.New("operation not supported in offline mode")
+
+// OfflineNetworkBackend is a NetworkBackend that fails every call. It is meant
+// to be used in wallets which will only perform local operations.
+type OfflineNetworkBackend struct{}
+
+func (o OfflineNetworkBackend) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error) {
+	return nil, errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) CFiltersV2(ctx context.Context, blockHashes []*chainhash.Hash) ([]FilterProof, error) {
+	return nil, errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) PublishTransactions(ctx context.Context, txs ...*wire.MsgTx) error {
+	return errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) LoadTxFilter(ctx context.Context, reload bool, addrs []stdaddr.Address, outpoints []wire.OutPoint) error {
+	return errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) Rescan(ctx context.Context, blocks []chainhash.Hash, save func(block *chainhash.Hash, txs []*wire.MsgTx) error) error {
+	return errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error) {
+	return 0, errOfflineNetworkBackend
+}
+
+func (o OfflineNetworkBackend) Synced(ctx context.Context) (bool, int32) {
+	return true, 0
+}
+
+// Compile time check to ensure OfflineNetworkBackend fulfills the
+// NetworkBackend interface.
+var _ NetworkBackend = OfflineNetworkBackend{}


### PR DESCRIPTION
This prevents the wallet from syncing from blockConnected messages when it is connected to a dcrd instance that is not yet as synced as the one the wallet has used in the past. This improves performance by batching the sync work in the initial getHeaders stage and prevents wallet misuse by ensuring the underlying dcrd is also synced to recent blocks.

Note that the the case of a new wallet (with recorded tip height 0) connected to a network isolated dcrd instance (header and block height both 0) is explicitly allowed to proceed without waiting. This handles the use-cases of airgapped and empty simnet wallets.