### PR TITLE
Remove pruned unmined tickets from vsp client and DB.

### DIFF
--- a/wallet/udb/vsp.go
+++ b/wallet/udb/vsp.go
@@ -87,6 +87,12 @@ func SetVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash *chainhash.Hash, record 
 	return bucket.Put(ticketHash[:], serializedRecord)
 }
 
+// DeleteVSPTicket removes the specified ticket from the DB. Does not return an
+// error if the ticket does not exist.
+func DeleteVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash chainhash.Hash) error {
+	return dbtx.ReadWriteBucket(vspBucketKey).Delete(ticketHash[:])
+}
+
 // GetVSPTicket gets a specific ticket by its hash. Returns errors.NotExist if
 // the the ticket does not exists.
 func GetVSPTicket(dbtx walletdb.ReadTx, tickethash chainhash.Hash) (*VSPTicket, error) {

--- a/wallet/udb/vsp.go
+++ b/wallet/udb/vsp.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 The Decred developers
+// Copyright (c) 2020-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -87,7 +87,8 @@ func SetVSPTicket(dbtx walletdb.ReadWriteTx, ticketHash *chainhash.Hash, record 
 	return bucket.Put(ticketHash[:], serializedRecord)
 }
 
-// GetVSPTicket gets a specific ticket by its hash.
+// GetVSPTicket gets a specific ticket by its hash. Returns errors.NotExist if
+// the the ticket does not exists.
 func GetVSPTicket(dbtx walletdb.ReadTx, tickethash chainhash.Hash) (*VSPTicket, error) {
 	bucket := dbtx.ReadBucket(vspBucketKey)
 	serializedTicket := bucket.Get(tickethash[:])

--- a/wallet/udb/vsp_test.go
+++ b/wallet/udb/vsp_test.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"testing"
 
+	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/wallet/walletdb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 )
@@ -192,6 +193,15 @@ func TestSetGetVSPTicket(t *testing.T) {
 		VSPHostID:   321,
 		Host:        "example.com",
 		PubKey:      []byte("not-a-real-key"),
+	}
+
+	// Non-existent tickets should return an error.
+	err = walletdb.View(ctx, db, func(dbtx walletdb.ReadTx) error {
+		_, err = GetVSPTicket(dbtx, *ticketHash)
+		return err
+	})
+	if !errors.Is(err, errors.NotExist) {
+		t.Fatalf("Expected NotExist error, got: %v", err)
 	}
 
 	// Insert into DB.

--- a/wallet/vsp.go
+++ b/wallet/vsp.go
@@ -93,6 +93,18 @@ func (w *Wallet) NewVSPClient(cfg VSPClientConfig, log slog.Logger, dialer DialF
 	return v, nil
 }
 
+// RemoveTicket removes the ticket from the VSPClient and cancels any jobs
+// scheduled for that ticket.
+func (c *VSPClient) RemoveTicket(ticketHash chainhash.Hash, reason string) {
+	c.mu.Lock()
+	fp := c.jobs[ticketHash]
+	c.mu.Unlock()
+
+	if fp != nil {
+		fp.remove(reason)
+	}
+}
+
 func (c *VSPClient) FeePercentage(ctx context.Context) (float64, error) {
 	resp, err := c.Client.VspInfo(ctx)
 	if err != nil {

--- a/wallet/vspticket.go
+++ b/wallet/vspticket.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023-2024 The Decred developers
+// Copyright (c) 2023-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sync"
 
-	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/wallet/udb"
 	"decred.org/dcrwallet/v5/wallet/walletdb"
 	"github.com/decred/dcrd/blockchain/stake/v5"
@@ -325,12 +324,10 @@ func (v *VSPTicket) VSPTicketInfo(ctx context.Context) (*TicketInfo, error) {
 		}
 		return nil
 	})
-	if err == nil && data == nil {
-		err = errors.E(errors.NotExist)
-		return nil, err
-	} else if data == nil {
+	if err != nil {
 		return nil, err
 	}
+
 	convertedData := &TicketInfo{
 		FeeHash:     data.FeeHash,
 		FeeTxStatus: data.FeeTxStatus,


### PR DESCRIPTION
~If a ticket becomes unmined because of a fork it should be removed from any VSP clients the wallet has configured.~

**See comment below for corrected description**
