### PR TITLE
Initialize RPC services more consistently

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -379,10 +379,12 @@ func run(ctx context.Context) error {
 		return err
 	}
 	if gRPCServer != nil {
-		// Start wallet, voting and network gRPC services after a
-		// wallet is loaded.
+		// Start wallet, voting and network gRPC services after a wallet is
+		// loaded.
 		loader.RunAfterLoad(func(w *wallet.Wallet) {
 			rpcserver.StartWalletService(gRPCServer, w)
+			rpcserver.StartTicketBuyerService(gRPCServer, w)
+			rpcserver.StartAccountMixerService(gRPCServer, w)
 			rpcserver.StartNetworkService(gRPCServer, w)
 			rpcserver.StartVotingService(gRPCServer, w)
 		})

--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -382,11 +382,11 @@ func run(ctx context.Context) error {
 		// Start wallet, voting and network gRPC services after a wallet is
 		// loaded.
 		loader.RunAfterLoad(func(w *wallet.Wallet) {
-			rpcserver.StartWalletService(gRPCServer, w)
-			rpcserver.StartTicketBuyerService(gRPCServer, w)
-			rpcserver.StartAccountMixerService(gRPCServer, w)
-			rpcserver.StartNetworkService(gRPCServer, w)
-			rpcserver.StartVotingService(gRPCServer, w)
+			rpcserver.StartWalletService(w)
+			rpcserver.StartTicketBuyerService(w)
+			rpcserver.StartAccountMixerService(w)
+			rpcserver.StartNetworkService(w)
+			rpcserver.StartVotingService(w)
 		})
 		defer func() {
 			log.Warn("Stopping gRPC server...")

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -166,6 +166,8 @@ type versionServer struct {
 
 // walletServer provides wallet services for RPC clients.
 type walletServer struct {
+	// ready indicates this service has been provided with all of its
+	// dependencies and is ready to service requests.
 	ready  atomic.Bool
 	wallet *wallet.Wallet
 	pb.UnimplementedWalletServiceServer
@@ -174,7 +176,6 @@ type walletServer struct {
 // loaderServer provides RPC clients with the ability to load and close wallets,
 // as well as establishing a RPC connection to a dcrd consensus server.
 type loaderServer struct {
-	ready     atomic.Bool
 	loader    *loader.Loader
 	activeNet *netparams.Params
 	pb.UnimplementedWalletLoaderServiceServer
@@ -190,6 +191,8 @@ type seedServer struct {
 // accountMixerServer provides RPC clients with the ability to start/stop the
 // account mixing privacy service.
 type accountMixerServer struct {
+	// ready indicates this service has been provided with all of its
+	// dependencies and is ready to service requests.
 	ready  atomic.Bool
 	wallet *wallet.Wallet
 	pb.UnimplementedAccountMixerServiceServer
@@ -198,18 +201,21 @@ type accountMixerServer struct {
 // ticketbuyerServer provides RPC clients with the ability to start/stop the
 // automatic ticket buyer service.
 type ticketbuyerServer struct {
+	// ready indicates this service has been provided with all of its
+	// dependencies and is ready to service requests.
 	ready  atomic.Bool
 	wallet *wallet.Wallet
 	pb.UnimplementedTicketBuyerServiceServer
 }
 
 type agendaServer struct {
-	ready     atomic.Bool
 	activeNet *chaincfg.Params
 	pb.UnimplementedAgendaServiceServer
 }
 
 type votingServer struct {
+	// ready indicates this service has been provided with all of its
+	// dependencies and is ready to service requests.
 	ready  atomic.Bool
 	wallet *wallet.Wallet
 	pb.UnimplementedVotingServiceServer
@@ -230,6 +236,8 @@ type decodeMessageServer struct {
 // networkServer provices RPC clients with the ability to perform network
 // related calls that are not necessarily used or backed by the wallet itself.
 type networkServer struct {
+	// ready indicates this service has been provided with all of its
+	// dependencies and is ready to service requests.
 	ready  atomic.Bool
 	wallet *wallet.Wallet
 	pb.UnimplementedNetworkServiceServer
@@ -2498,13 +2506,6 @@ func (s *walletServer) ConfirmationNotifications(svr pb.WalletService_Confirmati
 func StartWalletLoaderService(server *grpc.Server, loader *loader.Loader, activeNet *netparams.Params) {
 	loaderService.loader = loader
 	loaderService.activeNet = activeNet
-	if loaderService.ready.Swap(true) {
-		panic("service already started")
-	}
-}
-
-func (s *loaderServer) checkReady() bool {
-	return s.ready.Load()
 }
 
 // StartAccountMixerService starts the AccountMixerService.
@@ -3173,13 +3174,6 @@ func (s *seedServer) DecodeSeed(ctx context.Context, req *pb.DecodeSeedRequest) 
 
 func StartAgendaService(server *grpc.Server, activeNet *chaincfg.Params) {
 	agendaService.activeNet = activeNet
-	if agendaService.ready.Swap(true) {
-		panic("service already started")
-	}
-}
-
-func (s *agendaServer) checkReady() bool {
-	return s.ready.Load()
 }
 
 func (s *agendaServer) Agendas(ctx context.Context, req *pb.AgendasRequest) (*pb.AgendasResponse, error) {

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -146,17 +146,6 @@ func decodeAddress(a string, params *chaincfg.Params) (stdaddr.Address, error) {
 	return addr, nil
 }
 
-func decodeStakeAddress(s string, params *chaincfg.Params) (stdaddr.StakeAddress, error) {
-	a, err := decodeAddress(s, params)
-	if err != nil {
-		return nil, err
-	}
-	if sa, ok := a.(stdaddr.StakeAddress); ok {
-		return sa, nil
-	}
-	return nil, status.Errorf(codes.InvalidArgument, "invalid stake address %q", s)
-}
-
 func decodeHashes(in [][]byte) ([]*chainhash.Hash, error) {
 	out := make([]*chainhash.Hash, len(in))
 	var err error

--- a/internal/rpc/rpcserver/server.go
+++ b/internal/rpc/rpcserver/server.go
@@ -319,7 +319,7 @@ func (*versionServer) Version(ctx context.Context, req *pb.VersionRequest) (*pb.
 }
 
 // StartWalletService starts the WalletService.
-func StartWalletService(server *grpc.Server, wallet *wallet.Wallet) {
+func StartWalletService(wallet *wallet.Wallet) {
 	if walletService.ready.Swap(true) {
 		panic("service already started")
 	}
@@ -2503,13 +2503,13 @@ func (s *walletServer) ConfirmationNotifications(svr pb.WalletService_Confirmati
 }
 
 // StartWalletLoaderService starts the WalletLoaderService.
-func StartWalletLoaderService(server *grpc.Server, loader *loader.Loader, activeNet *netparams.Params) {
+func StartWalletLoaderService(loader *loader.Loader, activeNet *netparams.Params) {
 	loaderService.loader = loader
 	loaderService.activeNet = activeNet
 }
 
 // StartAccountMixerService starts the AccountMixerService.
-func StartAccountMixerService(server *grpc.Server, wallet *wallet.Wallet) {
+func StartAccountMixerService(wallet *wallet.Wallet) {
 	accountMixerService.wallet = wallet
 	if accountMixerService.ready.Swap(true) {
 		panic("service already started")
@@ -2559,7 +2559,7 @@ func (t *accountMixerServer) checkReady() bool {
 }
 
 // StartTicketBuyerService starts the TicketBuyerService.
-func StartTicketBuyerService(server *grpc.Server, wallet *wallet.Wallet) {
+func StartTicketBuyerService(wallet *wallet.Wallet) {
 	ticketBuyerService.wallet = wallet
 	if ticketBuyerService.ready.Swap(true) {
 		panic("service already started")
@@ -3172,7 +3172,7 @@ func (s *seedServer) DecodeSeed(ctx context.Context, req *pb.DecodeSeedRequest) 
 	return &pb.DecodeSeedResponse{DecodedSeed: seed}, nil
 }
 
-func StartAgendaService(server *grpc.Server, activeNet *chaincfg.Params) {
+func StartAgendaService(activeNet *chaincfg.Params) {
 	agendaService.activeNet = activeNet
 }
 
@@ -3207,7 +3207,7 @@ func (s *agendaServer) Agendas(ctx context.Context, req *pb.AgendasRequest) (*pb
 }
 
 // StartVotingService starts the VotingService.
-func StartVotingService(server *grpc.Server, wallet *wallet.Wallet) {
+func StartVotingService(wallet *wallet.Wallet) {
 	votingService.wallet = wallet
 	if votingService.ready.Swap(true) {
 		panic("service already started")
@@ -3477,7 +3477,7 @@ func (s *votingServer) SetTreasuryPolicy(ctx context.Context, req *pb.SetTreasur
 }
 
 // StartMessageVerificationService starts the MessageVerification service
-func StartMessageVerificationService(server *grpc.Server, chainParams *chaincfg.Params) {
+func StartMessageVerificationService(chainParams *chaincfg.Params) {
 	messageVerificationService.chainParams = chainParams
 }
 
@@ -3508,7 +3508,7 @@ func (s *messageVerificationServer) VerifyMessage(ctx context.Context, req *pb.V
 }
 
 // StartDecodeMessageService starts the MessageDecode service
-func StartDecodeMessageService(server *grpc.Server, chainParams *chaincfg.Params) {
+func StartDecodeMessageService(chainParams *chaincfg.Params) {
 	decodeMessageService.chainParams = chainParams
 }
 
@@ -3747,7 +3747,7 @@ func (s *walletServer) AbandonTransaction(ctx context.Context, req *pb.AbandonTr
 }
 
 // StartNetworkService starts the NetworkService.
-func StartNetworkService(server *grpc.Server, wallet *wallet.Wallet) {
+func StartNetworkService(wallet *wallet.Wallet) {
 	networkService.wallet = wallet
 	if networkService.ready.Swap(true) {
 		panic("service already started")

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -332,8 +332,6 @@ func startRPCServers(ctx context.Context, walletLoader *loader.Loader) (*grpc.Se
 			)
 			rpcserver.RegisterServices(server)
 			rpcserver.StartWalletLoaderService(server, walletLoader, activeNet)
-			rpcserver.StartTicketBuyerService(server, walletLoader)
-			rpcserver.StartAccountMixerService(server, walletLoader)
 			rpcserver.StartAgendaService(server, activeNet.Params)
 			rpcserver.StartDecodeMessageService(server, activeNet.Params)
 			rpcserver.StartMessageVerificationService(server, activeNet.Params)

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -331,10 +331,10 @@ func startRPCServers(ctx context.Context, walletLoader *loader.Loader) (*grpc.Se
 				grpc.UnaryInterceptor(interceptUnary),
 			)
 			rpcserver.RegisterServices(server)
-			rpcserver.StartWalletLoaderService(server, walletLoader, activeNet)
-			rpcserver.StartAgendaService(server, activeNet.Params)
-			rpcserver.StartDecodeMessageService(server, activeNet.Params)
-			rpcserver.StartMessageVerificationService(server, activeNet.Params)
+			rpcserver.StartWalletLoaderService(walletLoader, activeNet)
+			rpcserver.StartAgendaService(activeNet.Params)
+			rpcserver.StartDecodeMessageService(activeNet.Params)
+			rpcserver.StartMessageVerificationService(activeNet.Params)
 			for _, lis := range listeners {
 				go func() {
 					laddr := lis.Addr().String()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2025 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -338,7 +338,6 @@ func startRPCServers(ctx context.Context, walletLoader *loader.Loader) (*grpc.Se
 			rpcserver.StartDecodeMessageService(server, activeNet.Params)
 			rpcserver.StartMessageVerificationService(server, activeNet.Params)
 			for _, lis := range listeners {
-				lis := lis
 				go func() {
 					laddr := lis.Addr().String()
 					grpcAddrNotifier.notify(laddr)


### PR DESCRIPTION
After discussions in #2518 I took a closer look at how RPC services are initialized. This is a first step towards improving consistency between services.

<del>The races described in #2518 are not addressed by this PR.</del>
The races described in #2518 are addressed by the last commit in this PR.