### PR TITLE
Init process optimize

### DIFF
--- a/config.go
+++ b/config.go
@@ -443,11 +443,10 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 		// if path error, create default config file, assign default dcrd rpc config data if any
 		createFileErr := createDefaultConfigFile(configFilePath, preCfg.DcrdAuthType)
 		if createFileErr != nil {
-			fmt.Fprintf(os.Stderr, "Error creating a default "+
+			fmt.Fprintf(os.Stderr, "Error creating default "+
 				"config file: %v\n", createFileErr)
 			configFileError = createFileErr
 		} else {
-			log.Warnf("Config file does not exist. New default file created: %s", configFilePath)
 			configFileError = nil
 			// Reparse data on config file
 			err = flags.NewIniParser(parser).ParseFile(configFilePath)
@@ -477,12 +476,12 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 
 	if cfg.RPCUser != "" {
 		cfg.Username = cfg.RPCUser
-	} else {
+	} else if cfg.Username != "" {
 		log.Warn("The 'username' attribute in the config file is outdated. You should update it to 'rpcuser'")
 	}
 	if cfg.RPCPass != "" {
 		cfg.Password = cfg.RPCPass
-	} else {
+	} else if cfg.Password != "" {
 		log.Warn("The 'password' attribute in the config file is outdated. You should update it to 'rpcpass'")
 	}
 
@@ -1154,10 +1153,10 @@ func createDefaultConfigFile(destPath string, authType string) error {
 		return err
 	}
 	cfg := Dcrwallet()
+	dcrdRpcUser := ""
+	dcrdRpcPass := ""
 	// check and read dcrd config file
 	if authType == authTypeBasic {
-		dcrdRpcUser := ""
-		dcrdRpcPass := ""
 		if exists(dcrdDefaultConfigFile) {
 			var getRpcErr error
 			// get rpc user, password info from dcrd
@@ -1172,12 +1171,6 @@ func createDefaultConfigFile(destPath string, authType string) error {
 				cfg = updatedCfg
 			}
 		}
-		// If dcrd rpc info cannot be obtained, the dcrwallet.conf file is still created, but warns the user about setting rpc parameters manually.
-		if dcrdRpcUser == "" && dcrdRpcPass == "" {
-			log.Warnf("Unable to get rpc informations from dcrd. You need to set these parameters manually for the program to run correctly.\n"+
-				"Config file path: %s", destPath)
-
-		}
 	}
 	// Create config file at the provided path.
 	dest, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
@@ -1186,6 +1179,13 @@ func createDefaultConfigFile(destPath string, authType string) error {
 	}
 	defer dest.Close()
 	_, err = dest.WriteString(cfg)
+	if err == nil {
+		log.Warnf("Config file does not exist. New default file created: %s", destPath)
+	}
+	// If dcrd rpc info cannot be obtained, the dcrwallet.conf file is still created, but warns the user about setting rpc parameters manually.
+	if dcrdRpcUser == "" && dcrdRpcPass == "" {
+		log.Warnf("Unable to get rpc informations from dcrd. Launch dcrd to automatically update or set it manually on the config file.")
+	}
 	return err
 }
 func getRpcConfigFromDcrdConfigFile(filePath string) (string, string, error) {

--- a/config.go
+++ b/config.go
@@ -163,6 +163,8 @@ type config struct {
 	LegacyRPCMaxWebsockets int64                   `long:"rpcmaxwebsockets" description:"Max JSON-RPC websocket clients"`
 	Username               string                  `short:"u" long:"username" description:"JSON-RPC username and default dcrd RPC username"`
 	Password               string                  `short:"P" long:"password" default-mask:"-" description:"JSON-RPC password and default dcrd RPC password"`
+	RPCUser                string                  `long:"rpcuser" description:"JSON-RPC username and default dcrd RPC username"`
+	RPCPass                string                  `long:"rpcpass" default-mask:"-" description:"JSON-RPC password and default dcrd RPC password"`
 	JSONRPCAuthType        string                  `long:"jsonrpcauthtype" description:"Method for JSON-RPC client authentication (basic or clientcert)"`
 
 	// IPC options
@@ -459,6 +461,17 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 				configFileError = err
 			}
 		}
+	}
+
+	if cfg.RPCUser != "" {
+		cfg.Username = cfg.RPCUser
+	} else {
+		log.Warn("The 'username' attribute in the config file is outdated. You should update it to 'rpcuser'")
+	}
+	if cfg.RPCPass != "" {
+		cfg.Password = cfg.RPCPass
+	} else {
+		log.Warn("The 'password' attribute in the config file is outdated. You should update it to 'rpcpass'")
 	}
 
 	// Parse command line options again to ensure they take precedence.
