### PR TITLE
multi: Send empty VSP policy fields

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4687,6 +4687,18 @@ func (s *Server) setVoteChoice(ctx context.Context, icmd any) (any, error) {
 func (s *Server) updateVSPVoteChoices(ctx context.Context, w *wallet.Wallet, ticketHash *chainhash.Hash,
 	choices map[string]string, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
 
+	// Ensure empty (as opposed to nil) choices on every category (required
+	// by the contract of the VSP API).
+	if choices == nil {
+		choices = map[string]string{}
+	}
+	if tspendPolicy == nil {
+		tspendPolicy = map[string]string{}
+	}
+	if treasuryPolicy == nil {
+		treasuryPolicy = map[string]string{}
+	}
+
 	if ticketHash != nil {
 		vspHost, err := w.VSPHostForTicket(ctx, ticketHash)
 		if err != nil {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -408,7 +408,7 @@ func (w *Wallet) AgendaChoices(ctx context.Context, ticketHash *chainhash.Hash) 
 	const op errors.Op = "wallet.AgendaChoices"
 	version, deployments := CurrentAgendas(w.chainParams)
 	if len(deployments) == 0 {
-		return nil, 0, nil
+		return map[string]string{}, 0, nil
 	}
 
 	choices = make(map[string]string, len(deployments))


### PR DESCRIPTION
This changes the call sites of VSP library functions to fill in missing policy choices with empty maps instead of nil maps.

This fixes an issue where certain VSPs will fail to accept the policy calls because those fields are required by the API but not sent.

Fix #2402