### PR TITLE
Use testing.T.TempDir() for temporary test directories

### DIFF
--- a/wallet/setup_test.go
+++ b/wallet/setup_test.go
@@ -25,7 +25,7 @@ var basicWalletConfig = Config{
 }
 
 func testWallet(ctx context.Context, t *testing.T, cfg *Config, seed []byte) (w *Wallet, teardown func()) {
-	f, err := os.CreateTemp("", "dcrwallet.testdb")
+	f, err := os.CreateTemp(t.TempDir(), "dcrwallet.testdb")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wallet/udb/txcommon_test.go
+++ b/wallet/udb/txcommon_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func tempDB(t *testing.T) (db walletdb.DB, teardown func()) {
-	f, err := os.CreateTemp("", "udb")
+	f, err := os.CreateTemp(t.TempDir(), "udb")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
These test directories are always unique per test and will be cleaned up automatically after the test ends.