### PR TITLE
refactor: use slices.Backward to simplify the code

### DIFF
--- a/wallet/discovery.go
+++ b/wallet/discovery.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
 
 	"decred.org/dcrwallet/v5/errors"
@@ -671,7 +672,7 @@ Bsearch:
 		if err != nil {
 			return 0, err
 		}
-		for i := len(addrs) - 1; i >= 0; i-- {
+		for i, v := range slices.Backward(addrs) {
 			if existsBits.Get(i) {
 				lastUsed = mid*scanLen + uint32(i)
 				lo = mid + 1

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -2569,7 +2569,7 @@ func (w *Wallet) ListTransactions(ctx context.Context, from, count int) ([]types
 			// This does nothing for unmined transactions, which are
 			// unsorted, but it will process mined transactions in the
 			// reverse order they were marked mined.
-			for i := len(details) - 1; i >= 0; i-- {
+			for _, v := range slices.Backward(details) {
 				if n >= count {
 					return true, nil
 				}
@@ -2579,7 +2579,7 @@ func (w *Wallet) ListTransactions(ctx context.Context, from, count int) ([]types
 					continue
 				}
 
-				sends, receives := listTransactions(dbtx, &details[i],
+				sends, receives := listTransactions(dbtx, &v,
 					w.manager, tipHeight, w.chainParams)
 				txList = append(txList, sends...)
 				txList = append(txList, receives...)
@@ -2669,8 +2669,8 @@ func (w *Wallet) ListAllTransactions(ctx context.Context) ([]types.ListTransacti
 			// which are unsorted, but it will process mined
 			// transactions in the reverse order they were marked
 			// mined.
-			for i := len(details) - 1; i >= 0; i-- {
-				sends, receives := listTransactions(dbtx, &details[i],
+			for _, v := range slices.Backward(details) {
+				sends, receives := listTransactions(dbtx, &v,
 					w.manager, tipHeight, w.chainParams)
 				txList = append(txList, sends...)
 				txList = append(txList, receives...)


### PR DESCRIPTION

There is a [new function](https://pkg.go.dev/slices@go1.23.0#Backward)  added in the go1.23 standard library, which can make the code more concise and easy to read.

More info can see  https://github.com/golang/go/issues/61899