### PR TITLE
Prevent hang when dcrd connection is lost

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -759,13 +759,15 @@ func (s *Syncer) Run(ctx context.Context) (err error) {
 	log.Infof("Blockchain sync completed, wallet ready for general usage.")
 
 	g.Go(func() error {
+		var err error
 		select {
 		case <-ctx.Done():
-			walletCtxCancel()
-			return ctx.Err()
+			err = ctx.Err()
 		case <-wsClient.Done():
-			return wsClient.Err()
+			err = wsClient.Err()
 		}
+		walletCtxCancel()
+		return err
 	})
 	return g.Wait()
 }


### PR DESCRIPTION
The ordered shutdown of wallet goroutines before closing the websocket connection introduced a new bug where the RPC syncer would hang if the dcrd connection is lost before clean shutdown is signaled, due to a missing call to cancel the context passed to Wallet.Run.