### PR TITLE
Prevent deadlock removing pruned VSP tickets from DB

### DIFF
--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -256,13 +256,7 @@ func (w *Wallet) ChainSwitch(ctx context.Context, forest *SidechainForest, chain
 			}
 
 			// Remove pruned tickets from database.
-			_, err = udb.GetVSPTicket(dbtx, *hash)
-			switch {
-			case errors.Is(err, errors.NotExist):
-				err = nil
-			case err == nil:
-				err = udb.DeleteVSPTicket(dbtx, *hash)
-			}
+			err := udb.DeleteVSPTicket(dbtx, *hash)
 			if err != nil {
 				log.Errorf("Failed to remove pruned ticket from db: %v", err)
 			}


### PR DESCRIPTION
A database update transaction is already opened here, and attempting to open another one will deadlock the wallet while processing new blocks.

While here, also simplify the removal logic to skip an unnecessary read and serialization of the DB's VSP ticket.