### PR TITLE
Standardize on "mixingEnabled" and explain --mixing config more thoroughly.

### DIFF
--- a/config.go
+++ b/config.go
@@ -168,7 +168,7 @@ type config struct {
 	IssueClientCert   bool  `long:"issueclientcert" description:"Notify a client cert and key over the TX pipe for RPC authentication"`
 
 	// CSPP
-	Mixing             bool                    `long:"mixing" description:"Enable mixing support"`
+	MixingEnabled      bool                    `long:"mixing" description:"Enable mixing support"`
 	CSPPSolver         *cfgutil.ExplicitString `long:"csppsolver" description:"Path to CSPP solver executable (if not in PATH)"`
 	MixedAccount       string                  `long:"mixedaccount" description:"Account/branch used to derive CoinShuffle++ mixed outputs and voting rewards"`
 	mixedAccount       string
@@ -738,7 +738,7 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 	}
 
 	var solverMustWork bool
-	if cfg.Mixing {
+	if cfg.MixingEnabled {
 		if cfg.CSPPSolver.ExplicitlySet() {
 			solverrpc.SolverProcess = cfg.CSPPSolver.Value
 			solverMustWork = true

--- a/config.go
+++ b/config.go
@@ -168,7 +168,7 @@ type config struct {
 	IssueClientCert   bool  `long:"issueclientcert" description:"Notify a client cert and key over the TX pipe for RPC authentication"`
 
 	// CSPP
-	MixingEnabled      bool                    `long:"mixing" description:"Enable mixing support"`
+	MixingEnabled      bool                    `long:"mixing" description:"Enable creation of mixed transactions and participation in the peer-to-peer mixing network"`
 	CSPPSolver         *cfgutil.ExplicitString `long:"csppsolver" description:"Path to CSPP solver executable (if not in PATH)"`
 	MixedAccount       string                  `long:"mixedaccount" description:"Account/branch used to derive CoinShuffle++ mixed outputs and voting rewards"`
 	mixedAccount       string

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -169,7 +169,7 @@ func run(ctx context.Context) error {
 	loader := ldr.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
-		cfg.DisableCoinTypeUpgrades, !cfg.Mixing, cfg.ManualTickets,
+		cfg.DisableCoinTypeUpgrades, cfg.MixingEnabled, cfg.ManualTickets,
 		cfg.MixSplitLimit, cfg.dial)
 
 	// Stop any services started by the loader after the shutdown procedure is
@@ -252,7 +252,7 @@ func run(ctx context.Context) error {
 
 		if cfg.VSPOpts.URL != "" {
 			changeAccountName := cfg.ChangeAccount
-			if changeAccountName == "" && !cfg.Mixing {
+			if changeAccountName == "" && !cfg.MixingEnabled {
 				log.Warnf("Change account not set, using "+
 					"purchase account %q", cfg.PurchaseAccount)
 				changeAccountName = cfg.PurchaseAccount
@@ -308,7 +308,7 @@ func run(ctx context.Context) error {
 			if cfg.EnableTicketBuyer {
 				purchaseAccount = lookup("purchaseaccount", cfg.PurchaseAccount)
 
-				if cfg.Mixing && cfg.TBOpts.VotingAccount == "" {
+				if cfg.MixingEnabled && cfg.TBOpts.VotingAccount == "" {
 					err := errors.New("cannot run mixed ticketbuyer without --votingaccount")
 					log.Error(err)
 					return err
@@ -317,11 +317,11 @@ func run(ctx context.Context) error {
 					votingAccount = lookup("ticketbuyer.votingaccount", cfg.TBOpts.VotingAccount)
 				}
 			}
-			if (cfg.EnableTicketBuyer && cfg.Mixing) || cfg.MixChange {
+			if (cfg.EnableTicketBuyer && cfg.MixingEnabled) || cfg.MixChange {
 				mixedAccount = lookup("mixedaccount", cfg.mixedAccount)
 				changeAccount = lookup("changeaccount", cfg.ChangeAccount)
 			}
-			if cfg.EnableTicketBuyer && cfg.Mixing {
+			if cfg.EnableTicketBuyer && cfg.MixingEnabled {
 				ticketSplitAccount = lookup("ticketsplitaccount", cfg.TicketSplitAccount)
 			}
 
@@ -338,7 +338,7 @@ func run(ctx context.Context) error {
 				Maintain:           cfg.TBOpts.BalanceToMaintainAbsolute.Amount,
 				Limit:              int(cfg.TBOpts.Limit),
 				VotingAccount:      votingAccount,
-				Mixing:             cfg.Mixing,
+				Mixing:             cfg.MixingEnabled,
 				MixChange:          cfg.MixChange,
 				MixedAccount:       mixedAccount,
 				MixedAccountBranch: cfg.mixedBranch,

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -42,7 +42,7 @@ type Loader struct {
 	watchLast               uint32
 	accountGapLimit         int
 	disableCoinTypeUpgrades bool
-	disableMixing           bool
+	mixingEnabled           bool
 	allowHighFees           bool
 	manualTickets           bool
 	relayFee                dcrutil.Amount
@@ -56,7 +56,7 @@ type Loader struct {
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled bool, gapLimit uint32,
 	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, vspMaxFee dcrutil.Amount, accountGapLimit int,
-	disableCoinTypeUpgrades bool, disableMixing bool, manualTickets bool, mixSplitLimit int, dialer wallet.DialFunc) *Loader {
+	disableCoinTypeUpgrades bool, mixingEnabled bool, manualTickets bool, mixSplitLimit int, dialer wallet.DialFunc) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
@@ -66,7 +66,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled boo
 		watchLast:               watchLast,
 		accountGapLimit:         accountGapLimit,
 		disableCoinTypeUpgrades: disableCoinTypeUpgrades,
-		disableMixing:           disableMixing,
+		mixingEnabled:           mixingEnabled,
 		allowHighFees:           allowHighFees,
 		manualTickets:           manualTickets,
 		relayFee:                relayFee,
@@ -174,7 +174,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
-		DisableMixing:           l.disableMixing,
+		MixingEnabled:           l.mixingEnabled,
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
@@ -264,7 +264,7 @@ func (l *Loader) CreateNewWallet(ctx context.Context, pubPassphrase, privPassphr
 		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
-		DisableMixing:           l.disableMixing,
+		MixingEnabled:           l.mixingEnabled,
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,
@@ -323,7 +323,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		WatchLast:               l.watchLast,
 		AccountGapLimit:         l.accountGapLimit,
 		DisableCoinTypeUpgrades: l.disableCoinTypeUpgrades,
-		DisableMixing:           l.disableMixing,
+		MixingEnabled:           l.mixingEnabled,
 		ManualTickets:           l.manualTickets,
 		AllowHighFees:           l.allowHighFees,
 		RelayFee:                l.relayFee,

--- a/internal/rpc/jsonrpc/config.go
+++ b/internal/rpc/jsonrpc/config.go
@@ -17,7 +17,7 @@ type Options struct {
 	MaxPOSTClients      int64
 	MaxWebsocketClients int64
 
-	Mixing             bool
+	MixingEnabled      bool
 	MixAccount         string
 	MixBranch          uint32
 	MixChangeAccount   string

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3355,7 +3355,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd any) (any, error) {
 	// mixing is enabled).
 	var changeAccount = account
 
-	if s.cfg.Mixing {
+	if s.cfg.MixingEnabled {
 		mixedAccount, err = w.AccountNumber(ctx, s.cfg.MixAccount)
 		if err != nil {
 			return nil, rpcErrorf(dcrjson.ErrRPCInvalidParameter,
@@ -3404,7 +3404,7 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd any) (any, error) {
 		DontSignTx:    dontSignTx,
 
 		// CSPP
-		Mixing:             s.cfg.Mixing,
+		Mixing:             s.cfg.MixingEnabled,
 		MixedAccount:       mixedAccount,
 		MixedAccountBranch: mixedAccountBranch,
 		MixedSplitAccount:  mixedSplitAccount,
@@ -3531,7 +3531,7 @@ func makeOutputs(pairs map[string]dcrutil.Amount, chainParams *chaincfg.Params) 
 // All errors are returned in dcrjson.RPCError format
 func (s *Server) sendPairs(ctx context.Context, w *wallet.Wallet, amounts map[string]dcrutil.Amount, account uint32, minconf int32) (string, error) {
 	changeAccount := account
-	if s.cfg.Mixing && s.cfg.MixAccount != "" && s.cfg.MixChangeAccount != "" {
+	if s.cfg.MixingEnabled && s.cfg.MixAccount != "" && s.cfg.MixChangeAccount != "" {
 		mixAccount, err := w.AccountNumber(ctx, s.cfg.MixAccount)
 		if err != nil {
 			return "", err
@@ -3567,7 +3567,7 @@ func (s *Server) sendPairs(ctx context.Context, w *wallet.Wallet, amounts map[st
 // returned in dcrjson.RPCError format
 func (s *Server) sendAmountToTreasury(ctx context.Context, w *wallet.Wallet, amount dcrutil.Amount, account uint32, minconf int32) (string, error) {
 	changeAccount := account
-	if s.cfg.Mixing {
+	if s.cfg.MixingEnabled {
 		mixAccount, err := w.AccountNumber(ctx, s.cfg.MixAccount)
 		if err != nil {
 			return "", err
@@ -5517,7 +5517,7 @@ func (s *Server) walletPassphraseChange(ctx context.Context, icmd any) (any, err
 
 func (s *Server) mixOutput(ctx context.Context, icmd any) (any, error) {
 	cmd := icmd.(*types.MixOutputCmd)
-	if !s.cfg.Mixing {
+	if !s.cfg.MixingEnabled {
 		return nil, errors.E("Mixing is not configured")
 	}
 	w, ok := s.walletLoader.LoadedWallet()
@@ -5552,7 +5552,7 @@ func (s *Server) mixOutput(ctx context.Context, icmd any) (any, error) {
 }
 
 func (s *Server) mixAccount(ctx context.Context, icmd any) (any, error) {
-	if !s.cfg.Mixing {
+	if !s.cfg.MixingEnabled {
 		return nil, errors.E("Mixing is not configured")
 	}
 	w, ok := s.walletLoader.LoadedWallet()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -373,7 +373,7 @@ func startRPCServers(ctx context.Context, walletLoader *loader.Loader) (*grpc.Se
 			Password:            pass,
 			MaxPOSTClients:      cfg.LegacyRPCMaxClients,
 			MaxWebsocketClients: cfg.LegacyRPCMaxWebsockets,
-			Mixing:              cfg.Mixing,
+			MixingEnabled:       cfg.MixingEnabled,
 			MixAccount:          cfg.mixedAccount,
 			MixBranch:           cfg.mixedBranch,
 			MixChangeAccount:    cfg.ChangeAccount,

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -276,7 +276,7 @@ func (w *Wallet) ChainSwitch(ctx context.Context, forest *SidechainForest, chain
 	forest.PruneChain(chain)
 	forest.Prune(int32(chain[len(chain)-1].Header.Height), w.chainParams)
 
-	if w.mixing {
+	if w.mixingEnabled {
 		w.mixClient.ExpireMessages(chain[len(chain)-1].Header.Height)
 	}
 

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -270,7 +270,7 @@ func (w *Wallet) MixOutput(ctx context.Context, output *wire.OutPoint, changeAcc
 	op := errors.Opf("wallet.MixOutput(%v)", output)
 
 	// Mixing requests require wallet mixing support.
-	if !w.mixing {
+	if !w.mixingEnabled {
 		s := "wallet mixing support is disabled"
 		return errors.E(op, errors.Invalid, s)
 	}
@@ -454,7 +454,7 @@ func (w *Wallet) MixAccount(ctx context.Context, changeAccount, mixAccount,
 	const op errors.Op = "wallet.MixAccount"
 
 	// Mixing requests require wallet mixing support.
-	if !w.mixing {
+	if !w.mixingEnabled {
 		s := "wallet mixing support is disabled"
 		return errors.E(op, errors.Invalid, s)
 	}

--- a/wallet/setup_test.go
+++ b/wallet/setup_test.go
@@ -22,6 +22,7 @@ var basicWalletConfig = Config{
 	GapLimit:      20,
 	RelayFee:      dcrutil.Amount(1e5),
 	Params:        chaincfg.SimNetParams(),
+	MixingEnabled: true,
 }
 
 func testWallet(ctx context.Context, t *testing.T, cfg *Config, seed []byte) (w *Wallet, teardown func()) {

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -115,7 +115,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 	loader := loader.NewLoader(activeNet.Params, dbDir, cfg.EnableVoting,
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
-		cfg.DisableCoinTypeUpgrades, !cfg.Mixing, cfg.ManualTickets,
+		cfg.DisableCoinTypeUpgrades, cfg.MixingEnabled, cfg.ManualTickets,
 		cfg.MixSplitLimit, cfg.dial)
 
 	var privPass, pubPass, seed []byte


### PR DESCRIPTION
Loader was using a flag to disable mixing whereas the rest of the code was using a flag to enable it. Standardizing on one removes the need to invert back and forth.