### PR TITLE
Require an explicit voting account.

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -315,6 +315,8 @@ func run(ctx context.Context) error {
 				}
 				if cfg.TBOpts.VotingAccount != "" {
 					votingAccount = lookup("ticketbuyer.votingaccount", cfg.TBOpts.VotingAccount)
+				} else {
+					votingAccount = purchaseAccount
 				}
 			}
 			if (cfg.EnableTicketBuyer && cfg.MixingEnabled) || cfg.MixChange {

--- a/internal/rpc/jsonrpc/methods.go
+++ b/internal/rpc/jsonrpc/methods.go
@@ -3412,6 +3412,13 @@ func (s *Server) purchaseTicket(ctx context.Context, icmd any) (any, error) {
 
 		VSPClient: vspClient,
 	}
+	// Use the mixed account as voting account if mixing is enabled,
+	// otherwise use the source account.
+	if s.cfg.MixingEnabled {
+		request.VotingAccount = mixedAccount
+	} else {
+		request.VotingAccount = account
+	}
 
 	ticketsResponse, err := w.PurchaseTickets(ctx, n, request)
 	if err != nil {

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -1864,13 +1864,12 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 	}
 
 	request := &wallet.PurchaseTicketsRequest{
-		Count:            numTickets,
-		SourceAccount:    req.Account,
-		MinConf:          minConf,
-		Expiry:           expiry,
-		DontSignTx:       dontSignTx,
-		UseVotingAccount: req.UseVotingAccount,
-		VotingAccount:    req.VotingAccount,
+		Count:         numTickets,
+		SourceAccount: req.Account,
+		VotingAccount: req.VotingAccount,
+		MinConf:       minConf,
+		Expiry:        expiry,
+		DontSignTx:    dontSignTx,
 
 		// CSPP
 		Mixing:             req.EnableMixing,
@@ -1880,6 +1879,16 @@ func (s *walletServer) PurchaseTickets(ctx context.Context,
 		ChangeAccount:      changeAccount,
 
 		VSPClient: vspClient,
+	}
+	// If an explicit voting account is not set, use the mixed account as
+	// the voting account if mixing is enabled, otherwise use the source
+	// account.
+	if !req.UseVotingAccount {
+		if req.EnableMixing {
+			request.VotingAccount = mixedAccount
+		} else {
+			request.VotingAccount = req.Account
+		}
 	}
 
 	// If dontSignTx is false we unlock the wallet so we can sign the tx.

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -282,12 +282,11 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	}
 
 	purchaseTicketReq := &wallet.PurchaseTicketsRequest{
-		Count:            buy,
-		SourceAccount:    account,
-		MinConf:          minconf,
-		Expiry:           expiry,
-		VotingAccount:    votingAccount,
-		UseVotingAccount: true,
+		Count:         buy,
+		SourceAccount: account,
+		VotingAccount: votingAccount,
+		MinConf:       minconf,
+		Expiry:        expiry,
 
 		// CSPP
 		Mixing:             mixing,

--- a/ticketbuyer/tb.go
+++ b/ticketbuyer/tb.go
@@ -282,14 +282,15 @@ func (tb *TB) buy(ctx context.Context, passphrase []byte, tip *wire.BlockHeader,
 	}
 
 	purchaseTicketReq := &wallet.PurchaseTicketsRequest{
-		Count:         buy,
-		SourceAccount: account,
-		MinConf:       minconf,
-		Expiry:        expiry,
+		Count:            buy,
+		SourceAccount:    account,
+		MinConf:          minconf,
+		Expiry:           expiry,
+		VotingAccount:    votingAccount,
+		UseVotingAccount: true,
 
 		// CSPP
 		Mixing:             mixing,
-		VotingAccount:      votingAccount,
 		MixedAccount:       mixedAccount,
 		MixedAccountBranch: mixedBranch,
 		MixedSplitAccount:  splitAccount,

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1504,32 +1504,14 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 			PrevOut:  *txOut,
 		}
 
-		var addrVote stdaddr.StakeAddress
-
-		// If req.Mixing or req.UseVotingAccount is true, derive the
-		// submission script's address from the voting account. This
-		// is intended to be used with a special account type. The
-		// signing address for the same index is saved to the
-		// database. That address is later used to sign messages sent
-		// to a vspd related to this ticket.
-		if req.Mixing || req.UseVotingAccount {
-			var idx uint32
-			addrVote, idx, err = stakeAddrFunc(op, req.VotingAccount, 1)
-			if err != nil {
-				return nil, err
-			}
-			_, err := w.signingAddressAtIdx(ctx, op, w.persistReturnedChild(ctx, nil),
-				req.VotingAccount, idx)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			// If the user hasn't specified a voting account, derive a voting
-			// address from the purchasing account.
-			addrVote, _, err = stakeAddrFunc(op, req.SourceAccount, 1)
-			if err != nil {
-				return nil, err
-			}
+		addrVote, idx, err := stakeAddrFunc(op, req.VotingAccount, 1)
+		if err != nil {
+			return nil, err
+		}
+		_, err = w.signingAddressAtIdx(ctx, op, w.persistReturnedChild(ctx, nil),
+			req.VotingAccount, idx)
+		if err != nil {
+			return nil, err
 		}
 		subsidyAccount := req.SourceAccount
 		var branch uint32 = 1

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1555,13 +1555,12 @@ func (w *Wallet) CreateMultisigTx(ctx context.Context, account uint32, amount dc
 
 // PurchaseTicketsRequest describes the parameters for purchasing tickets.
 type PurchaseTicketsRequest struct {
-	Count            int
-	SourceAccount    uint32
-	MinConf          int32
-	Expiry           int32
-	VotingAccount    uint32 // Used when Mixing == true || UseVotingAccount == true
-	UseVotingAccount bool   // Forces use of supplied voting account.
-	DontSignTx       bool
+	Count         int
+	SourceAccount uint32
+	VotingAccount uint32
+	MinConf       int32
+	Expiry        int32
+	DontSignTx    bool
 
 	// Mixed split buying through CoinShuffle++
 	Mixing             bool


### PR DESCRIPTION
This is a breaking API change that removes the error-prone UseVotingAccount
field from the purchase tickets request configuration.  Users of this API must
instead explicitly specify this field (or the default account 0 will be used
instead).

Rebased over #2482.  The previous commit can be backported if needed, while this is a breaking API change for v5.