### PR TITLE
Fix reorg transaction loss

### DIFF
--- a/spv/backend.go
+++ b/spv/backend.go
@@ -304,7 +304,7 @@ nextbatch:
 			} else {
 				hash = &headers[i+1].PrevBlock
 			}
-			nodes[i] = wallet.NewBlockNode(headers[i], hash, nil)
+			nodes[i] = wallet.NewBlockNode(headers[i], hash, nil, nil)
 			if wallet.BadCheckpoint(cnet, hash, int32(headers[i].Height)) {
 				nodes[i].BadCheckpoint()
 			}

--- a/wallet/checkpoints.go
+++ b/wallet/checkpoints.go
@@ -59,7 +59,7 @@ func (w *Wallet) rollbackInvalidCheckpoints(dbtx walletdb.ReadWriteTx) error {
 		}
 		ckpt := CheckpointHash(w.chainParams.Net, height)
 		if h != *ckpt {
-			err := w.txStore.Rollback(dbtx, height)
+			_, err := w.txStore.Rollback(dbtx, height)
 			if err != nil {
 				return err
 			}

--- a/wallet/reorg_test.go
+++ b/wallet/reorg_test.go
@@ -112,7 +112,7 @@ func (tw *tw) assertNoBetterChain(ctx context.Context, forest *SidechainForest) 
 }
 
 func (tw *tw) chainSwitch(ctx context.Context, forest *SidechainForest, chain []*BlockNode) {
-	prevChain, err := tw.ChainSwitch(ctx, forest, chain, nil)
+	prevChain, err := tw.ChainSwitch(ctx, forest, chain)
 	if err != nil {
 		tw.Fatal(err)
 	}

--- a/wallet/sidechains.go
+++ b/wallet/sidechains.go
@@ -29,15 +29,15 @@ type SidechainForest struct {
 }
 
 // BlockNode represents a block node for a SidechainForest.  BlockNodes are not
-// safe for concurrent access, and all exported fields must be treated as
-// immutable.
+// safe for concurrent access.
 type BlockNode struct {
-	Header   *wire.BlockHeader
-	Hash     *chainhash.Hash
-	FilterV2 *gcs.FilterV2
-	parent   *BlockNode
-	workSum  *big.Int
-	invalid  bool
+	Header      *wire.BlockHeader
+	Hash        *chainhash.Hash
+	FilterV2    *gcs.FilterV2
+	RelevantTxs []*wire.MsgTx
+	parent      *BlockNode
+	workSum     *big.Int
+	invalid     bool
 }
 
 // sidechainRootedTree represents a rooted tree of blocks not currently in the
@@ -63,11 +63,14 @@ func newSideChainRootedTree(root *BlockNode) *sidechainRootedTree {
 }
 
 // NewBlockNode creates a block node for usage with a SidechainForest.
-func NewBlockNode(header *wire.BlockHeader, hash *chainhash.Hash, filter *gcs.FilterV2) *BlockNode {
+func NewBlockNode(header *wire.BlockHeader, hash *chainhash.Hash, filter *gcs.FilterV2,
+	relevantTxs []*wire.MsgTx) *BlockNode {
+
 	return &BlockNode{
-		Header:   header,
-		Hash:     hash,
-		FilterV2: filter,
+		Header:      header,
+		Hash:        hash,
+		FilterV2:    filter,
+		RelevantTxs: relevantTxs,
 	}
 }
 

--- a/wallet/udb/tx_test.go
+++ b/wallet/udb/tx_test.go
@@ -174,7 +174,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 		{
 			name: "rollback confirmed credit",
 			f: func(s *Store, dbtx walletdb.ReadWriteTx) (*Store, error) {
-				err := s.Rollback(dbtx, int32(b1H.Height))
+				_, err := s.Rollback(dbtx, int32(b1H.Height))
 				return s, err
 			},
 			bal: 0,
@@ -231,7 +231,7 @@ func TestInsertsCreditsDebitsRollbacks(t *testing.T) {
 		{
 			name: "rollback after spending tx",
 			f: func(s *Store, dbtx walletdb.ReadWriteTx) (*Store, error) {
-				err := s.Rollback(dbtx, int32(b2H.Height))
+				_, err := s.Rollback(dbtx, int32(b2H.Height))
 				return s, err
 			},
 			bal:      0,
@@ -531,7 +531,7 @@ func TestCoinbases(t *testing.T) {
 		// Reorg out the block that matured the coinbase and spends part of the
 		// coinbase. The immature coinbase should be deducted by the amount
 		// being spent by the tx.
-		err = s.Rollback(dbtx, int32(b17H.Height))
+		_, err = s.Rollback(dbtx, int32(b17H.Height))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -551,7 +551,7 @@ func TestCoinbases(t *testing.T) {
 		// Reorg out the block that contained the coinbase. Since the block
 		// with the coinbase is no longer part of the chain there should not be
 		// any mature or immature amounts reported.
-		err = s.Rollback(dbtx, int32(b1H.Height))
+		_, err = s.Rollback(dbtx, int32(b1H.Height))
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
There is a longstanding bug that causes the wallet to lose transactions if they appear in a mined block, that block is reorged out, and a later reorg reinstates the original block back in the best main chain.  This occurs due to how relevant transactions are passed around during reorgs.  Each syncer is responsible for providing the relevant transactions during the call to ChainSwitch, but the syncers are not aware of the transactions that are rolled back from previous reorgs.

Rather than passing in relevant transactions from the syncer, record these transactions in each block node in the sidechain forest.  During a reorg, save the removed transactions along with each block node when saving the sidechains.

Requires #2526.
Fixes #1740.