### PR TITLE
Remove unneeded accountName param from nextAddress

### DIFF
--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -807,9 +807,8 @@ func (w *Wallet) compressWalletInternal(ctx context.Context, op errors.Op, dbtx 
 
 	// Check if output address is default, and generate a new address if needed
 	if changeAddr == nil {
-		const accountName = "" // not used, so can be faked.
 		changeAddr, err = w.newChangeAddress(ctx, op, nil, dbtx,
-			accountName, account, gapPolicyIgnore)
+			account, gapPolicyIgnore)
 		if err != nil {
 			return nil, errors.E(op, err)
 		}
@@ -1175,8 +1174,7 @@ func (w *Wallet) purchaseTickets(ctx context.Context, op errors.Op,
 	}
 
 	stakeAddrFunc := func(op errors.Op, account, branch uint32) (stdaddr.StakeAddress, uint32, error) {
-		const accountName = "" // not used, so can be faked.
-		a, err := w.nextAddress(ctx, op, nil, nil, accountName,
+		a, err := w.nextAddress(ctx, op, nil, nil,
 			account, branch, WithGapPolicyIgnore())
 		if err != nil {
 			return nil, 0, err

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -56,9 +56,8 @@ func (w *Wallet) makeGen(ctx context.Context, account, branch uint32) mixclient.
 		updates := make(accountBranchChildUpdates, 0, mcount)
 
 		for i := range mcount {
-			const accountName = "" // not used, so can be faked.
 			mixAddr, err := w.nextAddress(ctx, op, &updates, nil,
-				accountName, account, branch, WithGapPolicyIgnore())
+				account, branch, WithGapPolicyIgnore())
 			if err != nil {
 				return nil, err
 			}
@@ -392,9 +391,8 @@ SplitPoints:
 	var change *wire.TxOut
 	if changeValue > 0 {
 		updates := make(accountBranchChildUpdates, 0, 1)
-		const accountName = "" // not used, so can be faked.
 		addr, err := w.nextAddress(ctx, op, &updates, nil,
-			accountName, changeAccount, udb.InternalBranch, WithGapPolicyIgnore())
+			changeAccount, udb.InternalBranch, WithGapPolicyIgnore())
 		if err != nil {
 			return errors.E(op, err)
 		}


### PR DESCRIPTION
To ensure nextAddress is returning valid and helpful information, retrieve the real account name from the database rather than just blindly returning whatever account name was passed as a param (this was often a fake/placeholder value anyway).