### PR TITLE
vsp: Prevent nil pointer dereference.

### DIFF
--- a/vsp/vsp.go
+++ b/vsp/vsp.go
@@ -219,7 +219,7 @@ func (c *Client) Process(ctx context.Context, ticket *wallet.VSPTicket, feeTx *w
 		// transaction, submit it then confirm.
 		fp := c.feePayment(ctx, ticket, false)
 		if fp == nil {
-			err := fp.ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
+			err := ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
 			if err != nil {
 				return err
 			}
@@ -232,7 +232,7 @@ func (c *Client) Process(ctx context.Context, ticket *wallet.VSPTicket, feeTx *w
 		fp.mu.Unlock()
 		err := fp.receiveFeeAddress()
 		if err != nil {
-			err := fp.ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
+			err := ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
 			if err != nil {
 				return err
 			}
@@ -243,7 +243,7 @@ func (c *Client) Process(ctx context.Context, ticket *wallet.VSPTicket, feeTx *w
 		}
 		err = fp.makeFeeTx(feeTx)
 		if err != nil {
-			err := fp.ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
+			err := ticket.UpdateFeeErrored(ctx, c.Client.URL, c.Client.PubKey)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Previously was checking if fp == nil and then attempting to access fp.