### PR TITLE
Do not specify TLS curve preferences

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -569,8 +569,7 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 		pool := x509.NewCertPool()
 		pool.AppendCertsFromPEM(s.opts.CA)
 		tc := &tls.Config{
-			MinVersion:       tls.VersionTLS12,
-			CurvePreferences: []tls.CurveID{tls.X25519, tls.CurveP256},
+			MinVersion: tls.VersionTLS12,
 			CipherSuites: []uint16{ // Only applies to TLS 1.2. TLS 1.3 ciphersuites are not configurable.
 				tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
 				tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,


### PR DESCRIPTION
TLS 1.2 is already the required minimum TLS version, which does not support any insecure curves.

Additionally, setting the curve preferences disables the X25519MLKEM768 key exchange, which would otherwise be used by default beginning in Go 2.24.