### PR TITLE
fix: fix incorrect nil return value

### DIFF
--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -626,7 +626,7 @@ func (f *existsAddrIndexFinder) accountUsed(ctx context.Context, xpub *hd.Extend
 	for i := 0; i < 2; i++ {
 		r := <-results
 		if r.err != nil {
-			return false, err
+			return false, r.err
 		}
 		if r.used {
 			return true, nil


### PR DESCRIPTION
Since we have already checked err before and returned != nil, err must be nil here. In fact, it should return `r.err`.