### PR TITLE
rpcserver: Bump gRPC major version to 8.

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -62,9 +62,9 @@ import (
 
 // Public API version constants
 const (
-	semverString = "7.17.0"
-	semverMajor  = 7
-	semverMinor  = 17
+	semverString = "8.0.0"
+	semverMajor  = 8
+	semverMinor  = 0
 	semverPatch  = 0
 )
 


### PR DESCRIPTION
Preparing for some up-coming breaking changes.