### PR TITLE
[release-v2.1] Update mixing module to v0.7.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/decred/dcrd/dcrutil/v4 v4.0.3
 	github.com/decred/dcrd/gcs/v4 v4.1.1
 	github.com/decred/dcrd/hdkeychain/v3 v3.1.3
-	github.com/decred/dcrd/mixing v0.7.1
+	github.com/decred/dcrd/mixing v0.7.2
 	github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0
 	github.com/decred/dcrd/rpcclient/v8 v8.1.0
 	github.com/decred/dcrd/txscript/v4 v4.1.2

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,8 @@ github.com/decred/dcrd/gcs/v4 v4.1.1 h1:3ELoII8uwIxXFGq6ETB29AjW7Lmr3McQOYsSD3dv
 github.com/decred/dcrd/gcs/v4 v4.1.1/go.mod h1:5q1EnYp1CzJw057/XfRB6UGkos24fpu2r2ZLuwE7YdE=
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3 h1:Kn2wfj5cOR6pQO/WrYOMT1KK12IgWFEeQwnk1o81WsU=
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3/go.mod h1:mDAuGaH6InRD+hKVeVJsjLD/ih1mD3aCKURNHS8Tq2s=
-github.com/decred/dcrd/mixing v0.7.1 h1:TJs7R0DtYCUEVWQm215jhM4GZeEUzO+aBnOr81mQRh4=
-github.com/decred/dcrd/mixing v0.7.1/go.mod h1:WE2YmCL3KOySA2Yv+EZpGUnrvIF1g3fiKH3nIsltbf8=
+github.com/decred/dcrd/mixing v0.7.2 h1:lfCjkn9N7KuANNJkBdTJTrkIbzzklsf8yGBQ8trVTpk=
+github.com/decred/dcrd/mixing v0.7.2/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0 h1:BBVaYemabsFsaqNVlCmacoZlSsLDqwHYIs8ty6fg59Q=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0/go.mod h1:w4C6hZ7ywpc8/YNkiPAknCaqKofF68cRhUiTglEIc7s=
 github.com/decred/dcrd/rpcclient/v8 v8.1.0 h1:FLZ1j4ub7+O9oCIcKf+frYCrZW++G3FSzk2/f4U80hI=


### PR DESCRIPTION
Fixes P2SH script detection

Backport of 23d796d0bd617eae660a11924be335d24569d786.