### PR TITLE
Ignore repeat blockconnected notifications

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -847,6 +847,12 @@ func (s *Syncer) blockConnected(ctx context.Context, params json.RawMessage) err
 }
 
 func (s *Syncer) handleBlockConnected(ctx context.Context, header *wire.BlockHeader, relevantTxs []*wire.MsgTx, isProcessingMissingBlock bool) error {
+	blockHash := header.BlockHash()
+	haveBlock, _, _ := s.wallet.BlockInMainChain(ctx, &blockHash)
+	if haveBlock {
+		return nil
+	}
+
 	// Ensure the ancestor is known to be in the main or in a side chain.
 	// If it is not, this means we missed some blocks and should perform a
 	// new round of initial header sync.
@@ -866,7 +872,6 @@ func (s *Syncer) handleBlockConnected(ctx context.Context, header *wire.BlockHea
 		return s.getMissingHeaders(ctx)
 	}
 
-	blockHash := header.BlockHash()
 	filter, proofIndex, proof, err := s.rpc.CFilterV2(ctx, &blockHash)
 	if err != nil {
 		return err


### PR DESCRIPTION
dcrd was observed to send blockconnected notifications for the same block multiple times, apparently during a series of reorgs.  If we already have the notified block, return out from the blockconnected notification handler without also recording the block as a sidechain.  This prevents later on performing a reorg that replaces the tip block with an identical block recorded with the sidechains.

Updates #1740.