### PR TITLE
Provide mixclient jitter as param.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,8 @@ require (
 	google.golang.org/protobuf v1.36.10
 )
 
+replace github.com/decred/dcrd/mixing => ../dcrd/mixing
+
 require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/companyzero/sntrup4591761 v0.0.0-20220309191932-9e0f3af2f07a // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,8 +50,6 @@ github.com/decred/dcrd/gcs/v4 v4.1.1 h1:3ELoII8uwIxXFGq6ETB29AjW7Lmr3McQOYsSD3dv
 github.com/decred/dcrd/gcs/v4 v4.1.1/go.mod h1:5q1EnYp1CzJw057/XfRB6UGkos24fpu2r2ZLuwE7YdE=
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3 h1:Kn2wfj5cOR6pQO/WrYOMT1KK12IgWFEeQwnk1o81WsU=
 github.com/decred/dcrd/hdkeychain/v3 v3.1.3/go.mod h1:mDAuGaH6InRD+hKVeVJsjLD/ih1mD3aCKURNHS8Tq2s=
-github.com/decred/dcrd/mixing v0.7.3 h1:zrMPKvR3GP2stDiqT9tiv0e8GGnFpgl1EClNRew7FFk=
-github.com/decred/dcrd/mixing v0.7.3/go.mod h1:riSgG1GpWXl8LVuBvo8WXuFgcBj01ZGpTAxT/4PrtU0=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0 h1:BBVaYemabsFsaqNVlCmacoZlSsLDqwHYIs8ty6fg59Q=
 github.com/decred/dcrd/rpc/jsonrpc/types/v4 v4.4.0/go.mod h1:w4C6hZ7ywpc8/YNkiPAknCaqKofF68cRhUiTglEIc7s=
 github.com/decred/dcrd/rpcclient/v8 v8.1.0 h1:FLZ1j4ub7+O9oCIcKf+frYCrZW++G3FSzk2/f4U80hI=

--- a/wallet/mixing.go
+++ b/wallet/mixing.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2025 The Decred developers
+// Copyright (c) 2019-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,6 +7,7 @@ package wallet
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/wallet/txrules"
@@ -15,6 +16,7 @@ import (
 	"decred.org/dcrwallet/v5/wallet/walletdb"
 	"github.com/decred/dcrd/chaincfg/chainhash"
 	"github.com/decred/dcrd/chaincfg/v3"
+	"github.com/decred/dcrd/crypto/rand"
 	"github.com/decred/dcrd/dcrec"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrutil/v4"
@@ -588,5 +590,11 @@ func (w *Wallet) dicemix(ctx context.Context, cj *mixclient.CoinJoin) error {
 	if mixc == nil {
 		return errors.E(errors.Invalid, "mixing client is not running")
 	}
-	return mixc.Dicemix(ctx, cj)
+
+	timeoutDuration := 30 * time.Second
+	maxJitter := timeoutDuration / 10
+	msgJitter := 300 * time.Millisecond
+	peerJitter := rand.Duration(maxJitter - msgJitter)
+
+	return mixc.Dicemix(ctx, cj, peerJitter)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -5536,7 +5536,8 @@ func (w *Wallet) MixingEnabled() bool {
 }
 
 func newMixClient(w *Wallet) *mixclient.Client {
-	c := mixclient.NewClient((*mixingWallet)(w))
+	msgJitter := 300 * time.Millisecond
+	c := mixclient.NewClient((*mixingWallet)(w), msgJitter)
 	c.SetLogger(loggers.MixcLog)
 	return c
 }


### PR DESCRIPTION
Recent changes to mixclient removed hard-coded jitter durations and they now need to be provided by the consumer.

## Note

This is a proof-of-concept just for feedback, and should be considered along with decred/dcrd#3732. This includes a go.mod replace which should not be included in the final PR.