### PR TITLE
Improve error message for initial csppsolver check

### DIFF
--- a/config.go
+++ b/config.go
@@ -795,10 +795,12 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 				"other peers publishing results")
 		}
 	}
-	if solverMustWork && !testStartedSolverWorks() {
-		err := errors.Errorf("csppsolver process is not operating properly")
-		fmt.Fprintln(os.Stderr, err)
-		return loadConfigError(err)
+	if solverMustWork {
+		if err := testStartedSolverWorks(); err != nil {
+			err := errors.Errorf("csppsolver process is not operating properly: %v", err)
+			fmt.Fprintln(os.Stderr, err)
+			return loadConfigError(err)
+		}
 	}
 
 	// Parse mixedaccount account/branch

--- a/testsolver.go
+++ b/testsolver.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math/big"
 	"net/rpc"
@@ -14,9 +15,9 @@ import (
 	"github.com/decred/dcrd/mixing"
 )
 
-func testStartedSolverWorks() bool {
+func testStartedSolverWorks() error {
 	if err := solverrpc.StartSolver(); err != nil {
-		return false
+		return err
 	}
 
 	// Values don't matter; we just need to not observe an io.UnexpectedEOF
@@ -27,8 +28,8 @@ func testStartedSolverWorks() bool {
 	}
 	_, err := solverrpc.Roots(coeffs, mixing.F)
 	if errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, rpc.ErrShutdown) {
-		return false
+		return fmt.Errorf("rpc failed: %w", err)
 	}
 
-	return true
+	return nil
 }


### PR DESCRIPTION
There was some confusion over the `csppsolver` option that resulted in it being set as if it were a boolean option.  This caused a properly built and working csppsolver to not be used, and instead, the solverrpc package attempted look up and exec a file named "1".  Adding the error message would have removed some confusion as this was debugged.