### PR TITLE
Move VSP client code to wallet package

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -28,7 +28,6 @@ import (
 	"decred.org/dcrwallet/v5/spv"
 	"decred.org/dcrwallet/v5/ticketbuyer"
 	"decred.org/dcrwallet/v5/version"
-	"decred.org/dcrwallet/v5/vsp"
 	"decred.org/dcrwallet/v5/wallet"
 	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/wire"
@@ -190,7 +189,7 @@ func run(ctx context.Context) error {
 	}()
 
 	// Open the wallet when --noinitialload was not set.
-	var vspClient *vsp.Client
+	var vspClient *wallet.VSPClient
 	passphrase := []byte{}
 	if !cfg.NoInitialLoad {
 		walletPass := []byte(cfg.WalletPass)
@@ -271,19 +270,17 @@ func run(ctx context.Context) error {
 					cfg.PurchaseAccount, err)
 				return err
 			}
-			vspCfg := vsp.Config{
+			vspCfg := wallet.VSPClientConfig{
 				URL:    cfg.VSPOpts.URL,
 				PubKey: cfg.VSPOpts.PubKey,
 				Dialer: cfg.dial,
-				Wallet: w,
-				Policy: &vsp.Policy{
+				Policy: &wallet.VSPPolicy{
 					MaxFee:     cfg.VSPOpts.MaxFee.Amount,
 					FeeAcct:    purchaseAcct,
 					ChangeAcct: changeAcct,
 				},
-				Params: w.ChainParams(),
 			}
-			vspClient, err = ldr.VSP(vspCfg)
+			vspClient, err = w.VSP(vspCfg)
 			if err != nil {
 				log.Errorf("vsp: %v", err)
 				return err

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"decred.org/dcrwallet/v5/errors"
-	"decred.org/dcrwallet/v5/vsp"
 	"decred.org/dcrwallet/v5/wallet"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/wire"
@@ -43,7 +42,7 @@ type Config struct {
 	MixChange          bool
 
 	// VSP client
-	VSP *vsp.Client
+	VSP *wallet.VSPClient
 }
 
 // TB is an automated ticket buyer, buying as many tickets as possible given an
@@ -293,12 +292,10 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 		MixedAccountBranch: mixedBranch,
 		MixedSplitAccount:  splitAccount,
 		ChangeAccount:      changeAccount,
+
+		VSPClient: tb.cfg.VSP,
 	}
-	// If VSP is configured, we need to set the methods for vsp fee processment.
-	if tb.cfg.VSP != nil {
-		purchaseTicketReq.VSPFeePaymentProcess = tb.cfg.VSP.Process
-		purchaseTicketReq.VSPFeePercent = tb.cfg.VSP.FeePercentage
-	}
+
 	tix, err := w.PurchaseTickets(ctx, n, purchaseTicketReq)
 	if tix != nil {
 		for _, hash := range tix.TicketHashes {

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1261,12 +1261,8 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		}
 		return
 	}
-	if req.VSPFeePaymentProcess != nil {
-		if req.VSPFeePercent == nil {
-			return nil, errors.E(op, errors.Bug, "VSPFeeProcess "+
-				"may not be nil if VSPServerProcess is non-nil")
-		}
-		feePrice, err := req.VSPFeePercent(ctx)
+	if req.VSPClient != nil {
+		feePrice, err := req.VSPClient.FeePercentage(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1639,7 +1635,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		log.Infof("Published ticket purchase %v", ticket.TxHash())
 
 		// Pay VSP fee when configured to do so.
-		if req.VSPFeePaymentProcess == nil {
+		if req.VSPClient == nil {
 			continue
 		}
 		unlockCredits = false
@@ -1664,7 +1660,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 			continue
 		}
 
-		err = req.VSPFeePaymentProcess(ctx, ticket, feeTx)
+		err = req.VSPClient.Process(ctx, ticket, feeTx)
 		if err != nil {
 			unlock()
 			continue

--- a/wallet/vspclientloader.go
+++ b/wallet/vspclientloader.go
@@ -1,45 +1,35 @@
-package loader
+package wallet
 
 import (
-	"sync"
-
 	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/internal/loggers"
-	"decred.org/dcrwallet/v5/vsp"
 )
-
-var vspClients = struct {
-	mu      sync.Mutex
-	clients map[string]*vsp.Client
-}{
-	clients: make(map[string]*vsp.Client),
-}
 
 // VSP loads or creates a package-global instance of the VSP client for a host.
 // This allows clients to be created and reused across various subsystems.
-func VSP(cfg vsp.Config) (*vsp.Client, error) {
+func (w *Wallet) VSP(cfg VSPClientConfig) (*VSPClient, error) {
 	key := cfg.URL
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	client, ok := vspClients.clients[key]
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	client, ok := w.vspClients[key]
 	if ok {
 		return client, nil
 	}
-	client, err := vsp.New(cfg, loggers.VspcLog)
+	client, err := w.NewVSPClient(cfg, loggers.VspcLog)
 	if err != nil {
 		return nil, err
 	}
-	vspClients.clients[key] = client
+	w.vspClients[key] = client
 	return client, nil
 }
 
 // LookupVSP returns a previously-configured VSP client, if one has been created
 // and registered with the VSP function.  Otherwise, a NotExist error is
 // returned.
-func LookupVSP(host string) (*vsp.Client, error) {
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	client, ok := vspClients.clients[host]
+func (w *Wallet) LookupVSP(host string) (*VSPClient, error) {
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	client, ok := w.vspClients[host]
 	if !ok {
 		err := errors.Errorf("VSP client for %q not found", host)
 		return nil, errors.E(errors.NotExist, err)
@@ -48,12 +38,12 @@ func LookupVSP(host string) (*vsp.Client, error) {
 }
 
 // AllVSPs returns the list of all currently registered VSPs.
-func AllVSPs() map[string]*vsp.Client {
+func (w *Wallet) AllVSPs() map[string]*VSPClient {
 	// Create a copy to avoid callers mutating the list.
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	res := make(map[string]*vsp.Client, len(vspClients.clients))
-	for host, client := range vspClients.clients {
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	res := make(map[string]*VSPClient, len(w.vspClients))
+	for host, client := range w.vspClients {
 		res[host] = client
 	}
 	return res

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -170,6 +170,9 @@ type Wallet struct {
 	deploymentsByID    map[string]*chaincfg.ConsensusDeployment
 	minTestNetTarget   *big.Int
 	minTestNetDiffBits uint32
+
+	vspClientsMu sync.Mutex
+	vspClients   map[string]*VSPClient
 }
 
 // Config represents the configuration options needed to initialize a wallet.
@@ -1556,15 +1559,7 @@ type PurchaseTicketsRequest struct {
 	MixedSplitAccount  uint32
 	ChangeAccount      uint32
 
-	// VSPServer methods
-	// XXX this should be an interface
-
-	// VSPFeePercent returns the VSPs fee as a percentage of the vote reward.
-	VSPFeePercent func(context.Context) (float64, error)
-	// VSPFeePaymentProcess checks the fee payment status for the specified
-	// ticket and, if necessary, starts a long-lived handler to process the fee
-	// payment.
-	VSPFeePaymentProcess func(context.Context, *VSPTicket, *wire.MsgTx) error
+	VSPClient *VSPClient
 
 	// extraSplitOutput is an additional transaction output created during
 	// UTXO contention, to be used as the input to pay a VSP fee
@@ -1605,7 +1600,7 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 		return nil, errors.E(op, errors.InsufficientBalance)
 	}
 
-	feePercent, err := req.VSPFeePercent(ctx)
+	feePercent, err := req.VSPClient.FeePercentage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -5409,6 +5404,8 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 
 		mixSems: newMixSemaphores(cfg.MixSplitLimit),
 		mixing:  !cfg.DisableMixing,
+
+		vspClients: make(map[string]*VSPClient),
 	}
 
 	// Open database managers


### PR DESCRIPTION
Moving this code should have minimal impact on consumers of the vsp package because they will have been importing the wallet package already due to the fact that a VSP client could not be created without an instance of wallet.

The benefits of this are:
- vsp client creation now exists only in the wallet package, rather than being scattered across 3 packages.
- vsp client loading funcs and variables are no longer package global.
- simplifies the creation of a vsp client because the wallet no longer needs to be passed into the func as a param.
- no longer necessary to abstract the vsp client away by referring to its methods, the client can just be used directly.

Can be squashed before merging.