### PR TITLE
chain: Wait for errgroup before returning from sync

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -632,7 +632,14 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(ctx)
 	g, ctx := errgroup.WithContext(ctx)
+	defer func() {
+		cancel()
+		if e := g.Wait(); err == nil {
+			err = e
+		}
+	}()
 	g.Go(func() error {
 		// Run wallet background goroutines (currently, this just runs
 		// mixclient).


### PR DESCRIPTION
If syncing over JSON-RPC is being reattempted in a loop, as the main package does, not waiting for the errgroup that runs the wallet's mixing client may cause it to concurrently enter mixclient.Client.Run again before it has returned.  This eventually results in a panic due to closing the already-closed warming chan.

This is a backport candidate for 2.0.1.