### PR TITLE
Always use configured voting account when mixing

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1510,13 +1510,13 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 
 		var addrVote stdaddr.StakeAddress
 
-		// If req.UseVotingAccount is true, derive the submission
-		// script's address from the voting account. This is intended
-		// to be used with a special account type. The signing address
-		// for the same index is saved to the database. That address is
-		// later used to sign messages sent to a vspd related to this
-		// ticket.
-		if req.UseVotingAccount {
+		// If req.Mixing or req.UseVotingAccount is true, derive the
+		// submission script's address from the voting account. This
+		// is intended to be used with a special account type. The
+		// signing address for the same index is saved to the
+		// database. That address is later used to sign messages sent
+		// to a vspd related to this ticket.
+		if req.Mixing || req.UseVotingAccount {
 			var idx uint32
 			addrVote, idx, err = stakeAddrFunc(op, req.VotingAccount, 1)
 			if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1545,7 +1545,7 @@ type PurchaseTicketsRequest struct {
 	SourceAccount    uint32
 	MinConf          int32
 	Expiry           int32
-	VotingAccount    uint32 // Used when Mixing == true
+	VotingAccount    uint32 // Used when Mixing == true || UseVotingAccount == true
 	UseVotingAccount bool   // Forces use of supplied voting account.
 	DontSignTx       bool
 


### PR DESCRIPTION
The comments suggested that this was the intended behavior, but the voting account option was only being considered when UseVotingAccount (allowing the option to be used in non-mixing situations) was true, and mixed ticketbuying was not setting this value.