### PR TITLE
Prevent VSP fee rate overpayment

### DIFF
--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1659,9 +1659,9 @@ func (w *Wallet) PurchaseTickets(ctx context.Context, n NetworkBackend,
 	version, script := addr.(Address).PaymentScript()
 	a.outputs = append(a.outputs, &wire.TxOut{Version: version, PkScript: script})
 	txsize := txsizes.EstimateSerializeSize([]int{txsizes.RedeemP2PKHInputSize},
-		a.outputs, txsizes.P2PKHPkScriptSize)
+		a.outputs, 0)
 	txfee := txrules.FeeForSerializeSize(relayFee, txsize)
-	a.outputs[0].Value = int64(vspFee + 2*txfee)
+	a.outputs[0].Value = int64(vspFee + txfee)
 	err = w.authorTx(ctx, op, a)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
When an extra output is required to be created to pay the VSP during UTXO
contention, the estimated fee tx size included an unnecessary change output
and a buffer of 2x the estimated network fee.  However, this would create
change outputs small enough to be considered dust, causing the additional
value to be rolled into the network transaction fee instead, causing a roughly
3x network fee overpayment for these VSP fee transactions.

Fix this by removing the unnecessary change output from the size calculation
and do not add more than 1x the estimated network fee for the 1:1 VSP fee
transaction.