### PR TITLE
Detect DCP0005 activation. 

### DIFF
--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 The Decred developers
+// Copyright (c) 2018-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -22,7 +22,6 @@ import (
 // active, not when it is inactive.
 type HardcodedDeployment struct {
 	MainNetActivationHeight  int32
-	TestNet2ActivationHeight int32
 	TestNet3ActivationHeight int32
 	SimNetActivationHeight   int32
 }
@@ -31,7 +30,6 @@ type HardcodedDeployment struct {
 // defined by https://github.com/decred/dcps/blob/master/dcp-0001/dcp-0001.mediawiki.
 var DCP0001 = HardcodedDeployment{
 	MainNetActivationHeight:  149248,
-	TestNet2ActivationHeight: 46128,
 	TestNet3ActivationHeight: 0,
 	SimNetActivationHeight:   0,
 }
@@ -40,7 +38,6 @@ var DCP0001 = HardcodedDeployment{
 // https://github.com/decred/dcps/blob/master/dcp-0002/dcp-0002.mediawiki.
 var DCP0002 = HardcodedDeployment{
 	MainNetActivationHeight:  189568,
-	TestNet2ActivationHeight: 151968,
 	TestNet3ActivationHeight: 0,
 	SimNetActivationHeight:   0,
 }
@@ -49,7 +46,6 @@ var DCP0002 = HardcodedDeployment{
 // https://github.com/decred/dcps/blob/master/dcp-0003/dcp-0003.mediawiki.
 var DCP0003 = HardcodedDeployment{
 	MainNetActivationHeight:  189568,
-	TestNet2ActivationHeight: 151968,
 	TestNet3ActivationHeight: 0,
 	SimNetActivationHeight:   0,
 }
@@ -62,8 +58,6 @@ func (d *HardcodedDeployment) Active(height int32, net wire.CurrencyNet) bool {
 	switch net {
 	case wire.MainNet:
 		activationHeight = d.MainNetActivationHeight
-	case 0x48e7a065: // testnet2
-		activationHeight = d.TestNet2ActivationHeight
 	case wire.TestNet3:
 		activationHeight = d.TestNet3ActivationHeight
 	case wire.SimNet:

--- a/deployments/deployments.go
+++ b/deployments/deployments.go
@@ -50,6 +50,14 @@ var DCP0003 = HardcodedDeployment{
 	SimNetActivationHeight:   0,
 }
 
+// DCP0005 specifies the activation of a block header commitments soft fork as
+// defined by https://github.com/decred/dcps/blob/master/dcp-0005/dcp-0005.mediawiki.
+var DCP0005 = HardcodedDeployment{
+	MainNetActivationHeight:  431488,
+	TestNet3ActivationHeight: 0,
+	SimNetActivationHeight:   0,
+}
+
 // Active returns whether the hardcoded deployment is active at height on the
 // network specified by params.  Active always returns false for unrecognized
 // networks.

--- a/spv/backend.go
+++ b/spv/backend.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"decred.org/dcrwallet/v5/deployments"
 	"decred.org/dcrwallet/v5/errors"
 	"decred.org/dcrwallet/v5/p2p"
 	"decred.org/dcrwallet/v5/validate"
@@ -64,7 +65,8 @@ func pickForGetCfilters(lastHeaderHeight int32) func(rp *p2p.RemotePeer) bool {
 // the block match what is promised by the merkle commitment in the block
 // header.  The remote peer is disconnected if it returns a block that fails
 // this verification.
-func blocksFromPeer(ctx context.Context, rp *p2p.RemotePeer, blockHashes []*chainhash.Hash) ([]*wire.MsgBlock, error) {
+func blocksFromPeer(ctx context.Context, rp *p2p.RemotePeer,
+	blockHashes []*chainhash.Hash, net wire.CurrencyNet) ([]*wire.MsgBlock, error) {
 	blocks, err := rp.Blocks(ctx, blockHashes)
 	if err != nil {
 		return nil, err
@@ -79,9 +81,11 @@ func blocksFromPeer(ctx context.Context, rp *p2p.RemotePeer, blockHashes []*chai
 		// request. Every block obtained from a remote peer must therefore have
 		// its transaction trees checked against the merkle root commitments of
 		// the header before the transactions are used for anything.
-		err := validate.MerkleRoots(b)
-		if err != nil {
+		var err error
+		if deployments.DCP0005.Active(int32(b.Header.Height), net) {
 			err = validate.DCP0005MerkleRoot(b)
+		} else {
+			err = validate.MerkleRoots(b)
 		}
 		if err != nil {
 			rp.Disconnect(err)
@@ -101,7 +105,7 @@ func (s *Syncer) Blocks(ctx context.Context, blockHashes []*chainhash.Hash) ([]*
 		if err != nil {
 			return nil, err
 		}
-		blocks, err := blocksFromPeer(ctx, rp, blockHashes)
+		blocks, err := blocksFromPeer(ctx, rp, blockHashes, s.wallet.ChainParams().Net)
 		if err != nil {
 			log.Debugf("Unable to fetch blocks from %v: %v", rp, err)
 			continue
@@ -587,7 +591,7 @@ func (s *Syncer) Rescan(ctx context.Context, blockHashes []chainhash.Hash, save 
 				return err
 			}
 
-			blocks, err := blocksFromPeer(ctx, rp, fmatches)
+			blocks, err := blocksFromPeer(ctx, rp, fmatches, s.wallet.ChainParams().Net)
 			if err != nil {
 				continue PickPeer
 			}

--- a/spv/sync.go
+++ b/spv/sync.go
@@ -1069,7 +1069,7 @@ func (s *Syncer) handleBlockInvs(ctx context.Context, rp *p2p.RemotePeer, hashes
 		return nil
 	}
 
-	blocks, err := blocksFromPeer(ctx, rp, hashes)
+	blocks, err := blocksFromPeer(ctx, rp, hashes, s.wallet.ChainParams().Net)
 	if err != nil {
 		op := errors.Opf(opf, rp)
 		return errors.E(op, err)
@@ -1349,7 +1349,7 @@ func (s *Syncer) scanChain(ctx context.Context, rp *p2p.RemotePeer, chain []*wal
 	wg.Wait()
 
 	if len(fmatches) != 0 {
-		blocks, err := blocksFromPeer(ctx, rp, fmatches)
+		blocks, err := blocksFromPeer(ctx, rp, fmatches, s.wallet.ChainParams().Net)
 		if err != nil {
 			return nil, err
 		}

--- a/wallet/createtx.go
+++ b/wallet/createtx.go
@@ -585,8 +585,6 @@ func (w *Wallet) txToMultisigInternal(ctx context.Context, op errors.Op, dbtx wa
 	switch w.chainParams.Net {
 	case wire.MainNet:
 		feeEstForTx = 5e7
-	case 0x48e7a065: // testnet2
-		feeEstForTx = 5e7
 	case wire.TestNet3:
 		feeEstForTx = 5e7
 	default:

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -292,8 +292,6 @@ func voteVersion(params *chaincfg.Params) uint32 {
 	switch params.Net {
 	case wire.MainNet:
 		return 11
-	case 0x48e7a065: // TestNet2
-		return 6
 	case wire.TestNet3:
 		return 12
 	case wire.SimNet:

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2015 The btcsuite developers
-// Copyright (c) 2015-2024 The Decred developers
+// Copyright (c) 2015-2026 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -35,8 +35,6 @@ func networkDir(dataDir string, chainParams *chaincfg.Params) string {
 	netname := chainParams.Name
 	// Be cautious of v2+ testnets being named only "testnet".
 	switch chainParams.Net {
-	case 0x48e7a065: // testnet2
-		netname = "testnet2"
 	case wire.TestNet3:
 		netname = "testnet3"
 	}


### PR DESCRIPTION
Using a hard-coded value for the activation height of DCP0005 means the correct merkle root func can be executed first time rather than brute forcing through an error to find the correct one.

As suggested by @davecgh in [this comment](https://github.com/decred/dcrwallet/pull/2644/changes#r3718957689)

Also taking the opportunity to clean up some ancient references to testnet2.