### PR TITLE
wallet: Add multi-UTXO batch mixing to increase throughput

### DIFF
--- a/dcrwallet.go
+++ b/dcrwallet.go
@@ -170,7 +170,7 @@ func run(ctx context.Context) error {
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
 		cfg.DisableCoinTypeUpgrades, cfg.MixingEnabled, cfg.ManualTickets,
-		cfg.MixSplitLimit, cfg.dial)
+		cfg.MixSplitLimit, cfg.MixChangeLimit, cfg.dial)
 
 	// Stop any services started by the loader after the shutdown procedure is
 	// initialized and this function returns.

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -48,6 +48,7 @@ type Loader struct {
 	relayFee                dcrutil.Amount
 	vspMaxFee               dcrutil.Amount
 	mixSplitLimit           int
+	mixChangeLimit          int
 	dialer                  wallet.DialFunc
 
 	mu sync.Mutex
@@ -56,7 +57,7 @@ type Loader struct {
 // NewLoader constructs a Loader.
 func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled bool, gapLimit uint32,
 	watchLast uint32, allowHighFees bool, relayFee dcrutil.Amount, vspMaxFee dcrutil.Amount, accountGapLimit int,
-	disableCoinTypeUpgrades bool, mixingEnabled bool, manualTickets bool, mixSplitLimit int, dialer wallet.DialFunc) *Loader {
+	disableCoinTypeUpgrades bool, mixingEnabled bool, manualTickets bool, mixSplitLimit int, mixChangeLimit int, dialer wallet.DialFunc) *Loader {
 
 	return &Loader{
 		chainParams:             chainParams,
@@ -72,6 +73,7 @@ func NewLoader(chainParams *chaincfg.Params, dbDirPath string, votingEnabled boo
 		relayFee:                relayFee,
 		vspMaxFee:               vspMaxFee,
 		mixSplitLimit:           mixSplitLimit,
+		mixChangeLimit:          mixChangeLimit,
 		dialer:                  dialer,
 	}
 }
@@ -180,6 +182,7 @@ func (l *Loader) CreateWatchingOnlyWallet(ctx context.Context, extendedPubKey st
 		RelayFee:                l.relayFee,
 		VSPMaxFee:               l.vspMaxFee,
 		MixSplitLimit:           l.mixSplitLimit,
+		MixChangeLimit:          l.mixChangeLimit,
 		Params:                  l.chainParams,
 		Dialer:                  l.dialer,
 	}
@@ -329,6 +332,7 @@ func (l *Loader) OpenExistingWallet(ctx context.Context, pubPassphrase []byte) (
 		RelayFee:                l.relayFee,
 		VSPMaxFee:               l.vspMaxFee,
 		MixSplitLimit:           l.mixSplitLimit,
+		MixChangeLimit:          l.mixChangeLimit,
 		Params:                  l.chainParams,
 		Dialer:                  l.dialer,
 	}

--- a/sample-dcrwallet.conf
+++ b/sample-dcrwallet.conf
@@ -101,6 +101,10 @@
 ; Use CoinShuffle++ to mix change account outputs into mix account.
 ; mixchange=0
 
+; Maximum number of change UTXOs to mix in a single CoinShuffle++ session.
+; Higher values improve throughput but may impact privacy. Range: 1-10.
+; mixchangelimit=1
+
 
 ; ------------------------------------------------------------------------------
 ; RPC server settings

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -155,10 +155,11 @@ type Wallet struct {
 	passphraseTimeoutCancel chan struct{}
 
 	// Mixing
-	mixingEnabled bool
-	mixpool       *mixpool.Pool
-	mixSems       mixSemaphores
-	mixClient     *mixclient.Client
+	mixingEnabled  bool
+	mixpool        *mixpool.Pool
+	mixSems        mixSemaphores
+	mixChangeLimit int
+	mixClient      *mixclient.Client
 
 	// Cached Blake3 anchor candidate
 	cachedBlake3WorkDiffCandidateAnchor   *wire.BlockHeader
@@ -190,6 +191,7 @@ type Config struct {
 	WatchLast               uint32
 	AccountGapLimit         int
 	MixSplitLimit           int
+	MixChangeLimit          int
 	DisableCoinTypeUpgrades bool
 	MixingEnabled           bool
 
@@ -5420,8 +5422,9 @@ func Open(ctx context.Context, cfg *Config) (*Wallet, error) {
 
 		addressBuffers: make(map[uint32]*bip0044AccountData),
 
-		mixSems:       newMixSemaphores(cfg.MixSplitLimit),
-		mixingEnabled: cfg.MixingEnabled,
+		mixSems:        newMixSemaphores(cfg.MixSplitLimit),
+		mixChangeLimit: cfg.MixChangeLimit,
+		mixingEnabled:  cfg.MixingEnabled,
 
 		vspMaxFee:  cfg.VSPMaxFee,
 		vspClients: make(map[string]*VSPClient),

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -116,7 +116,7 @@ func createWallet(ctx context.Context, cfg *config) error {
 		cfg.GapLimit, cfg.WatchLast, cfg.AllowHighFees, cfg.RelayFee.Amount,
 		cfg.VSPOpts.MaxFee.Amount, cfg.AccountGapLimit,
 		cfg.DisableCoinTypeUpgrades, cfg.MixingEnabled, cfg.ManualTickets,
-		cfg.MixSplitLimit, cfg.dial)
+		cfg.MixSplitLimit, cfg.MixChangeLimit, cfg.dial)
 
 	var privPass, pubPass, seed []byte
 	var imported bool


### PR DESCRIPTION
This commit addresses the mixing bottleneck where change outputs from staking activities accumulate due to slow processing (only ~72-96 UTXOs/day). The limitation was in the wallet implementation, not the CoinShuffle++ protocol.

 Changes:
  - Add --mixchangelimit config parameter (range 1-10, default 1) to control how many UTXOs of the same denomination can be mixed in a single session
  - Implement groupUTXOsForBatchMixing() to group UTXOs by denomination
  - Add MixMultipleOutputs() to handle multiple UTXOs in one CoinShuffle++ session
  - Modify MixAccount() to use batch mixing when mixchangelimit > 1
  - Add privacy mitigations: timing jitter, session participation limits