### PR TITLE
Use Go 1.23 default GODEBUG

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -1,0 +1,9 @@
+// Copyright (c) 2024 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build go1.23
+
+//go:debug default=go1.23
+
+package main


### PR DESCRIPTION
Removes the following compatibility flags when building the "go 1.22" module with Go 1.23:

```
build	DefaultGODEBUG=asynctimerchan=1,gotypesalias=0,httpservecontentkeepheaders=1,tls3des=1,tlskyber=0,x509keypairleaf=0,x509negativeserial=1
```