### PR TITLE
rpc: Refresh Docker for generating protobuf files.

### DIFF
--- a/rpc/Dockerfile
+++ b/rpc/Dockerfile
@@ -1,8 +1,17 @@
-FROM golang:1.21.0-bookworm
+# The image below is golang:1.23.1-alpine3.20 (linux/amd64)
+# It's pulled by the digest (immutable id) to avoid supply-chain attacks.
+# Maintainer Note:
+#    To update to a new digest, you must first manually pull the new image:
+#    `docker pull golang:<new version>`
+#    Docker will print the digest of the new image after the pull has finished.
+FROM golang@sha256:ac67716dd016429be8d4c2c53a248d7bcdf06d34127d3dc451bda6aa5a87bc06
 
-RUN apt-get update && apt-get install -y protobuf-compiler
+ENV PB_REPO https://github.com/protocolbuffers/protobuf
+ENV PB_VERSION 27.3
+
+RUN wget $PB_REPO/releases/download/v$PB_VERSION/protoc-$PB_VERSION-linux-x86_64.zip
+RUN unzip protoc-$PB_VERSION-linux-x86_64.zip -d $HOME/protobuf
+RUN mv $HOME/protobuf/bin/protoc /usr/local/bin
 
 WORKDIR /build/rpc
-CMD ["/bin/bash", "regen.sh"]
-
-
+CMD ["./regen.sh"]


### PR DESCRIPTION
- Pull base image by digest, helping to avoid supply chain attacks.
- Use alpine base image instead of debian (245MB vs 837MB).
- Update from golang 1.21.0 to 1.23.1.
- Download specific version of protobuf from GitHub rather than whatever version happens to be provided by the base images package manager.


Prior to this PR the Dockerfile did not work at all and the version of protobuf provided by Debian's package manager was v21.12. For context, the most recent pb files in the repo were built with version v27.3.