### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -96,10 +97,8 @@ func promptList(reader *bufio.Reader, prefix string, validResponses []string, de
 			reply = defaultEntry
 		}
 
-		for _, validResponse := range validResponses {
-			if reply == validResponse {
-				return reply, nil
-			}
+		if slices.Contains(validResponses, reply) {
+			return reply, nil
 		}
 	}
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.