### PR TITLE
 Validate tx signature before adding to wallet.

### DIFF
--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1157,7 +1157,19 @@ func (s *Syncer) handleTxInvs(ctx context.Context, rp *p2p.RemotePeer, hashes []
 		err := s.wallet.AddTransaction(ctx, tx, nil)
 		if err != nil {
 			op := errors.Opf(opf, rp.RemoteAddr())
-			log.Warn(errors.E(op, err))
+			err := errors.E(op, err)
+			log.Warn(err)
+
+			// Disconnect the peer if the transaction contains an invalid
+			// attempt to spend a UTXO owned by this wallet. This only applies
+			// to full node peers because they should validate the transaction
+			// before relaying it. SPV peers are not able to validate
+			// transactions before relaying them.
+			if errors.Is(err, errors.ScriptFailure) &&
+				rp.Services()&wire.SFNodeNetwork == wire.SFNodeNetwork {
+				rp.Disconnect(err)
+				return
+			}
 		}
 	}
 	s.mempoolTxs(relevant)

--- a/wallet/chainntfns.go
+++ b/wallet/chainntfns.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2015 The btcsuite developers
-// Copyright (c) 2015-2025 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -376,6 +376,48 @@ func (w *Wallet) AddTransaction(ctx context.Context, tx *wire.MsgTx, blockHash *
 			*meta, err = w.txStore.GetBlockMetaForHash(txmgrNs, blockHash)
 			if err != nil {
 				return err
+			}
+		}
+
+		// If the transaction is unmined, inputs which reference UTXOs owned by
+		// this wallet require extra scrutiny before the transaction is
+		// accepted. This is necessary because a malicious SPV peer could relay
+		// a forged transaction which falsely claims to spend a UTXO from this
+		// wallet.
+		// Mined transactions do not need these extra checks because they have
+		// already been validated by consensus.
+		if header == nil {
+			for i, in := range rec.MsgTx.TxIn {
+				prevOut := &in.PreviousOutPoint
+				credit, err := w.txStore.UnspentOutput(txmgrNs, *prevOut, true)
+				if errors.Is(err, errors.NotExist) {
+					// Not a UTXO belonging to this wallet, skip.
+					continue
+				}
+				if err != nil {
+					return errors.E(op, err)
+				}
+
+				// UTXOs are keyed in the DB without their transaction tree, so
+				// an explicit check is needed to validate tree.
+				if credit.OutPoint != *prevOut {
+					return errors.E(op, errors.ScriptFailure, errors.Errorf(
+						"input %d spends %v from the wrong transaction tree", i, prevOut))
+				}
+
+				// ValueIn is not committed to by the signature hash, so script
+				// execution below does not cover it.
+				if in.ValueIn != int64(credit.Amount) {
+					return errors.E(op, errors.ScriptFailure, errors.Errorf(
+						"input %d claims value %v for %v which is worth %v", i,
+						dcrutil.Amount(in.ValueIn), prevOut, credit.Amount))
+				}
+
+				// Validate the signature.
+				err = validateTxInput(op, tx, i, credit.PkScript)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2025 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -723,24 +723,34 @@ func (w *Wallet) txToMultisigInternal(ctx context.Context, op errors.Op, dbtx wa
 	return created, scAddr, msScript, nil
 }
 
+// validateTxInput verifies that input i of tx satisfies prevScript, the
+// previous output script it redeems.
+func validateTxInput(op errors.Op, tx *wire.MsgTx, i int, prevScript []byte) error {
+	vm, err := txscript.NewEngine(prevScript, tx, i,
+		sanityVerifyFlags, scriptVersionAssumed, nil)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	err = vm.Execute()
+	if err != nil {
+		prevOut := &tx.TxIn[i].PreviousOutPoint
+		sigScript := tx.TxIn[i].SignatureScript
+
+		log.Errorf("Script validation failed (outpoint %v pkscript %x sigscript %x): %v",
+			prevOut, prevScript, sigScript, err)
+		return errors.E(op, errors.ScriptFailure, err)
+	}
+	return nil
+}
+
 // validateMsgTx verifies transaction input scripts for tx.  All previous output
 // scripts from outputs redeemed by the transaction, in the same order they are
 // spent, must be passed in the prevScripts slice.
 func validateMsgTx(op errors.Op, tx *wire.MsgTx, prevScripts [][]byte) error {
 	for i, prevScript := range prevScripts {
-		vm, err := txscript.NewEngine(prevScript, tx, i,
-			sanityVerifyFlags, scriptVersionAssumed, nil)
+		err := validateTxInput(op, tx, i, prevScript)
 		if err != nil {
-			return errors.E(op, err)
-		}
-		err = vm.Execute()
-		if err != nil {
-			prevOut := &tx.TxIn[i].PreviousOutPoint
-			sigScript := tx.TxIn[i].SignatureScript
-
-			log.Errorf("Script validation failed (outpoint %v pkscript %x sigscript %x): %v",
-				prevOut, prevScript, sigScript, err)
-			return errors.E(op, errors.ScriptFailure, err)
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Validate transactions which spend UTXOs owned by this wallet before adding them to the mempool/database. Disconnect peers violating the validation.

Closes #2633

@davecgh - to address your concern from https://github.com/decred/dcrwallet/pull/2642#discussion_r3717765255, `AddTransaction` was not previously capable of returning `errors.ScriptFailure`, so only the code newly added in this PR will lead to peers being disconnected.