### PR TITLE
Make VSP clients respect tor config

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -169,7 +169,7 @@ func run(ctx context.Context) error {
 	loader := ldr.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, !cfg.Mixing,
-		cfg.ManualTickets, cfg.MixSplitLimit)
+		cfg.ManualTickets, cfg.MixSplitLimit, cfg.dial)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.
@@ -273,7 +273,6 @@ func run(ctx context.Context) error {
 			vspCfg := wallet.VSPClientConfig{
 				URL:    cfg.VSPOpts.URL,
 				PubKey: cfg.VSPOpts.PubKey,
-				Dialer: cfg.dial,
 				Policy: &wallet.VSPPolicy{
 					MaxFee:     cfg.VSPOpts.MaxFee.Amount,
 					FeeAcct:    purchaseAcct,

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -28,7 +28,6 @@ import (
 	"decred.org/dcrwallet/v5/spv"
 	"decred.org/dcrwallet/v5/ticketbuyer"
 	"decred.org/dcrwallet/v5/version"
-	"decred.org/dcrwallet/v5/vsp"
 	"decred.org/dcrwallet/v5/wallet"
 	"github.com/decred/dcrd/addrmgr/v2"
 	"github.com/decred/dcrd/wire"
@@ -190,7 +189,7 @@ func run(ctx context.Context) error {
 	}()
 
 	// Open the wallet when --noinitialload was not set.
-	var vspClient *vsp.Client
+	var vspClient *wallet.VSPClient
 	passphrase := []byte{}
 	if !cfg.NoInitialLoad {
 		walletPass := []byte(cfg.WalletPass)
@@ -271,19 +270,17 @@ func run(ctx context.Context) error {
 					cfg.PurchaseAccount, err)
 				return err
 			}
-			vspCfg := vsp.Config{
+			vspCfg := wallet.VSPClientConfig{
 				URL:    cfg.VSPOpts.URL,
 				PubKey: cfg.VSPOpts.PubKey,
 				Dialer: cfg.dial,
-				Wallet: w,
-				Policy: &vsp.Policy{
+				Policy: &wallet.VSPPolicy{
 					MaxFee:     cfg.VSPOpts.MaxFee.Amount,
 					FeeAcct:    purchaseAcct,
 					ChangeAcct: changeAcct,
 				},
-				Params: w.ChainParams(),
 			}
-			vspClient, err = ldr.VSP(vspCfg)
+			vspClient, err = w.VSP(vspCfg)
 			if err != nil {
 				log.Errorf("vsp: %v", err)
 				return err

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -47,6 +47,7 @@ type Loader struct {
 	manualTickets           bool
 	relayFee                dcrutil.Amount
 	mixSplitLimit           int
+	dialer                  wallet.DialFunc
 
 	mu sync.Mutex
 }
@@ -54,7 +55,7 @@ type Loader struct {
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled bool, gapLimit uint32,
 	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int,
-	disableCoinTypeUpgrades bool, disableMixing bool, manualTickets bool, mixSplitLimit int) *Loader {
+	disableCoinTypeUpgrades bool, disableMixing bool, manualTickets bool, mixSplitLimit int, dialer wallet.DialFunc) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
@@ -69,6 +70,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled boo
 		manualTickets:           manualTickets,
 		relayFee:                relayFee,
 		mixSplitLimit:           mixSplitLimit,
+		dialer:                  dialer,
 	}
 }
 
@@ -176,6 +178,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		RelayFee:                l.relayFee,
 		MixSplitLimit:           l.mixSplitLimit,
 		Params:                  l.chainParams,
+		Dialer:                  l.dialer,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
@@ -262,6 +265,7 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
 		Params:                  l.chainParams,
+		Dialer:                  l.dialer,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {
@@ -319,6 +323,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		RelayFee:                l.relayFee,
 		MixSplitLimit:           l.mixSplitLimit,
 		Params:                  l.chainParams,
+		Dialer:                  l.dialer,
 	}
 	w, err = wallet.Open(ctx, cfg)
 	if err != nil {

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3347,7 +3347,6 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd any) (any, error) {
 		cfg := wallet.VSPClientConfig{
 			URL:    s.cfg.VSPHost,
 			PubKey: s.cfg.VSPPubKey,
-			Dialer: s.cfg.Dial,
 			Policy: &wallet.VSPPolicy{
 				MaxFee:     s.cfg.VSPMaxFee,
 				FeeAcct:    account,

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -321,8 +321,6 @@ func (*versionServer) Version(ctx context.Context, req *pb.VersionRequest) (*pb.
 	}, nil
 }
 
-type dialFunc func(ctx context.Context, network, addr string) (net.Conn, error)
-
 // StartWalletService starts the WalletService.
 func StartWalletService(server *grpc.Server, wallet *wallet.Wallet) {
 	if walletService.ready.Swap(1) != 0 {
@@ -1817,7 +1815,6 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 		cfg := wallet.VSPClientConfig{
 			URL:    vspHost,
 			PubKey: vspPubKey,
-			Dialer: nil,
 			Policy: &wallet.VSPPolicy{
 				MaxFee:     0.1e8,
 				FeeAcct:    req.Account,
@@ -2626,7 +2623,6 @@ func (t *ticketbuyerServer) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr pb
 		cfg := wallet.VSPClientConfig{
 			URL:    vspHost,
 			PubKey: vspPubKey,
-			Dialer: nil,
 			Policy: &wallet.VSPPolicy{
 				MaxFee:     0.1e8,
 				FeeAcct:    req.Account,
@@ -4112,7 +4108,6 @@ func (s *walletServer) SyncVSPFailedTickets(ctx context.Context, req *pb.SyncVSP
 	cfg := wallet.VSPClientConfig{
 		URL:    vspHost,
 		PubKey: vspPubKey,
-		Dialer: nil,
 		Policy: policy,
 	}
 	vspClient, err := s.wallet.VSP(cfg)
@@ -4159,7 +4154,6 @@ func (s *walletServer) ProcessManagedTickets(ctx context.Context, req *pb.Proces
 	cfg := wallet.VSPClientConfig{
 		URL:    vspHost,
 		PubKey: vspPubKey,
-		Dialer: nil,
 		Policy: policy,
 	}
 	vspClient, err := s.wallet.VSP(cfg)
@@ -4199,7 +4193,6 @@ func (s *walletServer) ProcessUnmanagedTickets(ctx context.Context, req *pb.Proc
 	cfg := wallet.VSPClientConfig{
 		URL:    vspHost,
 		PubKey: vspPubKey,
-		Dialer: nil,
 		Policy: policy,
 	}
 	vspClient, err := s.wallet.VSP(cfg)
@@ -4236,7 +4229,6 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 	cfg := wallet.VSPClientConfig{
 		URL:    vspHost,
 		PubKey: vspPubKey,
-		Dialer: nil,
 		Policy: policy,
 	}
 	vspClient, err := s.wallet.VSP(cfg)

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 
 	"decred.org/dcrwallet/v5/errors"
-	"decred.org/dcrwallet/v5/vsp"
 	"decred.org/dcrwallet/v5/wallet"
 	"github.com/decred/dcrd/dcrutil/v4"
 	"github.com/decred/dcrd/wire"
@@ -43,7 +42,7 @@ type Config struct {
 	MixChange          bool
 
 	// VSP client
-	VSP *vsp.Client
+	VSP *wallet.VSPClient
 }
 
 // TB is an automated ticket buyer, buying as many tickets as possible given an
@@ -293,12 +292,10 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 		MixedAccountBranch: mixedBranch,
 		MixedSplitAccount:  splitAccount,
 		ChangeAccount:      changeAccount,
+
+		VSPClient: tb.cfg.VSP,
 	}
-	// If VSP is configured, we need to set the methods for vsp fee processment.
-	if tb.cfg.VSP != nil {
-		purchaseTicketReq.VSPFeePaymentProcess = tb.cfg.VSP.Process
-		purchaseTicketReq.VSPFeePercent = tb.cfg.VSP.FeePercentage
-	}
+
 	tix, err := w.PurchaseTickets(ctx, n, purchaseTicketReq)
 	if tix != nil {
 		for _, hash := range tix.TicketHashes {

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1261,12 +1261,8 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		}
 		return
 	}
-	if req.VSPFeePaymentProcess != nil {
-		if req.VSPFeePercent == nil {
-			return nil, errors.E(op, errors.Bug, "VSPFeeProcess "+
-				"may not be nil if VSPServerProcess is non-nil")
-		}
-		feePrice, err := req.VSPFeePercent(ctx)
+	if req.VSPClient != nil {
+		feePrice, err := req.VSPClient.FeePercentage(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -1639,7 +1635,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 		log.Infof("Published ticket purchase %v", ticket.TxHash())
 
 		// Pay VSP fee when configured to do so.
-		if req.VSPFeePaymentProcess == nil {
+		if req.VSPClient == nil {
 			continue
 		}
 		unlockCredits = false
@@ -1664,7 +1660,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 			continue
 		}
 
-		err = req.VSPFeePaymentProcess(ctx, ticket, feeTx)
+		err = req.VSPClient.Process(ctx, ticket, feeTx)
 		if err != nil {
 			unlock()
 			continue

--- a/wallet/vsp.go
+++ b/wallet/vsp.go
@@ -49,15 +49,12 @@ type VSPClientConfig struct {
 	// PubKey specifies the VSP's base64 encoded public key
 	PubKey string
 
-	// Dialer specifies an optional dialer when connecting to the VSP.
-	Dialer DialFunc
-
 	// Default policy for fee payments unless another is provided by the
 	// caller.
 	Policy *VSPPolicy
 }
 
-func (w *Wallet) NewVSPClient(cfg VSPClientConfig, log slog.Logger) (*VSPClient, error) {
+func (w *Wallet) NewVSPClient(cfg VSPClientConfig, log slog.Logger, dialer DialFunc) (*VSPClient, error) {
 	u, err := url.Parse(cfg.URL)
 	if err != nil {
 		return nil, err
@@ -74,7 +71,7 @@ func (w *Wallet) NewVSPClient(cfg VSPClientConfig, log slog.Logger) (*VSPClient,
 		Log:    log,
 	}
 	client.Transport = &http.Transport{
-		DialContext: cfg.Dialer,
+		DialContext: dialer,
 	}
 
 	v := &VSPClient{

--- a/wallet/vspclientloader.go
+++ b/wallet/vspclientloader.go
@@ -15,7 +15,7 @@ func (w *Wallet) VSP(cfg VSPClientConfig) (*VSPClient, error) {
 	if ok {
 		return client, nil
 	}
-	client, err := w.NewVSPClient(cfg, loggers.VspcLog)
+	client, err := w.NewVSPClient(cfg, loggers.VspcLog, w.dialer)
 	if err != nil {
 		return nil, err
 	}

--- a/wallet/vspclientloader.go
+++ b/wallet/vspclientloader.go
@@ -1,45 +1,35 @@
-package loader
+package wallet
 
 import (
-	"sync"
-
 	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/internal/loggers"
-	"decred.org/dcrwallet/v5/vsp"
 )
-
-var vspClients = struct {
-	mu      sync.Mutex
-	clients map[string]*vsp.Client
-}{
-	clients: make(map[string]*vsp.Client),
-}
 
 // VSP loads or creates a package-global instance of the VSP client for a host.
 // This allows clients to be created and reused across various subsystems.
-func VSP(cfg vsp.Config) (*vsp.Client, error) {
+func (w *Wallet) VSP(cfg VSPClientConfig) (*VSPClient, error) {
 	key := cfg.URL
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	client, ok := vspClients.clients[key]
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	client, ok := w.vspClients[key]
 	if ok {
 		return client, nil
 	}
-	client, err := vsp.New(cfg, loggers.VspcLog)
+	client, err := w.NewVSPClient(cfg, loggers.VspcLog)
 	if err != nil {
 		return nil, err
 	}
-	vspClients.clients[key] = client
+	w.vspClients[key] = client
 	return client, nil
 }
 
 // LookupVSP returns a previously-configured VSP client, if one has been created
 // and registered with the VSP function.  Otherwise, a NotExist error is
 // returned.
-func LookupVSP(host string) (*vsp.Client, error) {
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	client, ok := vspClients.clients[host]
+func (w *Wallet) LookupVSP(host string) (*VSPClient, error) {
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	client, ok := w.vspClients[host]
 	if !ok {
 		err := errors.Errorf("VSP client for %q not found", host)
 		return nil, errors.E(errors.NotExist, err)
@@ -48,12 +38,12 @@ func LookupVSP(host string) (*vsp.Client, error) {
 }
 
 // AllVSPs returns the list of all currently registered VSPs.
-func AllVSPs() map[string]*vsp.Client {
+func (w *Wallet) AllVSPs() map[string]*VSPClient {
 	// Create a copy to avoid callers mutating the list.
-	vspClients.mu.Lock()
-	defer vspClients.mu.Unlock()
-	res := make(map[string]*vsp.Client, len(vspClients.clients))
-	for host, client := range vspClients.clients {
+	w.vspClientsMu.Lock()
+	defer w.vspClientsMu.Unlock()
+	res := make(map[string]*VSPClient, len(w.vspClients))
+	for host, client := range w.vspClients {
 		res[host] = client
 	}
 	return res

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -170,6 +170,9 @@ type Wallet struct {
 	deploymentsByID    map[string]*chaincfg.ConsensusDeployment
 	minTestNetTarget   *big.Int
 	minTestNetDiffBits uint32
+
+	vspClientsMu sync.Mutex
+	vspClients   map[string]*VSPClient
 }
 
 // Config represents the configuration options needed to initialize a wallet.
@@ -1556,15 +1559,7 @@ type PurchaseTicketsRequest struct {
 	MixedSplitAccount  uint32
 	ChangeAccount      uint32
 
-	// VSPServer methods
-	// XXX this should be an interface
-
-	// VSPFeePercent returns the VSPs fee as a percentage of the vote reward.
-	VSPFeePercent func(context.Context) (float64, error)
-	// VSPFeePaymentProcess checks the fee payment status for the specified
-	// ticket and, if necessary, starts a long-lived handler to process the fee
-	// payment.
-	VSPFeePaymentProcess func(context.Context, *VSPTicket, *wire.MsgTx) error
+	VSPClient *VSPClient
 
 	// extraSplitOutput is an additional transaction output created during
 	// UTXO contention, to be used as the input to pay a VSP fee
@@ -1605,7 +1600,7 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 		return nil, errors.E(op, errors.InsufficientBalance)
 	}
 
-	feePercent, err := req.VSPFeePercent(ctx)
+	feePercent, err := req.VSPClient.FeePercentage(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -5409,6 +5404,8 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 
 		mixSems: newMixSemaphores(cfg.MixSplitLimit),
 		mixing:  !cfg.DisableMixing,
+
+		vspClients: make(map[string]*VSPClient),
 	}
 
 	// Open database managers

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -173,6 +173,8 @@ type Wallet struct {
 
 	vspClientsMu sync.Mutex
 	vspClients   map[string]*VSPClient
+
+	dialer DialFunc
 }
 
 // Config represents the configuration options needed to initialize a wallet.
@@ -194,6 +196,8 @@ type Config struct {
 	AllowHighFees bool
 	RelayFee      dcrutil.Amount
 	Params        *chaincfg.Params
+
+	Dialer DialFunc
 }
 
 // DisapprovePercent returns the wallet's block disapproval percentage.
@@ -5406,6 +5410,8 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 		mixing:  !cfg.DisableMixing,
 
 		vspClients: make(map[string]*VSPClient),
+
+		dialer: cfg.Dialer,
 	}
 
 	// Open database managers

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -115,7 +115,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 	loader := loader.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, !cfg.Mixing,
-		cfg.ManualTickets, cfg.MixSplitLimit)
+		cfg.ManualTickets, cfg.MixSplitLimit, cfg.dial)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
Ensure dialer is set correctly so VSPs are reached over tor if requested in config. This also has a nice side-effect of simplifying VSP client creation.

Based on #2428 