### PR TITLE
rpcserver: Remove wrong ticketbuyer limit comment.

### DIFF
--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -2649,10 +2649,6 @@ func (t *ticketbuyerServer) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr pb
 		}
 	}
 
-	// set limit. If it is not informed by the request it is used 0, which
-	// is defaulted to 20.
-	limit := int(req.Limit)
-
 	tb := ticketbuyer.New(w, ticketbuyer.Config{
 		BuyTickets:         true,
 		Account:            req.Account,
@@ -2665,7 +2661,7 @@ func (t *ticketbuyerServer) RunTicketBuyer(req *pb.RunTicketBuyerRequest, svr pb
 		ChangeAccount:      changeAccount,
 		MixedAccountBranch: mixedAccountBranch,
 		TicketSplitAccount: mixedSplitAccount,
-		Limit:              limit,
+		Limit:              int(req.Limit),
 	})
 
 	if len(req.Passphrase) > 0 {


### PR DESCRIPTION
This value is not defaulted to 20 (as far as I can tell it never has been).