### PR TITLE
Add dcrwallet version to version JSON-RPC result

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -5332,6 +5332,14 @@ func (s *Server) version(ctx context.Context, icmd any) (any, error) {
 		}
 	}
 
+	resp["dcrwallet"] = dcrdtypes.VersionResult{
+		VersionString: version.String(),
+		Major:         version.Major,
+		Minor:         version.Minor,
+		Patch:         version.Patch,
+		Prerelease:    version.PreRelease,
+		BuildMetadata: version.BuildMetadata,
+	}
 	resp["dcrwalletjsonrpcapi"] = dcrdtypes.VersionResult{
 		VersionString: jsonrpcSemverString,
 		Major:         jsonrpcSemverMajor,


### PR DESCRIPTION
Previously, only the JSON-RPC API version would be included or added.

The application version, in addition to API version, is already returned by dcrd.