### PR TITLE
main: Update ticket buyer startup logging.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -364,12 +364,12 @@ func run(ctx context.Context) error {
 				c.ChangeAccount = changeAccount
 				c.VSP = vspClient
 			})
-			log.Infof("Starting auto transaction creator")
+			log.Infof("Starting auto ticker buyer (mixing=%t)", cfg.Mixing)
 			tbdone := make(chan struct{})
 			go func() {
 				err := tb.Run(ctx, passphrase)
 				if err != nil && !errors.Is(err, context.Canceled) {
-					log.Errorf("Transaction creator ended: %v", err)
+					log.Errorf("Auto ticker buyer ended: %v", err)
 				}
 				tbdone <- struct{}{}
 			}()


### PR DESCRIPTION
In all code and log messages the ticket buyer is referred to by name, however in startup/shutdown logging it was given the more vague name "auto transaction creator".

Its also helpful to log whether or not the ticket buyer is purchasing mixed tickets because that has a large impact on its behaviour and potential failure modes.