### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/kdf/kdf.go
+++ b/kdf/kdf.go
@@ -28,10 +28,7 @@ type Argon2idParams struct {
 // The time and memory parameters may be increased by an application when stronger
 // security requirements are desired, and additional memory is available.
 func NewArgon2idParams(rand io.Reader) (*Argon2idParams, error) {
-	ncpu := runtime.NumCPU()
-	if ncpu > 256 {
-		ncpu = 256
-	}
+	ncpu := min(runtime.NumCPU(), 256)
 	p := &Argon2idParams{
 		Time:    1,
 		Memory:  256 * 1024, // 256 MiB

--- a/p2p/peering.go
+++ b/p2p/peering.go
@@ -542,10 +542,7 @@ func (rp *RemotePeer) sendWaitingInventory(ctx context.Context) error {
 
 	s := rp.waitingInvs
 	for len(s) != 0 {
-		l := len(s)
-		if l > wire.MaxInvPerMsg {
-			l = wire.MaxInvPerMsg
-		}
+		l := min(len(s), wire.MaxInvPerMsg)
 		if err := sendInvMsg(s[:l]); err != nil {
 			return err
 		}

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -623,10 +623,7 @@ func (s *Syncer) breaksMinVersionTarget(rp *p2p.RemotePeer) bool {
 // backoff period.
 func nextBackoff(d time.Duration) time.Duration {
 	const maxBackoff = 90 * time.Second
-	d = 5*time.Second + d*95/100
-	if d > maxBackoff {
-		d = maxBackoff
-	}
+	d = min(5*time.Second+d*95/100, maxBackoff)
 	return d
 }
 

--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -871,10 +871,7 @@ func (w *Wallet) DiscoverActiveAddresses(ctx context.Context, n NetworkBackend, 
 				return ctx.Err()
 			}
 
-			to := j + N
-			if to > max {
-				to = max
-			}
+			to := min(j+N, max)
 			err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 				ns := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
 				return w.manager.SyncAccountToAddrIndex(ns, acct, to, 0)
@@ -893,10 +890,7 @@ func (w *Wallet) DiscoverActiveAddresses(ctx context.Context, n NetworkBackend, 
 				return ctx.Err()
 			}
 
-			to := j + N
-			if to > max {
-				to = max
-			}
+			to := min(j+N, max)
 			err = walletdb.Update(ctx, w.db, func(dbtx walletdb.ReadWriteTx) error {
 				ns := dbtx.ReadWriteBucket(waddrmgrNamespaceKey)
 				return w.manager.SyncAccountToAddrIndex(ns, acct, to, 1)

--- a/wallet/feepayment.go
+++ b/wallet/feepayment.go
@@ -204,10 +204,7 @@ func (fp *vspFeePayment) next() time.Duration {
 	switch {
 	case tipHeight < ticketLive: // immature, mined ticket
 		blocksUntilLive := ticketLive - tipHeight
-		jitter = fp.params.TargetTimePerBlock * time.Duration(blocksUntilLive)
-		if jitter > immatureJitter {
-			jitter = immatureJitter
-		}
+		jitter = min(fp.params.TargetTimePerBlock*time.Duration(blocksUntilLive), immatureJitter)
 	case tipHeight < ticketExpires: // live ticket
 		jitter = liveJitter
 	default: // unmined ticket

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -344,10 +344,7 @@ SplitPoints:
 			continue
 		}
 
-		count = uint32(amount / mixValue)
-		if count > 4 {
-			count = 4
-		}
+		count = min(uint32(amount/mixValue), 4)
 		for ; count > 0; count-- {
 			remValue = amount - dcrutil.Amount(count)*mixValue
 			if remValue < 0 {


### PR DESCRIPTION
In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.