### PR TITLE
Use correct account for mixed ticket split txns.

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1065,7 +1065,7 @@ func (w *Wallet) mixedSplit(ctx context.Context, req *PurchaseTicketsRequest, ne
 	if change != nil && dcrutil.Amount(change.Value) < smallestMixChange(relayFee) {
 		change = nil
 	}
-	gen := w.makeGen(ctx, req.MixedAccount, req.MixedAccountBranch)
+	gen := w.makeGen(ctx, req.MixedSplitAccount, req.MixedAccountBranch)
 	expires := w.dicemixExpiry(ctx)
 	cj := mixclient.NewCoinJoin(gen, change, int64(neededPerTicket), expires, uint32(req.Count))
 	for i, in := range atx.Tx.TxIn {


### PR DESCRIPTION
This was accidentally changed during the move to peer-to-peer mixing.

I believe this is all that is necessary to close #2420.