### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -691,13 +691,6 @@ func (w *Wallet) AddressAtIdx(ctx context.Context, account, branch,
 	return addr, nil
 }
 
-func minUint32(a, b uint32) uint32 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 // markUsedAddress updates the database, recording that the previously looked up
 // managed address has been publicly used.  After recording this usage, new
 // addresses are derived and saved to the db.
@@ -722,7 +715,7 @@ func (w *Wallet) markUsedAddress(op errors.Op, dbtx walletdb.ReadWriteTx, addr u
 		branch = udb.InternalBranch
 	}
 	err = w.manager.SyncAccountToAddrIndex(ns, account,
-		minUint32(hdkeychain.HardenedKeyStart-1, lastUsed+w.gapLimit),
+		min(hdkeychain.HardenedKeyStart-1, lastUsed+w.gapLimit),
 		branch)
 	if err != nil {
 		return errors.E(op, err)

--- a/wallet/notifications.go
+++ b/wallet/notifications.go
@@ -616,9 +616,9 @@ func (s *NotificationServer) notifyAccountProperties(props *udb.AccountPropertie
 	// addresses have also been generated and are being watched for transaction
 	// activity.
 	if props.AccountNumber <= udb.MaxAccountNum {
-		n.ExternalKeyCount = minUint32(hdkeychain.HardenedKeyStart,
+		n.ExternalKeyCount = min(hdkeychain.HardenedKeyStart,
 			props.LastUsedExternalIndex+s.wallet.gapLimit)
-		n.InternalKeyCount = minUint32(hdkeychain.HardenedKeyStart,
+		n.InternalKeyCount = min(hdkeychain.HardenedKeyStart,
 			props.LastUsedInternalIndex+s.wallet.gapLimit)
 	}
 	for _, c := range clients {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -918,8 +918,8 @@ func (w *Wallet) watchHDAddrs(ctx context.Context, firstWatch bool, n NetworkBac
 				return err
 			}
 			hdAccounts[acct] = hdAccount{
-				externalCount:        minUint32(props.LastReturnedExternalIndex+w.gapLimit, hdkeychain.HardenedKeyStart-1),
-				internalCount:        minUint32(props.LastReturnedInternalIndex+w.gapLimit, hdkeychain.HardenedKeyStart-1),
+				externalCount:        min(props.LastReturnedExternalIndex+w.gapLimit, hdkeychain.HardenedKeyStart-1),
+				internalCount:        min(props.LastReturnedInternalIndex+w.gapLimit, hdkeychain.HardenedKeyStart-1),
 				lastReturnedExternal: props.LastReturnedExternalIndex,
 				lastReturnedInternal: props.LastReturnedInternalIndex,
 				lastUsedExternal:     props.LastUsedExternalIndex,
@@ -1013,7 +1013,7 @@ func (w *Wallet) watchHDAddrs(ctx context.Context, firstWatch bool, n NetworkBac
 		const step = 256
 		for ; start <= end; start += step {
 			addrs := make([]stdaddr.Address, 0, step)
-			stop := minUint32(end+1, start+step)
+			stop := min(end+1, start+step)
 			for child := start; child < stop; child++ {
 				addr, err := deriveChildAddress(branchKey, child, w.chainParams)
 				if errors.Is(err, hdkeychain.ErrInvalidChild) {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.