### PR TITLE
Add context wrapping for syncer disconnections

### DIFF
--- a/chain/backend.go
+++ b/chain/backend.go
@@ -87,3 +87,24 @@ func (s *Syncer) ExistsLiveTickets(ctx context.Context, tickets []*chainhash.Has
 func (s *Syncer) UsedAddresses(ctx context.Context, addrs []stdaddr.Address) (bitset.Bytes, error) {
 	return s.rpc.UsedAddresses(ctx, addrs)
 }
+
+func (s *Syncer) Done() <-chan struct{} {
+	s.doneMu.Lock()
+	c := s.done
+	s.doneMu.Unlock()
+	return c
+}
+
+func (s *Syncer) Err() error {
+	s.doneMu.Lock()
+	c := s.done
+	err := s.err
+	s.doneMu.Unlock()
+
+	select {
+	case <-c:
+		return err
+	default:
+		return nil
+	}
+}

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -619,3 +619,24 @@ func (s *Syncer) Rescan(ctx context.Context, blockHashes []chainhash.Hash, save 
 func (s *Syncer) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error) {
 	return 0, errors.E(errors.Invalid, "stake difficulty is not queryable over wire protocol")
 }
+
+func (s *Syncer) Done() <-chan struct{} {
+	s.doneMu.Lock()
+	c := s.done
+	s.doneMu.Unlock()
+	return c
+}
+
+func (s *Syncer) Err() error {
+	s.doneMu.Lock()
+	c := s.done
+	err := s.err
+	s.doneMu.Unlock()
+
+	select {
+	case <-c:
+		return err
+	default:
+		return nil
+	}
+}

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -216,6 +216,8 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	if err != nil {
 		return err
 	}
+	ctx, cancel := wallet.WrapNetworkBackendContext(n, ctx)
+	defer cancel()
 
 	if len(passphrase) > 0 {
 		// Ensure wallet is unlocked with the current passphrase.  If the passphase

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -275,6 +275,13 @@ func (w *Wallet) MixOutput(ctx context.Context, output *wire.OutPoint, changeAcc
 		return errors.E(op, errors.Invalid, s)
 	}
 
+	nb, err := w.NetworkBackend()
+	if err != nil {
+		return err
+	}
+	ctx, cancel := WrapNetworkBackendContext(nb, ctx)
+	defer cancel()
+
 	sdiff, err := w.NextStakeDifficulty(ctx)
 	if err != nil {
 		return errors.E(op, err)

--- a/wallet/network_test.go
+++ b/wallet/network_test.go
@@ -35,3 +35,5 @@ func (mockNetwork) Rescan(ctx context.Context, blocks []chainhash.Hash, save fun
 }
 func (mockNetwork) StakeDifficulty(ctx context.Context) (dcrutil.Amount, error) { return 0, nil }
 func (mockNetwork) Synced(ctx context.Context) (bool, int32)                    { return false, 0 }
+func (mockNetwork) Done() <-chan struct{}                                       { return nil }
+func (mockNetwork) Err() error                                                  { return nil }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1588,6 +1588,9 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 
 	const op errors.Op = "wallet.PurchaseTickets"
 
+	ctx, cancel := WrapNetworkBackendContext(n, ctx)
+	defer cancel()
+
 	resp, err := w.purchaseTickets(ctx, op, n, req)
 	if err == nil || !errors.Is(err, errVSPFeeRequiresUTXOSplit) || req.DontSignTx {
 		return resp, err


### PR DESCRIPTION
Any long-lived process (such as mixing) must return if the network backend (e.g. the dcrd RPC connection) is disconnected or the syncer encounters another error.  However, it was observed that mixclient calls were continuing to execute despite the syncer erroring, resulting in locked outputs that could not be mixed after the syncer reconnected and restarted.

To avoid this, the network backend interface gains additional methods to select on when disconnect occurs, and a new context wrapping function is added, which creates a derived context that is canceled (or "done") after the syncer exits.  Wrapped contexts are added in the ticket purchasing and account mixing paths, including those being performed by the autobuyer.