### PR TITLE
jsonrpc: Allow mixaccount RPC to actually mix.

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -5525,7 +5525,7 @@ func (s *Server) mixOutput(ctx context.Context, icmd any) (any, error) {
 }
 
 func (s *Server) mixAccount(ctx context.Context, icmd any) (any, error) {
-	if s.cfg.Mixing {
+	if !s.cfg.Mixing {
 		return nil, errors.E("Mixing is not configured")
 	}
 	w, ok := s.walletLoader.LoadedWallet()


### PR DESCRIPTION
This RPC has been broken since dcrwallet was converted to peer-to-peer mixing in bb04b755c125892a770bec188639d5644ea2e676.