### PR TITLE
spv: Teardown syncer after all peers are lost 

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -523,21 +523,25 @@ func spvLoop(ctx context.Context, w *wallet.Wallet) {
 	addr := &net.TCPAddr{IP: net.ParseIP("::1"), Port: 0}
 	amgrDir := filepath.Join(cfg.AppDataDir.Value, w.ChainParams().Name)
 	amgr := addrmgr.New(amgrDir, cfg.lookup)
-	lp := p2p.NewLocalPeer(w.ChainParams(), addr, amgr)
-	lp.SetDialFunc(cfg.dial)
-	lp.SetDisableRelayTx(cfg.SPVDisableRelayTx)
-	syncer := spv.NewSyncer(w, lp)
-	if len(cfg.SPVConnect) > 0 {
-		syncer.SetPersistentPeers(cfg.SPVConnect)
-	}
-	w.SetNetworkBackend(syncer)
 	for {
+		lp := p2p.NewLocalPeer(w.ChainParams(), addr, amgr)
+		lp.SetDialFunc(cfg.dial)
+		lp.SetDisableRelayTx(cfg.SPVDisableRelayTx)
+		syncer := spv.NewSyncer(w, lp)
+		if len(cfg.SPVConnect) > 0 {
+			syncer.SetPersistentPeers(cfg.SPVConnect)
+		}
 		err := syncer.Run(ctx)
-		if done(ctx) {
+		if err == nil || done(ctx) {
 			loggers.SyncLog.Infof("SPV synchronization stopped")
 			return
 		}
 		loggers.SyncLog.Errorf("SPV synchronization stopped: %v", err)
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(5 * time.Second):
+		}
 	}
 }
 


### PR DESCRIPTION
Recreate a new syncer in the SPV reconnect loop in main.  This will allow
initial sync logic to be reperformed if peers can be connected later.

This also adds a forced 5s backoff before peers connection attempts are made
again, matching the backoff behavior for RPC syncing.

Rebased over #2463.