### PR TITLE
jsonrpc: Let client handle empty VSP policy fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/decred/dcrd/wire v1.7.0
 	github.com/decred/go-socks v1.1.0
 	github.com/decred/slog v1.2.0
-	github.com/decred/vspd/client/v4 v4.0.0
+	github.com/decred/vspd/client/v4 v4.0.1
 	github.com/decred/vspd/types/v3 v3.0.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/jessevdk/go-flags v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/decred/go-socks v1.1.0 h1:dnENcc0KIqQo3HSXdgboXAHgqsCIutkqq6ntQjYtm2U
 github.com/decred/go-socks v1.1.0/go.mod h1:sDhHqkZH0X4JjSa02oYOGhcGHYp12FsY1jQ/meV8md0=
 github.com/decred/slog v1.2.0 h1:soHAxV52B54Di3WtKLfPum9OFfWqwtf/ygf9njdfnPM=
 github.com/decred/slog v1.2.0/go.mod h1:kVXlGnt6DHy2fV5OjSeuvCJ0OmlmTF6LFpEPMu/fOY0=
-github.com/decred/vspd/client/v4 v4.0.0 h1:8qFB3t5CyBFuUU0LarJFsq/+twfUMPALwzOsB99r818=
-github.com/decred/vspd/client/v4 v4.0.0/go.mod h1:jhqu4KGGOskQcPVZ3XZLVZ1Wgkc9GQo+oEipr3gGODg=
+github.com/decred/vspd/client/v4 v4.0.1 h1:eoFWCoaqEMLBODRQrVABGcpFrFdOSPLiMWpPO+RVvi0=
+github.com/decred/vspd/client/v4 v4.0.1/go.mod h1:jhqu4KGGOskQcPVZ3XZLVZ1Wgkc9GQo+oEipr3gGODg=
 github.com/decred/vspd/types/v3 v3.0.0 h1:jHlQIpp6aCjIcFs8WE3AaVCJe1kgepNTq+nkBKAyQxk=
 github.com/decred/vspd/types/v3 v3.0.0/go.mod h1:hwifRZu6tpkbhSg2jZCUwuPaO/oETgbSCWCYJd4XepY=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -4687,18 +4687,6 @@ func (s *Server) setVoteChoice(ctx context.Context, icmd any) (any, error) {
 func (s *Server) updateVSPVoteChoices(ctx context.Context, w *wallet.Wallet, ticketHash *chainhash.Hash,
 	choices map[string]string, tspendPolicy map[string]string, treasuryPolicy map[string]string) error {
 
-	// Ensure empty (as opposed to nil) choices on every category (required
-	// by the contract of the VSP API).
-	if choices == nil {
-		choices = map[string]string{}
-	}
-	if tspendPolicy == nil {
-		tspendPolicy = map[string]string{}
-	}
-	if treasuryPolicy == nil {
-		treasuryPolicy = map[string]string{}
-	}
-
 	if ticketHash != nil {
 		vspHost, err := w.VSPHostForTicket(ctx, ticketHash)
 		if err != nil {


### PR DESCRIPTION
Changing nil to empty map is handled in VSP client v4.0.1 so this behaviour is no longer required in dcrwallet.

Ref #2438 