### PR TITLE
rpc: allow syncing older tips on test networks

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -467,6 +467,7 @@ func normalizeAddress(addr string, defaultPort string) (hostport string, err err
 // passed height and that is has all blockchain data up to its target header
 // height.
 func (s *Syncer) waitRPCSync(ctx context.Context, minHeight int64) error {
+	isMainnet := s.wallet.ChainParams().Net == wire.MainNet
 	for {
 		info, err := s.rpc.GetBlockchainInfo(ctx)
 		if err != nil {
@@ -476,7 +477,7 @@ func (s *Syncer) waitRPCSync(ctx context.Context, minHeight int64) error {
 		if info.Headers > minHeight {
 			minHeight = info.Headers
 		}
-		if info.Blocks >= minHeight && !info.InitialBlockDownload {
+		if info.Blocks >= minHeight && (!isMainnet || !info.InitialBlockDownload) {
 			// dcrd is synced.
 			return nil
 		}

--- a/chain/sync.go
+++ b/chain/sync.go
@@ -467,7 +467,7 @@ func normalizeAddress(addr string, defaultPort string) (hostport string, err err
 // passed height and that is has all blockchain data up to its target header
 // height.
 func (s *Syncer) waitRPCSync(ctx context.Context, minHeight int64) error {
-	isMainnet := s.wallet.ChainParams().Net == wire.MainNet
+	isSimnet := s.wallet.ChainParams().Net == wire.SimNet
 	for {
 		info, err := s.rpc.GetBlockchainInfo(ctx)
 		if err != nil {
@@ -477,7 +477,7 @@ func (s *Syncer) waitRPCSync(ctx context.Context, minHeight int64) error {
 		if info.Headers > minHeight {
 			minHeight = info.Headers
 		}
-		if info.Blocks >= minHeight && (!isMainnet || !info.InitialBlockDownload) {
+		if info.Blocks >= minHeight && (isSimnet || !info.InitialBlockDownload) {
 			// dcrd is synced.
 			return nil
 		}


### PR DESCRIPTION
#2340 added additional sync conditions to startup, one of which is that `InitialBlockDownload` from `getblockchaininfo` must be `true`. A condition for `InitialBlockDownload` to be true is that the best header cannot be older than 24 hours.

In dcrdex, we use a simnet harness that starts with an archived chain with about 600 blocks. Building the chain from scratch takes substantial time, and we can't e.g. mine one block to get a fresh header, because the wallets can't vote. 

This change forego's the check of `InitialBlockDownload` on test networks, leaving in place the condition `info.Blocks >= minHeight`.