### PR TITLE
ticketbuyer: Dont terminate if RescanPoint fails.

### DIFF
--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -109,7 +109,8 @@ func (tb *TB) Run(ctx context.Context, passphrase []byte) error {
 			// the tip block.
 			rp, err := w.RescanPoint(ctx)
 			if err != nil {
-				return err
+				log.Debugf("Skipping autobuyer actions: RescanPoint err: %v", err)
+				continue
 			}
 			if rp != nil {
 				log.Debugf("Skipping autobuyer actions: transactions are not synced")


### PR DESCRIPTION
If the call to RescanPoint fails the ticketbuyer should not be terminated forever, it can continue running and subsequent calls to RescanPoint may succeed. This is how all other errors in the ticketbuyer are handled (with the exception of incorrect passphrase error).