### PR TITLE
[release-v2.0] spv: Fix request of new blocks after initial sync

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1820,11 +1820,6 @@ func (s *Syncer) initialSyncRescan(ctx context.Context) error {
 // peerStartup performs initial startup operations with a recently connected
 // peer.
 func (s *Syncer) peerStartup(ctx context.Context, rp *p2p.RemotePeer) error {
-	// If the initial sync process has already completed, then immediately
-	// request any new headers from the peer at the end of the peer setup
-	// process.
-	requestHeaders := s.atomicWalletSynced.Load() == 1
-
 	// Only continue with peer startup after the initial sync process
 	// has completed.
 	select {
@@ -1860,16 +1855,14 @@ func (s *Syncer) peerStartup(ctx context.Context, rp *p2p.RemotePeer) error {
 		return err
 	}
 
-	// If needed, request any updated headers from the peer.
-	if requestHeaders {
-		log.Debugf("Requesting updated headers from peer %v", rp)
-		locators, _, err := s.wallet.BlockLocators(ctx, nil)
-		if err != nil {
-			return err
-		}
-		if err := rp.HeadersAsync(ctx, locators, &hashStop); err != nil {
-			return err
-		}
+	// Request any updated headers from the peer.
+	log.Debugf("Requesting updated headers from peer %v", rp)
+	locators, _, err := s.wallet.BlockLocators(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if err := rp.HeadersAsync(ctx, locators, &hashStop); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
This fixes an issue where SPV wallets would only request blocks from peers after a new block was mined.

The issue could be triggered if the number of peers ever dropped to zero, causing the SPV syncer to consider itself unsynced, and if blocks were mined in the intervening period until a new peer was connected.

The root cause was the addition of the unsynced status on the refactoring made in commit 6cde2cc. That made the sync status atomic decoupled to the state of the initialSyncDone signalling channel, which meant that if the atomic was switched to zero after the initial sync was done, new headers would fail to be requested from newly connected peers.

Upon further review, the check is ultimately unnecessary and is removed in this commit ensuring that, after initial sync is completed, the headers are asked of every peer.

Backport of 794fff4420e481ce7724c70f6c62f5ba1d623edb.