### PR TITLE
Don't use hard-coded VSP MaxFee.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -168,8 +168,9 @@ func run(ctx context.Context) error {
 
 	loader := ldr.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
-		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, !cfg.Mixing,
-		cfg.ManualTickets, cfg.MixSplitLimit, cfg.dial)
+		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
+		cfg.DisableCoinTypeUpgrades, !cfg.Mixing, cfg.ManualTickets,
+		cfg.MixSplitLimit, cfg.dial)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -46,6 +46,7 @@ type Loader struct {
 	allowHighFees           bool
 	manualTickets           bool
 	relayFee                dcrutil.Amount
+	vspMaxFee               dcrutil.Amount
 	mixSplitLimit           int
 	dialer                  wallet.DialFunc
 
@@ -54,7 +55,7 @@ type Loader struct {
 
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled bool, gapLimit uint32,
-	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, accountGapLimit int,
+	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, vspMaxFee dcrutil.Amount, accountGapLimit int,
 	disableCoinTypeUpgrades bool, disableMixing bool, manualTickets bool, mixSplitLimit int, dialer wallet.DialFunc) *Loader {
 
 	return &Loader{
@@ -69,6 +70,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled boo
 		allowHighFees:           allowHighFees,
 		manualTickets:           manualTickets,
 		relayFee:                relayFee,
+		vspMaxFee:               vspMaxFee,
 		mixSplitLimit:           mixSplitLimit,
 		dialer:                  dialer,
 	}
@@ -176,6 +178,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
+		VSPMaxFee:               l.vspMaxFee,
 		MixSplitLimit:           l.mixSplitLimit,
 		Params:                  l.chainParams,
 		Dialer:                  l.dialer,
@@ -264,6 +267,7 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
+		VSPMaxFee:               l.vspMaxFee,
 		Params:                  l.chainParams,
 		Dialer:                  l.dialer,
 	}
@@ -321,6 +325,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
+		VSPMaxFee:               l.vspMaxFee,
 		MixSplitLimit:           l.mixSplitLimit,
 		Params:                  l.chainParams,
 		Dialer:                  l.dialer,

--- a/internal/rpc/jsonrpc/config.go
+++ b/internal/rpc/jsonrpc/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2015 The btcsuite developers
+// Copyright (c) 2013-2024 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,8 +7,6 @@ package jsonrpc
 import (
 	"context"
 	"net"
-
-	"github.com/decred/dcrd/dcrutil/v4"
 )
 
 // Options contains the required options for running the legacy RPC server.
@@ -27,6 +25,5 @@ type Options struct {
 
 	VSPHost   string
 	VSPPubKey string
-	VSPMaxFee dcrutil.Amount
 	Dial      func(ctx context.Context, network, addr string) (net.Conn, error)
 }

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3348,7 +3348,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd any) (any, error) {
 			URL:    s.cfg.VSPHost,
 			PubKey: s.cfg.VSPPubKey,
 			Policy: &wallet.VSPPolicy{
-				MaxFee:     s.cfg.VSPMaxFee,
+				MaxFee:     w.VSPMaxFee(),
 				FeeAcct:    account,
 				ChangeAcct: changeAccount,
 			},

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1806,7 +1806,7 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 			URL:    req.VspHost,
 			PubKey: req.VspPubkey,
 			Policy: &wallet.VSPPolicy{
-				MaxFee:     0.1e8,
+				MaxFee:     s.wallet.VSPMaxFee(),
 				FeeAcct:    req.Account,
 				ChangeAcct: req.ChangeAccount,
 			},
@@ -2604,7 +2604,7 @@ func (t *ticketbuyerServer) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr pb
 			URL:    req.VspHost,
 			PubKey: req.VspPubkey,
 			Policy: &wallet.VSPPolicy{
-				MaxFee:     0.1e8,
+				MaxFee:     w.VSPMaxFee(),
 				FeeAcct:    req.Account,
 				ChangeAcct: req.Account,
 			},
@@ -4076,7 +4076,7 @@ func (s *walletServer) SyncVSPFailedTickets(ctx context.Context, req *pb.SyncVSP
 		URL:    req.VspHost,
 		PubKey: req.VspPubkey,
 		Policy: &wallet.VSPPolicy{
-			MaxFee:     0.1e8,
+			MaxFee:     s.wallet.VSPMaxFee(),
 			FeeAcct:    req.Account,
 			ChangeAcct: req.ChangeAccount,
 		},
@@ -4113,7 +4113,7 @@ func (s *walletServer) ProcessManagedTickets(ctx context.Context, req *pb.Proces
 		URL:    req.VspHost,
 		PubKey: req.VspPubkey,
 		Policy: &wallet.VSPPolicy{
-			MaxFee:     0.1e8,
+			MaxFee:     s.wallet.VSPMaxFee(),
 			FeeAcct:    req.FeeAccount,
 			ChangeAcct: req.ChangeAccount,
 		},
@@ -4143,7 +4143,7 @@ func (s *walletServer) ProcessUnmanagedTickets(ctx context.Context, req *pb.Proc
 		URL:    req.VspHost,
 		PubKey: req.VspPubkey,
 		Policy: &wallet.VSPPolicy{
-			MaxFee:     0.1e8,
+			MaxFee:     s.wallet.VSPMaxFee(),
 			FeeAcct:    req.FeeAccount,
 			ChangeAcct: req.ChangeAccount,
 		},
@@ -4170,7 +4170,7 @@ func (s *walletServer) SetVspdVoteChoices(ctx context.Context, req *pb.SetVspdVo
 		URL:    req.VspHost,
 		PubKey: req.VspPubkey,
 		Policy: &wallet.VSPPolicy{
-			MaxFee:     0.1e8,
+			MaxFee:     s.wallet.VSPMaxFee(),
 			FeeAcct:    req.FeeAccount,
 			ChangeAcct: req.ChangeAccount,
 		},

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -363,7 +363,6 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 			MixChangeAccount:    cfg.ChangeAccount,
 			VSPHost:             cfg.VSPOpts.URL,
 			VSPPubKey:           cfg.VSPOpts.PubKey,
-			VSPMaxFee:           cfg.VSPOpts.MaxFee.Amount,
 			TicketSplitAccount:  cfg.TicketSplitAccount,
 			Dial:                cfg.dial,
 		}

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -171,6 +171,7 @@ type Wallet struct {
 	minTestNetTarget   *big.Int
 	minTestNetDiffBits uint32
 
+	vspMaxFee    dcrutil.Amount
 	vspClientsMu sync.Mutex
 	vspClients   map[string]*VSPClient
 
@@ -195,6 +196,7 @@ type Config struct {
 	ManualTickets bool
 	AllowHighFees bool
 	RelayFee      dcrutil.Amount
+	VSPMaxFee     dcrutil.Amount
 	Params        *chaincfg.Params
 
 	Dialer DialFunc
@@ -753,6 +755,11 @@ func (w *Wallet) SetTSpendPolicy(ctx context.Context, tspendHash *chainhash.Hash
 
 	w.tspendPolicy[*tspendHash] = policy
 	return nil
+}
+
+// VSPMaxFee is the maximum fee to pay when registering a ticket with a VSP.
+func (w *Wallet) VSPMaxFee() dcrutil.Amount {
+	return w.vspMaxFee
 }
 
 // RelayFee returns the current minimum relay fee (per kB of serialized
@@ -5412,6 +5419,7 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 		mixSems: newMixSemaphores(cfg.MixSplitLimit),
 		mixing:  !cfg.DisableMixing,
 
+		vspMaxFee:  cfg.VSPMaxFee,
 		vspClients: make(map[string]*VSPClient),
 
 		dialer: cfg.Dialer,

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -114,8 +114,9 @@ func createWallet(ctx context.Context, cfg *config) error {
 	dbDir := networkDir(cfg.AppDataDir.Value, activeNet.Params)
 	loader := loader.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
-		cfg.AccountGapLimit, cfg.DisableCoinTypeUpgrades, !cfg.Mixing,
-		cfg.ManualTickets, cfg.MixSplitLimit, cfg.dial)
+		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
+		cfg.DisableCoinTypeUpgrades, !cfg.Mixing, cfg.ManualTickets,
+		cfg.MixSplitLimit, cfg.dial)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
A hard-coded value for VSP max fee should not be used when a value is available from config.