### PR TITLE
refactor: use maps.Clone to simplify code

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -7,6 +7,7 @@ package spv
 import (
 	"context"
 	"fmt"
+	"maps"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -220,11 +221,7 @@ func (s *Syncer) GetRemotePeers() map[string]*p2p.RemotePeer {
 	s.remotesMu.Lock()
 	defer s.remotesMu.Unlock()
 
-	remotes := make(map[string]*p2p.RemotePeer, len(s.remotes))
-	for k, rp := range s.remotes {
-		remotes[k] = rp
-	}
-	return remotes
+	return maps.Clone(s.remotes)
 }
 
 // peerConnected updates the notification for peer count, if set.

--- a/wallet/vspclientloader.go
+++ b/wallet/vspclientloader.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"maps"
+
 	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/internal/loggers"
 )
@@ -42,9 +44,6 @@ func (w *Wallet) AllVSPs() map[string]*VSPClient {
 	// Create a copy to avoid callers mutating the list.
 	w.vspClientsMu.Lock()
 	defer w.vspClientsMu.Unlock()
-	res := make(map[string]*VSPClient, len(w.vspClients))
-	for host, client := range w.vspClients {
-		res[host] = client
-	}
-	return res
+
+	return maps.Clone(w.vspClients)
 }


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Clone) added in the go1.21 standard library, which can make the code more concise and easy to read.