### PR TITLE
p2p: Ban peer with mix inv when disablerelaytx is active

### DIFF
--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -2141,11 +2141,14 @@ func (rp *RemotePeer) GetInitState(ctx context.Context, msg *wire.MsgGetInitStat
 	}
 }
 
-// invVecContainsTx returns true if at least one inv vector is of type
-// transaction.
-func invVecContainsTx(inv []*wire.InvVect) bool {
+// invVecContainsTxOrMix returns true if at least one inv vector is of type
+// transaction or mix message.
+func invVecContainsTxOrMix(inv []*wire.InvVect) bool {
 	for i := range inv {
 		if inv[i].Type == wire.InvTypeTx {
+			return true
+		}
+		if inv[i].Type == wire.InvTypeMix {
 			return true
 		}
 	}
@@ -2157,7 +2160,7 @@ func (rp *RemotePeer) receivedInv(ctx context.Context, inv *wire.MsgInv) {
 	const opf = "remotepeer(%v).receivedInv"
 
 	// When tx relay is disabled, we don't expect transactions on invs.
-	if rp.lp.disableRelayTx && invVecContainsTx(inv.InvList) {
+	if rp.lp.disableRelayTx && invVecContainsTxOrMix(inv.InvList) {
 		op := errors.Opf(opf, rp.raddr)
 		err := errors.E(op, errors.Protocol, "received tx in msginv when tx relaying is disabled")
 		rp.Disconnect(err)


### PR DESCRIPTION
Version 2.0.1 of dcrd will now not send invs related to mixing when disablerelaytx is signalled during the peer negotiation stage. Therefore, the wallet should ban peers that incorrectly send such invs when the wallet was configured with this flag.

While there may still be some peers running v2.0.0 (which would cause them to be banned from the wallet), their number should be small enough to not cause significant connection issues.