### PR TITLE
jsonrpc: Error early from mixoutput if mixing is not enabled

### DIFF
--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -5499,6 +5499,9 @@ func (s *Server) walletPassphraseChange(ctx context.Context, icmd any) (any, err
 
 func (s *Server) mixOutput(ctx context.Context, icmd any) (any, error) {
 	cmd := icmd.(*types.MixOutputCmd)
+	if !s.cfg.Mixing {
+		return nil, errors.E("Mixing is not configured")
+	}
 	w, ok := s.walletLoader.LoadedWallet()
 	if !ok {
 		return nil, errUnloadedWallet


### PR DESCRIPTION
This produces a nicer and more understandable error then "account not found" as it would have previously failed while looking up the unconfigured mixing accounts.