### PR TITLE
wallet: Use purchase acct for voting if not mixing

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1552,7 +1552,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 				addrVote = w.ticketAddress
 			}
 			if addrVote == nil {
-				addrVote, _, err = stakeAddrFunc(op, req.VotingAccount, 1)
+				addrVote, _, err = stakeAddrFunc(op, req.SourceAccount, 1)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
In the case where mixing is disabled and no voting account has been set, the purchase account should be used as a fallback to derive a ticket voting address.