### PR TITLE
Provide SPV peers as mixing message source

### DIFF
--- a/chain/sync.go
+++ b/chain/sync.go
@@ -944,7 +944,7 @@ func (s *Syncer) mixMessage(ctx context.Context, params json.RawMessage) error {
 	msg.WriteHash(s.blake256Hasher)
 	s.blake256HasherMu.Unlock()
 
-	err = s.wallet.AcceptMixMessage(msg)
+	err = s.wallet.AcceptMixMessageBySource(msg, mixpool.ZeroSource)
 	var e *mixpool.MissingOwnPRError
 	if errors.As(err, &e) {
 		ke, ok := msg.(*wire.MsgMixKeyExchange)
@@ -957,7 +957,7 @@ func (s *Syncer) mixMessage(ctx context.Context, params json.RawMessage) error {
 			pr.WriteHash(s.blake256Hasher)
 			s.blake256HasherMu.Unlock()
 
-			err = s.wallet.AcceptMixMessage(pr)
+			err = s.wallet.AcceptMixMessageBySource(pr, mixpool.ZeroSource)
 		}
 		return err
 	}

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1223,7 +1223,7 @@ func (s *Syncer) handleMixInvs(ctx context.Context, rp *p2p.RemotePeer, hashes [
 			}
 		}
 
-		err := s.wallet.AcceptMixMessage(msg)
+		err := s.wallet.AcceptMixMessageBySource(msg, rp)
 		var missingPRErr *mixpool.MissingOwnPRError
 		if errors.As(err, &missingPRErr) {
 			ke := msg.(*wire.MsgMixKeyExchange)

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -553,8 +553,21 @@ func PossibleCoinJoin(tx *wire.MsgTx) (isMix bool, mixDenom int64, mixCount uint
 
 // AcceptMixMessage adds a mixing message received from the network backend to
 // the wallet's mixpool.
+//
+// Deprecated: Use [AcceptMixMessageBySource].
 func (w *Wallet) AcceptMixMessage(msg mixing.Message) error {
 	_, err := w.mixpool.AcceptMessage(msg, mixpool.ZeroSource)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AcceptMixMessageBySource adds a mixing message received from the network
+// backend to the wallet's mixpool.
+func (w *Wallet) AcceptMixMessageBySource(msg mixing.Message, source mixpool.Source) error {
+	_, err := w.mixpool.AcceptMessage(msg, source)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Providing unique sources of mixing messages allows mixpool orphan removal to more accurately target peers who have submitted the most orphans.