### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/wallet/udb/upgrades_test.go
+++ b/wallet/udb/upgrades_test.go
@@ -41,10 +41,7 @@ var pubPass = []byte("public")
 
 func TestUpgrades(t *testing.T) {
 	ctx := context.Background()
-	d, err := os.MkdirTemp("", "dcrwallet_udb_TestUpgrades")
-	if err != nil {
-		t.Fatal(err)
-	}
+	d := t.TempDir()
 
 	t.Run("group", func(t *testing.T) {
 		for i, test := range dbUpgradeTests {
@@ -85,7 +82,6 @@ func TestUpgrades(t *testing.T) {
 		}
 	})
 
-	os.RemoveAll(d)
 }
 
 func verifyV2Upgrade(ctx context.Context, t *testing.T, db walletdb.DB) {


### PR DESCRIPTION
`TempDir()` is a method introduced in Go 1.15 for `testing.T`. It automatically creates a temporary directory and cleans it up after the test is complete, eliminating the hassle of manually handling errors and cleanup.  More detail about TempDir  https://pkg.go.dev/testing#B.TempDir