### PR TITLE
Add updates for Go 1.24.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.22", "1.23"]
+        go: ["1.23", "1.24"]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 #5.0.2
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #5.3.0
         with:
           go-version: ${{ matrix.go }}
       - name: Check out source
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Build
         run: go build ./...
       - name: Test

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ https://decred.org/downloads/
 
 ### Build from source (all platforms)
 
-- **Install Go 1.22 or 1.23**
+- **Install Go 1.23 or 1.24**
 
   Installation instructions can be found here: https://golang.org/doc/install.
   Ensure Go was installed properly and is a supported version:

--- a/debug.go
+++ b/debug.go
@@ -2,8 +2,16 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//go:build go1.23
+// We use a build tag to change the default GODEBUG value to the latest Go
+// release, rather than setting this default in the go.mod for two reasons:
+//
+// 1. Our go.mod specifies at most the previous supported Go version as a
+//    minimum, and the latest Go toolchain's default GODEBUG cannot be specified
+//    without breaking builds with the older toolchains.
+// 2. If a go.work is used, the godebug directives in go.mod will be ignored.
 
-//go:debug default=go1.23
+//go:build go1.24
+
+//go:debug default=go1.24
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module decred.org/dcrwallet/v5
 
-go 1.22
+go 1.23
 
 require (
 	decred.org/cspp/v2 v2.3.0


### PR DESCRIPTION
This bumps the Go version required by the v5 module (which has not yet been tagged) to the previous Go 1.23 release.

The default GODEBUG flags when building with Go 1.24 have been changed to the 1.24 default values.