### PR TITLE
Increment correct account branch.

### DIFF
--- a/wallet/addresses.go
+++ b/wallet/addresses.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2025 The Decred developers
+// Copyright (c) 2017-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -843,7 +843,7 @@ func (w *Wallet) BIP0044BranchNextIndexes(ctx context.Context, account uint32) (
 // BIP00044 account branch.  The next returned address for the branch will be
 // child+1.
 func (w *Wallet) SyncLastReturnedAddress(ctx context.Context, account, branch, child uint32) error {
-	const op errors.Op = "wallet.ExtendWatchedAddresses"
+	const op errors.Op = "wallet.SyncLastReturnedAddress"
 
 	var (
 		branchXpub *hdkeychain.ExtendedKey
@@ -860,7 +860,7 @@ func (w *Wallet) SyncLastReturnedAddress(ctx context.Context, account, branch, c
 		var alb *addressBuffer
 		switch branch {
 		case udb.ExternalBranch:
-			alb = &acctData.albInternal
+			alb = &acctData.albExternal
 		case udb.InternalBranch:
 			alb = &acctData.albInternal
 		default:


### PR DESCRIPTION
Ensure SyncLastReturnedAddress RPC increments the correct account branch when the caller specifies the external branch.

Also fix the func name used for errors/logging while this area is being touched.