### PR TITLE
Remove unnecessary code from feePayment

### DIFF
--- a/wallet/feepayment.go
+++ b/wallet/feepayment.go
@@ -104,14 +104,10 @@ func (c *VSPClient) feePayment(ctx context.Context, ticket *VSPTicket, paidConfi
 	}
 
 	defer func() {
-		if fp == nil {
-			return
-		}
 		var schedule bool
 		c.mu.Lock()
 		fp2 := c.jobs[*ticketHash]
 		if fp2 != nil {
-			fp.stop()
 			fp = fp2
 		} else {
 			c.jobs[*ticketHash] = fp


### PR DESCRIPTION
The fp variable is never nil by the time the defer runs so the nil check can be removed.

If this method is called concurrently with the same ticket hash, the newly created fp variable is never scheduled, so it doesn't need to be stopped.