@@ -1110,10 +1123,10 @@ func createDefaultConfigFile(destPath string, authType string) error {
 		if getRpcErr == nil {
 			// Replace the rpcuser and rpcpass lines in the sample configuration
 			// file contents with their generated values.
-			rpcUserRE := regexp.MustCompile(`(?m)^;\s*username=[^\s]*$`)
-			rpcPassRE := regexp.MustCompile(`(?m)^;\s*password=[^\s]*$`)
-			updatedCfg := rpcUserRE.ReplaceAllString(cfg, strings.ReplaceAll(rpcUser, "rpcuser", "username"))
-			updatedCfg = rpcPassRE.ReplaceAllString(updatedCfg, strings.ReplaceAll(rpcPass, "rpcpass", "password"))
+			rpcUserRE := regexp.MustCompile(`(?m)^;\s*rpcuser=[^\s]*$`)
+			rpcPassRE := regexp.MustCompile(`(?m)^;\s*rpcpass=[^\s]*$`)
+			updatedCfg := rpcUserRE.ReplaceAllString(cfg, strings.ReplaceAll(rpcUser, "rpcuser", "rpcuser"))
+			updatedCfg = rpcPassRE.ReplaceAllString(updatedCfg, strings.ReplaceAll(rpcPass, "rpcpass", "rpcpass"))
 			cfg = updatedCfg
 		}
 	}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -104,6 +104,10 @@ func promptList(reader *bufio.Reader, prefix string, validResponses []string, de
 	}
 }
 
+func AskConfirmBool(reader *bufio.Reader, prefix string, defaultEntry string) (bool, error) {
+	return promptListBool(reader, prefix, defaultEntry)
+}
+
 // promptListBool prompts the user for a boolean (yes/no) with the given prefix.
 // The function will repeat the prompt to the user until they enter a valid
 // response.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -297,11 +297,11 @@ func startRPCServers(walletLoader *loader.Loader) (*grpc.Server, *jsonrpc.Server
 		}
 
 		clientCAsExist = clientCAsExist || cfg.IssueClientCert
