### PR TITLE
jsonrpc: Use process ctx as request ctx parent.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -370,7 +370,7 @@ func run(ctx context.Context) error {
 	//
 	// Servers will be associated with a loaded wallet if it has already been
 	// loaded, or after it is loaded later on.
-	gRPCServer, jsonRPCServer, err := startRPCServers(loader)
+	gRPCServer, jsonRPCServer, err := startRPCServers(ctx, loader)
 	if err != nil {
 		log.Errorf("Unable to create RPC servers: %v", err)
 		return err

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -245,7 +245,7 @@ func (rpcLoggers) SetLevels(levelSpec string) error {
 	return parseAndSetDebugLevels(levelSpec)
 }
 
-func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server, error) {
+func startRPCServers(ctx context.Context, walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server, error) {
 	var jsonrpcAddrNotifier jsonrpcListenerEventServer
 	var grpcAddrNotifier grpcListenerEventServer
 	if cfg.RPCListenerEvents {
@@ -384,7 +384,7 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 			Dial:                cfg.dial,
 			Loggers:             rpcLoggers{},
 		}
-		jsonrpcServer = jsonrpc.NewServer(&opts, activeNet.Params, walletLoader, listeners)
+		jsonrpcServer = jsonrpc.NewServer(ctx, &opts, activeNet.Params, walletLoader, listeners)
 		for _, lis := range listeners {
 			jsonrpcAddrNotifier.notify(lis.Addr().String())
 		}


### PR DESCRIPTION
This ensures that the context of in-flight RPC requests is cancelled when the dcrwallet process context is cancelled.