### PR TITLE
multi: Expose disablerelaytx

### DIFF
--- a/config.go
+++ b/config.go
@@ -148,8 +148,9 @@ type config struct {
 	Offline bool `long:"offline" description:"Do not sync the wallet"`
 
 	// SPV options
-	SPV        bool     `long:"spv" description:"Sync using simplified payment verification"`
-	SPVConnect []string `long:"spvconnect" description:"SPV sync only with specified peers; disables DNS seeding"`
+	SPV               bool     `long:"spv" description:"Sync using simplified payment verification"`
+	SPVConnect        []string `long:"spvconnect" description:"SPV sync only with specified peers; disables DNS seeding"`
+	SPVDisableRelayTx bool     `long:"spvdisablerelaytx" description:"Disable receiving mempool transactions when in SPV mode"`
 
 	// RPC server options
 	RPCCert                *cfgutil.ExplicitString `long:"rpccert" description:"RPC server TLS certificate"`

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -546,6 +546,7 @@ func spvLoop(ctx context.Context, w *wallet.Wallet) {
 	amgr := addrmgr.New(amgrDir, cfg.lookup)
 	lp := p2p.NewLocalPeer(w.ChainParams(), addr, amgr)
 	lp.SetDialFunc(cfg.dial)
+	lp.SetDisableRelayTx(cfg.SPVDisableRelayTx)
 	syncer := spv.NewSyncer(w, lp)
 	if len(cfg.SPVConnect) > 0 {
 		syncer.SetPersistentPeers(cfg.SPVConnect)

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -199,6 +199,24 @@
 
 
 ; ------------------------------------------------------------------------------
+; SPV settings
+; ------------------------------------------------------------------------------
+
+; Enable SPV mode by setting SPV to 1.
+; spv=1
+
+; spvconnect may be used to specify specific peers to connect to, when using
+; SPV mode. Multiple peers may be specified. When spvconnect is set, the wallet
+; will connect _only_ to the listed peers.
+; spvconnect=
+
+; Set spvdisablerelaytx to 1 to disable receiving transactions from remote peers
+; in SPV mode. This reduces bandwidth consumption but effectively disables the
+; mempool.
+; spvdisablerelaytx=1
+
+
+; ------------------------------------------------------------------------------
 ; Debug
 ; ------------------------------------------------------------------------------
 


### PR DESCRIPTION
This setting allows the wallet to not sync mempool transactions when in SPV mode. This is useful to reduce cpu, memory and bandwidth consumption for wallets that see very few useful mempool transactions, such as wallets meant for only occasional use or mobile wallets.

The setting is exposed as a CLI or config argument --spvdisablerelaytx.

Related: https://github.com/decred/dcrd/issues/3234