### PR TITLE
Shorten the ticketbuyer.balancetomaintainabsolute param name

### DIFF
--- a/config.go
+++ b/config.go
@@ -185,6 +185,7 @@ type config struct {
 
 type ticketBuyerOptions struct {
 	BalanceToMaintainAbsolute *cfgutil.AmountFlag `long:"balancetomaintainabsolute" description:"Amount of funds to keep in wallet when purchasing tickets"`
+	BalanceToMaintain         *cfgutil.AmountFlag `long:"balancetomaintain" description:"Amount of funds to keep in wallet when purchasing tickets"`
 	Limit                     uint                `long:"limit" description:"Buy no more than specified number of tickets per block"`
 	VotingAccount             string              `long:"votingaccount" description:"Account used to derive addresses specifying voting rights"`
 }
@@ -380,8 +381,8 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 
 		// Ticket Buyer Options
 		TBOpts: ticketBuyerOptions{
-			BalanceToMaintainAbsolute: cfgutil.NewAmountFlag(defaultBalanceToMaintainAbsolute),
-			Limit:                     defaultTicketbuyerLimit,
+			BalanceToMaintain: cfgutil.NewAmountFlag(defaultBalanceToMaintainAbsolute),
+			Limit:             defaultTicketbuyerLimit,
 		},
 
 		VSPOpts: vspOptions{
@@ -435,6 +436,12 @@ func loadConfig(ctx context.Context) (*config, []string, error) {
 			return loadConfigError(err)
 		}
 		configFileError = err
+	}
+
+	if cfg.TBOpts.BalanceToMaintainAbsolute != nil {
+		log.Warn("The 'ticketbuyer.balancetomaintainabsolute' attribute in the config file is outdated. You should update it to 'ticketbuyer.balancetomaintain'")
+	} else {
+		cfg.TBOpts.BalanceToMaintainAbsolute = cfg.TBOpts.BalanceToMaintain
 	}
 
 	// Parse command line options again to ensure they take precedence.

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -237,7 +237,7 @@
 ; ------------------------------------------------------------------------------
 
 ; Amount of funds to keep in wallet when stake mining
-; ticketbuyer.balancetomaintainabsolute=0
+; ticketbuyer.balancetomaintain=0
 
 [VSP Options]
 


### PR DESCRIPTION
The parameter name was unnecessarily long, so I have adjusted it to 'ticketbuyer.balancetomaintain.'
The old name remains supported and valid for backward compatibility. However, there will be a notification about updating to the new param name
warning msg:
_“ DCRW: The 'ticketbuyer.balancetomaintainabsolute' attribute in the config file is outdated. You should update it to 'ticketbuyer.balancetomaintain'”_