-		if !clientCAsExist && len(cfg.GRPCListeners) != 0 {
+		if !clientCAsExist && len(cfg.GRPCListeners) != 0 && cfg.JSONRPCAuthType == "clientcert" {
 			log.Warnf("gRPC server is configured with listeners, but no "+
 				"trusted client certificates exist (looked in %v)",
 				cfg.ClientCAFile)
-		} else if clientCAsExist && len(cfg.GRPCListeners) != 0 {
+		} else if clientCAsExist && len(cfg.GRPCListeners) != 0 && cfg.JSONRPCAuthType == "clientcert" {
 			tlsConfig := tlsConfig.Clone()
 			tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 			listeners := makeListeners(cfg.GRPCListeners, net.Listen)

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -180,11 +180,6 @@
 ; RPC settings (both client and server)
 ; ------------------------------------------------------------------------------
 
-; Username and password to authenticate to a dcrd RPC server and authenticate
-; new client connections to dcrwallet.
-; username=
-; password=
-
 ; The official authentication information connects to the dcrd rpc server and authenticate
 ; new client connections to dcrwallet.
 ; rpcuser=

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -185,6 +185,11 @@
 ; username=
 ; password=
 
+; The official authentication information connects to the dcrd rpc server and authenticate
+; new client connections to dcrwallet.
+; rpcuser=
+; rpcpass=
+
 ; Alternative username and password for dcrd.  If set, these will be used
 ; instead of the username and password set above for authentication to a
 ; dcrd RPC server.

--- a/sampleconfig.go
+++ b/sampleconfig.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2017-2022 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	_ "embed"
+)
+
+//go:embed sample-dcrwallet.conf
+var sampleDcrwalletConf string
+
+// Dcrd returns a string containing the commented example config for dcrd.
+func Dcrwallet() string {
+	return sampleDcrwalletConf
+}
+
+// FileContents returns a string containing the commented example config for
+// dcrwallet.
+//
+// Deprecated: Use the [Dcrwallet] function instead.
+func FileContents() string {
+	return Dcrwallet()
+}

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -105,6 +105,13 @@ func displaySimnetMiningAddrs(seed []byte, imported bool) error {
 	return nil
 }
 
+// Confirm yes/no/y/n with confirm question and default confirmation value
+func ConfirmBool(prefix, defaultEntry string) (bool, error) {
+	r := bufio.NewReader(os.Stdin)
+	confirmYes, err := prompt.AskConfirmBool(r, prefix, defaultEntry)
+	return confirmYes, err
+}
+
 // createWallet prompts the user for information needed to generate a new wallet
 // and generates the wallet accordingly.  The new wallet will reside at the
 // provided path. The bool passed back gives whether or not the wallet was


### PR DESCRIPTION
Related issue: #2458 
Upon the first launch, initializing and running dcrwallet requires significant time and effort from users. 
- The configuration file is neither automatically generated nor initialized with the necessary RPC values.
- If the wallet is not created, the user must re-launch the --create command, as no solution is provided to create the wallet during the initial run.
- The naming of RPC parameters in dcrwallet remains inconsistent with those in dcrd. 
 * Dcrd rpc params: _rpcuser - rpcpass_ 
 * Dcrwallet rpc params: _username - password_
- Although rpcAuthType is set to "basic," the clientCAs certificate is still checked, and a warning is issued
_"DCRW: gRPC server is configured with listeners, but no trusted client certificates exist (looked in /home/x/.dcrwallet/clients.pem)"_

Although Decred provides a dcrinstall binary for quick installation and setup, there remains a need for active and comprehensive support for programs when run individually.

To address these issues:
- Upon the first launch, the program checks whether the configuration file exists. If it does not, it automatically creates the file using sample content from sample-config.conf.
Give notice when generating files automatically:
_"DCRW: Config file does not exist. New default file created: C:\Users\UserName\AppData\Local\Dcrwallet\dcrwallet.conf"_
- When creating the configuration file, I set the RPC parameters by retrieving information from the configuration file of the installed dcrd.
If RPC information cannot be obtained from dcrd, provide the user with the option to run in SPV mode. The RPC username and password will be automatically generated for use in SPV mode.
_“Would you like to launch SPV mode? (If SPV mode is selected, the username and password will be automatically generated.) (n/no/y/yes) [y]: ”_
If SPV mode is enabled in the launch command (--spv), rpcuser and rpcpass are still initialized automatically if their values cannot be obtained from dcrd.
- The program checks whether the wallet has been initialized. If it has not, it provides the user with instructions and procedures to create a wallet without requiring the command to be executed again.
Wallet creation notice:
_“The wallet does not exist. Do you want to create a wallet now? (n/no/y/yes) [y]:
Enter the private passphrase for your new wallet: Password
Confirm passphrase: Password 
….
…..”_
- Once setup is complete, users can launch dcrwallet immediately on the same process.
_“The wallet has been created successfully. Do you want to launch dcrwallet now? (n/no/y/yes) [y]:”_
- Update the RPC parameter names in dcrwallet to ensure consistency with those in dcrd. The parameters are changed to rpcuser and rpcpassword. Legacy users who rely on the old parameters will continue to be supported for backward compatibility. However, a warning will be issued to encourage updating.
warning msg: 
_“ [WRN] DCRW: The 'username' attribute in the config file is outdated. You should update it to 'rpcuser'
[WRN] DCRW: The 'password' attribute in the config file is outdated. You should update it to 'rpcpass'”_
- Fix the logic for checking the clientCAs certificate. Remove clientCAs checking when rpcAuthType is set to "basic."
By implementing these solutions, the usability and consistency of dcrwallet can be significantly improved, addressing key challenges faced by users during initialization and configuration